### PR TITLE
feat(skill): improve corezoid-create with placement and layout rules

### DIFF
--- a/plugins/corezoid/skills/corezoid-create/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-create/SKILL.md
@@ -38,6 +38,8 @@ Call MCP tool **`create-process`** with:
 
 This creates an empty process in Corezoid and saves the file as `<ID>_<Name>.conv.json` inside `folder_path`. The returned file path is `PROCESS_PATH` — all subsequent steps use it.
 
+> ⚠️ Always verify `folder_path` points to the intended target folder. Omitting it places the process in the project root, which may not be the correct location.
+
 If the process type is **business logic** and it needs to call existing processes, find their `conv_id` values by browsing the already-exported `.conv.json` files in the project folder.
 
 ---
@@ -111,6 +113,7 @@ Produce a valid `.conv.json` file.
   3. Reference in logic: `{{env_var[@variable-name]}}`
 - Use descriptive `title` values (e.g., "Call Payment Process", not "RPC")
 - Position nodes top-to-bottom, incrementing `y` by 200–250px; place error nodes to the right (`x + 300`)
+- Place each Reply Error node at the **same `y`** as the Call/API node it handles — this creates a straight horizontal connector line for the error path
 
 ### Common pitfalls
 


### PR DESCRIPTION
## Summary

- Warn that `folder_path` must point to the target folder; omitting it places the process in the project root
- Add layout rule: Reply Error node must share the same `y`-coordinate as the Call/API node it handles — creates a straight horizontal connector line for the error path

## Test plan

- [ ] Create a process without `folder_path` — verify warning is visible in skill guidance
- [ ] Build a process with error handling — verify Reply Error is placed at correct y

🤖 Generated with [Claude Code](https://claude.com/claude-code)