### PR TITLE
feat(docs): improve process creation and node positioning guidelines

### DIFF
--- a/plugins/corezoid/docs/process/node-positioning-best-practices.md
+++ b/plugins/corezoid/docs/process/node-positioning-best-practices.md
@@ -24,13 +24,21 @@ Corezoid nodes have specific dimensions that should be considered when positioni
    - Actual height varies based on node content
    - Pivot Point: Top-left corner
 
-3. **Nodes with Escalation or Error Links**
+3. **Nodes with a Timer (Semaphor / Delay)**
+
+   - Width: 200px
+   - Height: approximately **2× the standard height** of the same node type
+   - A timer semaphor adds a visible timer block below the node body, roughly doubling the rendered height
+   - Account for this when calculating vertical spacing to the next node — increase the Y gap accordingly
+   - Pivot Point: Top-left corner
+
+4. **Nodes with Escalation or Error Links**
 
    - Width: 200px
    - Minimum Height: 125px
    - Pivot Point: Top-left corner
 
-4. **Condition Nodes**
+5. **Condition Nodes**
    - With single rule:
      - Width: 200px
      - Minimum Height: 110px

--- a/plugins/corezoid/skills/corezoid-create/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-create/SKILL.md
@@ -38,6 +38,10 @@ Call MCP tool **`create-process`** with:
 
 This creates an empty process in Corezoid and saves the file as `<ID>_<Name>.conv.json` inside `folder_path`. The returned file path is `PROCESS_PATH` — all subsequent steps use it.
 
+> ⚠️ Always verify `folder_path` points to the intended target folder. Omitting it places the process in the project root, which may not be the correct location.
+
+> ⚠️ After `create-process`, Corezoid may create default template nodes (Start, a placeholder process node, Final) even with `create_mode: without_nodes`. Before generating the full JSON, check the current `scheme.nodes` array in the created file. If a Start node already exists, do **not** add another — doing so will cause a validation error.
+
 If the process type is **business logic** and it needs to call existing processes, find their `conv_id` values by browsing the already-exported `.conv.json` files in the project folder.
 
 ---
@@ -111,6 +115,7 @@ Produce a valid `.conv.json` file.
   3. Reference in logic: `{{env_var[@variable-name]}}`
 - Use descriptive `title` values (e.g., "Call Payment Process", not "RPC")
 - Position nodes top-to-bottom, incrementing `y` by 200–250px; place error nodes to the right (`x + 300`)
+- Place each Reply Error node at the **same `y`** as the Call/API node it handles — this creates a straight horizontal connector line for the error path
 
 ### Common pitfalls
 


### PR DESCRIPTION
## Summary

- Add `folder_path` warning in corezoid-create skill (Step 2)
- Add default template nodes check after `create-process` — prevent duplicate Start node error
- Add Reply Error same-y positioning rule for straight horizontal connector lines
- Add timer/semaphor node height rule (≈2×) to node-positioning-best-practices.md

## Test plan
- [ ] Review corezoid-create/SKILL.md warnings in Step 2
- [ ] Review Reply Error positioning rule in Core rules
- [ ] Review timer node height rule in node-positioning-best-practices.md (new item #3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)