### PR TITLE
Support personal workspaces (no WORKSPACE_ID)

### DIFF
--- a/plugins/corezoid/mcp-server/executor.go
+++ b/plugins/corezoid/mcp-server/executor.go
@@ -1258,6 +1258,22 @@ func (v *Executor) Share(userID, convID int) map[string]interface{} {
 
 // req sends a request to the Corezoid API with authentication
 func (v *Executor) req(method string, ops []map[string]any) (map[string]interface{}, error) {
+	// Personal-workspace accounts have no companyID. The callers in this file
+	// unconditionally inject `"company_id": workspaceID` into every op, so when
+	// workspaceID is empty the payload carries `"company_id": ""` and Corezoid
+	// rejects every request with `Value is not valid / company_id`. Drop the
+	// empty placeholder (and its mirrors) so the request matches what the API
+	// accepts for personal accounts. No-op for normal company workspaces.
+	if strings.TrimSpace(workspaceID) == "" {
+		for _, op := range ops {
+			for _, k := range []string{"company_id", "from_company_id", "to_company_id"} {
+				if s, ok := op[k].(string); ok && s == "" {
+					delete(op, k)
+				}
+			}
+		}
+	}
+
 	// Create the payload
 	payload := map[string]any{"ops": ops}
 	payloadJSON, _ := json.Marshal(payload)

--- a/plugins/corezoid/mcp-server/mcp_server.go
+++ b/plugins/corezoid/mcp-server/mcp_server.go
@@ -286,9 +286,8 @@ func ensureAuth() error {
 	if accountURL == "" {
 		missing = append(missing, "ACCOUNT_URL")
 	}
-	if workspaceID == "" {
-		missing = append(missing, "WORKSPACE_ID")
-	}
+	// WORKSPACE_ID is optional: personal-workspace accounts have no companyID.
+	// `Executor.req` strips the empty placeholder from outbound ops in that case.
 	if stageID == 0 {
 		missing = append(missing, "COREZOID_STAGE_ID")
 	}


### PR DESCRIPTION
Port of the equivalent Python fix from corezoid/corezoid-ai-doc#7 (per @MalishkinMV's suggestion to keep updates focused on the active Go plugin).

## Why

Some Corezoid deployments use **personal workspaces**, where there is no company segment in URLs and `get_process_details` returns `company_id: null`. Example: the Liobank VN production deployment — process URLs look like `https://corezoid.prod.liobank.vn/process/31972`, and the API returns `company_id: None` for that account.

Every op built by `executor.go` unconditionally injects `\"company_id\": workspaceID`. On personal accounts `workspaceID` is empty, so the payload carries `\"company_id\": \"\"` and the API rejects every request with:

\`\`\`json
{\"proc\":\"error\",\"description\":\"Value is not valid\",\"key\":\"company_id\",\"value\":\"\"}
\`\`\`

`ensureAuth` also unconditionally requires `WORKSPACE_ID` and refuses to authenticate without it, so personal-account users can't even reach the executor today.

## What

1. **`executor.go::req`** — when `workspaceID` is empty (trimmed), strip empty `company_id` / `from_company_id` / `to_company_id` from each op before marshaling. No-op for normal company workspaces.

2. **`mcp_server.go::ensureAuth`** — drop `WORKSPACE_ID` from the required-credentials list. Personal accounts can authenticate with just `ACCOUNT_URL` + token + `COREZOID_STAGE_ID`. The login flow's workspace-selection elicit step already tolerates an empty selection (the block only writes `workspaceID` when the user picks a non-empty value), so no further changes are needed there.

## Verification

The equivalent Python fix has been validated live against this same VN personal-workspace account (corezoid/corezoid-ai-doc#7 description has the full transcript). For the Go port I'm relying on CI for build — I don't have a local Go toolchain. The patch is purely additive: an empty-string scrub plus removing one entry from a `missing` slice, both behind explicit empty-string guards. Zero impact on company-workspace users.

## Scope

- ✅ All id-scoped ops (`GetProcessByID`, `ExportProcess`, `createTask`, `ModifyNodes`, `Commit`, `DeleteVersion`, etc.) work without workspaceID — covers the bulk of skill workflows (corezoid-create, corezoid-edit, corezoid-review, corezoid-process-tech-writer).
- ❌ Workspace-scoped queries that fundamentally need a workspace context still won't work in personal mode — same constraint as the Python fix, documented in the new `req` comment.

## Related

- corezoid/corezoid-ai-doc#7 — same fix in the Python MCP server. @MalishkinMV asked to port it here in https://github.com/corezoid/corezoid-ai-doc/pull/7#issuecomment.