### PR TITLE
feat: Add Claude Code plugin and marketplace support

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,36 @@
+{
+  "name": "corezoid",
+  "metadata": {
+    "description": "Official Corezoid plugin marketplace for Claude Code. Provides workflow skills, process builder, API orchestration, and MCP integration for the Corezoid Actor Engine."
+  },
+  "owner": {
+    "name": "Corezoid Inc.",
+    "email": "support@corezoid.com"
+  },
+  "plugins": [
+    {
+      "name": "corezoid",
+      "source": "./plugins/corezoid",
+      "description": "Corezoid product knowledge, workflow skills, public docs, schemas, templates, playbooks, samples, and MCP reference data for Claude Code.",
+      "version": "1.0.2",
+      "author": {
+        "name": "Corezoid Inc.",
+        "email": "support@corezoid.com"
+      },
+      "homepage": "https://corezoid.com",
+      "repository": "https://github.com/corezoid/corezoid-codex-plugin",
+      "license": "MIT",
+      "keywords": [
+        "corezoid",
+        "actor-engine",
+        "process-engine",
+        "api-orchestration",
+        "workflow-automation",
+        "dashboards",
+        "mcp",
+        "json-schema"
+      ],
+      "category": "Developer Tools"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,27 +1,63 @@
-# Corezoid Codex Marketplace
+# Corezoid Plugin Marketplace
 
-This repository publishes the **Corezoid** plugin for Codex. The plugin packages Corezoid product knowledge, public docs, workflow skills, schemas, templates, playbooks, samples, and MCP reference material so Codex can help design, build, review, document, and operate Corezoid processes.
+This repository publishes the **Corezoid** plugin for both **Codex** and **Claude Code**. The plugin packages Corezoid product knowledge, public docs, workflow skills, schemas, templates, playbooks, samples, and MCP reference material so AI coding tools can help design, build, review, document, and operate Corezoid processes.
 
 ## Marketplace Layout
 
 ```text
-.agents/plugins/marketplace.json      # Codex marketplace catalog
-plugins/corezoid/.codex-plugin/       # Required plugin manifest
-plugins/corezoid/skills/              # Corezoid workflow skills
-plugins/corezoid/assets/              # Icons, screenshots, public profile, bundled docs
-plugins/corezoid/.mcp.json            # Empty by default; credentials are user-specific
+.agents/plugins/marketplace.json          # Codex marketplace catalog
+.claude-plugin/marketplace.json           # Claude Code marketplace catalog
+plugins/corezoid/.codex-plugin/           # Codex plugin manifest
+plugins/corezoid/.claude-plugin/          # Claude Code plugin manifest
+plugins/corezoid/skills/                  # Corezoid workflow skills (shared)
+plugins/corezoid/assets/                  # Icons, screenshots, public profile, bundled docs
+plugins/corezoid/.mcp.json                # Empty by default; credentials are user-specific
 ```
 
-## Install From GitHub
+---
 
-After this repository is pushed to GitHub, users can add the marketplace with:
+## Claude Code
+
+### Install From GitHub
+
+```bash
+claude plugin marketplace add corezoid/corezoid-codex-plugin
+claude plugin install corezoid@corezoid
+```
+
+### Local Test
+
+```bash
+claude plugin marketplace add ./
+claude plugin install corezoid@corezoid
+```
+
+### Slash Commands
+
+After installation, the following skills are available in Claude Code:
+
+- `/corezoid` — product overview, reference map, and skill router
+- `/corezoid-architect` — design multi-process Corezoid systems
+- `/corezoid-process-builder` — build connector or logic process JSON
+- `/corezoid-process-reviewer` — audit process JSON before deployment
+- `/corezoid-process-updater` — modify existing processes or debug failed tasks
+- `/corezoid-process-tech-writer` — create Markdown docs and enrich process JSON
+- `/corezoid-apigw-manager` — expose Corezoid processes through API Gateway
+- `/corezoid-api-wrapper` — generate OpenAPI specs and wrapper processes
+- `/corezoid-dashboard-manager` — plan and create monitoring dashboards
+
+---
+
+## Codex
+
+### Install From GitHub
 
 ```bash
 codex plugin marketplace add corezoid/corezoid-codex-plugin --ref main
 codex plugin marketplace upgrade corezoid
 ```
 
-Then open Codex Plugin Directory, choose the **Corezoid** marketplace, and install **Corezoid**.
+Then open the Codex Plugin Directory, choose the **Corezoid** marketplace, and install **Corezoid**.
 
 For a pinned release, use a tag:
 
@@ -29,9 +65,7 @@ For a pinned release, use a tag:
 codex plugin marketplace add corezoid/corezoid-codex-plugin --ref v1.0.2
 ```
 
-## Local Test
-
-From this repository root:
+### Local Test
 
 ```bash
 codex plugin marketplace add ./
@@ -40,19 +74,23 @@ codex plugin marketplace upgrade corezoid
 
 Restart Codex, open the Plugin Directory, choose **Corezoid**, and verify that the plugin card renders with its icon, logo, screenshots, prompts, and skills.
 
+---
+
 ## Plugin Contents
 
-The Corezoid plugin includes:
+Both plugins include the same set of workflow skills:
 
-- `corezoid`: product overview, reference map, and skill router.
-- `corezoid-architect`: design multi-process Corezoid systems.
-- `corezoid-process-builder`: build connector or logic process JSON.
-- `corezoid-process-reviewer`: audit process JSON before deployment.
-- `corezoid-process-updater`: modify existing processes or debug failed tasks.
-- `corezoid-process-tech-writer`: create Markdown docs and enrich process JSON.
-- `corezoid-apigw-manager`: expose Corezoid processes through API Gateway.
-- `corezoid-api-wrapper`: generate OpenAPI specs and wrapper processes.
-- `corezoid-dashboard-manager`: plan and create monitoring dashboards.
+| Skill | Purpose |
+|-------|---------|
+| `corezoid` | Product overview, reference map, and skill router |
+| `corezoid-architect` | Design multi-process Corezoid systems |
+| `corezoid-process-builder` | Build connector or logic process JSON |
+| `corezoid-process-reviewer` | Audit process JSON before deployment |
+| `corezoid-process-updater` | Modify existing processes or debug failed tasks |
+| `corezoid-process-tech-writer` | Create Markdown docs and enrich process JSON |
+| `corezoid-apigw-manager` | Expose Corezoid processes through API Gateway |
+| `corezoid-api-wrapper` | Generate OpenAPI specs and wrapper processes |
+| `corezoid-dashboard-manager` | Plan and create monitoring dashboards |
 
 ## Upstream Sources
 
@@ -62,4 +100,7 @@ Public product positioning and source links are captured in `plugins/corezoid/as
 
 ## Publishing Status
 
-Codex supports custom marketplaces from local paths and Git repositories. Official OpenAI Plugin Directory self-serve publishing is not yet generally available, so this repo is the distributable Corezoid marketplace source until that opens.
+| Platform | Status |
+|----------|--------|
+| Claude Code | Available — install via `claude plugin marketplace add corezoid/corezoid-codex-plugin` |
+| Codex | Available — install via `codex plugin marketplace add corezoid/corezoid-codex-plugin` |

--- a/plugins/corezoid/.claude-plugin/plugin.json
+++ b/plugins/corezoid/.claude-plugin/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "corezoid",
+  "version": "1.0.2",
+  "description": "Corezoid product knowledge, workflow skills, public docs, schemas, templates, playbooks, samples, and MCP reference data for Claude Code.",
+  "author": {
+    "name": "Corezoid Inc.",
+    "email": "support@corezoid.com"
+  },
+  "homepage": "https://corezoid.com",
+  "repository": "https://github.com/corezoid/corezoid-codex-plugin",
+  "license": "MIT",
+  "keywords": [
+    "corezoid",
+    "actor-engine",
+    "process-engine",
+    "api-orchestration",
+    "workflow-automation",
+    "dashboards",
+    "mcp",
+    "json-schema"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json"
+}


### PR DESCRIPTION
## Summary

- Add `.claude-plugin/marketplace.json` — Claude Code marketplace catalog
- Add `plugins/corezoid/.claude-plugin/plugin.json` — Claude Code plugin manifest
- Update `README.md` to document installation for both Claude Code and Codex

## Details

The existing `skills/` directory (SKILL.md files) is shared between both platforms — no changes needed there. The Claude Code plugin manifest mirrors the Codex one but without the Codex-specific `interface` block.

Users can install via:
```bash
claude plugin marketplace add corezoid/corezoid-codex-plugin
claude plugin install corezoid@corezoid
```

## Test plan

- [x] `claude plugin validate .` — passes with no errors
- [x] `claude plugin marketplace add ./` — marketplace added successfully
- [x] `claude plugin install corezoid@corezoid` — plugin installed and enabled

🤖 Generated with [Claude Code](https://claude.ai/claude-code)