### PR TITLE
docs(delay-node): clarify 30s limit is static-literal only; document dynamic absolute-timestamp timers

### DIFF
--- a/plugins/corezoid/docs/nodes/delay-node.md
+++ b/plugins/corezoid/docs/nodes/delay-node.md
@@ -107,27 +107,18 @@ This lets you:
 Because the value is absolute, **always compute `now + delta`**, never a small bare number —
 a dynamic `value` of `3` would be interpreted as epoch second 3 (1970), i.e. fire immediately.
 
-The fire-moment can be produced anywhere upstream — it just has to land in task data before the
-Delay node reads it:
+**How the timestamp is produced does not matter.** The Delay node only reads the resolved value
+of its `{{placeholder}}` from task data; the only requirement is that an absolute epoch second is
+present in that key before the task reaches the node. Any of these are equivalent:
 
-- a **Set Parameter** node: `"timeout": "$.math($.unixtime()+{{delta}})"` (type `number`);
-- a **Code** node returning an epoch second;
-- passed in from **another process** or the incoming task `data`.
+- a value **passed in from another process** (or already present in the incoming task `data`);
+- a value returned by an **API Call** node;
+- a value computed in a **Code** node in JS (e.g. `return {timeout: Math.floor(Date.now()/1000) + 3}`);
+- a **Set Parameter** node: `"timeout": "$.math($.unixtime()+{{delta}})"` (type `number`).
 
 ### Pattern (verified)
 
-Upstream node computes the absolute moment:
-
-```json
-{
-  "type": "set_param",
-  "extra": { "timeout": "$.math($.unixtime()+{{delta}})" },
-  "extra_type": { "timeout": "number" },
-  "err_node_id": "error_node_id"
-}
-```
-
-Delay node holds the task until that moment, then routes onward:
+The Delay node is the only required part — set its time-semaphore `value` to the dynamic key:
 
 ```json
 {
@@ -143,9 +134,23 @@ Delay node holds the task until that moment, then routes onward:
 }
 ```
 
-**Observed behaviour** (live test, `dimension: "sec"`): with `delta = 3` the task entered the
-Delay node and reached the next node ~3 s later; with `delta = 10` it was released exactly at
-`now + 10`. Firing precision is ~1 s, and no 30-second floor is applied to the dynamic value.
+`{{timeout}}` must hold an absolute Unix second. One way to populate it (used in the live test
+below) is a Set Parameter node — but a Code node, an API response, or a value from another process
+are interchangeable:
+
+```json
+{
+  "type": "set_param",
+  "extra": { "timeout": "$.math($.unixtime()+{{delta}})" },
+  "extra_type": { "timeout": "number" },
+  "err_node_id": "error_node_id"
+}
+```
+
+**Observed behaviour** (live test, `dimension: "sec"`, `{{timeout}}` populated by Set Parameter):
+with `delta = 3` the task entered the Delay node and reached the next node ~3 s later; with
+`delta = 10` it was released exactly at `now + 10`. Firing precision is ~1 s, and no 30-second
+floor is applied to the dynamic value.
 
 ## Best Practices
 

--- a/plugins/corezoid/docs/nodes/delay-node.md
+++ b/plugins/corezoid/docs/nodes/delay-node.md
@@ -13,7 +13,7 @@
 1. **Delay Duration** (Number)
 
    - The amount of time to hold the task.
-   - Minimum value: 30 seconds. Values below this limit are not allowed (e.g., `"Timer value 15 sec is less than minimum limit 30 sec"`).
+   - Minimum value: 30 seconds — **but this limit is only enforced on a static numeric literal at deploy time** (e.g., `"value": 15` is rejected with `"Timer value 15 sec is less than minimum limit 30 sec"`). A **dynamic** `value` (a `{{placeholder}}` string resolved at runtime) is **not** subject to this static check. See [Scheduled & sub-30s timers via a dynamic absolute timestamp](#scheduled--sub-30s-timers-via-a-dynamic-absolute-timestamp).
    - Example: `"value": 30`
 
 2. **Time Unit** (String)
@@ -89,9 +89,68 @@ concurrent delayed tasks reaches the threshold, new tasks are routed to an escal
 
 This can be used to prevent system overload when many tasks are being delayed simultaneously.
 
+## Scheduled & sub-30s timers via a dynamic absolute timestamp
+
+The 30-second minimum is a **deploy-time validation of a static numeric literal** in the
+time-semaphore `value`. It is **not** a runtime floor. When `value` is a **dynamic reference**
+(a `{{placeholder}}` resolved at runtime), the static check does not apply — and the timer
+fires when that value tells it to.
+
+**Key semantic: a dynamic `value` is an _absolute Unix timestamp_ (the moment to fire), not a
+relative number of seconds.** Set it to the epoch second at which the task should be released.
+This lets you:
+
+- schedule a release at an exact moment (e.g. "tomorrow at 09:00"), and
+- release **sooner than 30 seconds** from now — set `value` to `now + 3`, and the task is held
+  for ~3 seconds. (A static `"value": 3` would be rejected at deploy; the dynamic form is not.)
+
+Because the value is absolute, **always compute `now + delta`**, never a small bare number —
+a dynamic `value` of `3` would be interpreted as epoch second 3 (1970), i.e. fire immediately.
+
+The fire-moment can be produced anywhere upstream — it just has to land in task data before the
+Delay node reads it:
+
+- a **Set Parameter** node: `"timeout": "$.math($.unixtime()+{{delta}})"` (type `number`);
+- a **Code** node returning an epoch second;
+- passed in from **another process** or the incoming task `data`.
+
+### Pattern (verified)
+
+Upstream node computes the absolute moment:
+
+```json
+{
+  "type": "set_param",
+  "extra": { "timeout": "$.math($.unixtime()+{{delta}})" },
+  "extra_type": { "timeout": "number" },
+  "err_node_id": "error_node_id"
+}
+```
+
+Delay node holds the task until that moment, then routes onward:
+
+```json
+{
+  "logics": [],
+  "semaphors": [
+    {
+      "type": "time",
+      "value": "{{timeout}}",
+      "dimension": "sec",
+      "to_node_id": "next_node_id"
+    }
+  ]
+}
+```
+
+**Observed behaviour** (live test, `dimension: "sec"`): with `delta = 3` the task entered the
+Delay node and reached the next node ~3 s later; with `delta = 10` it was released exactly at
+`now + 10`. Firing precision is ~1 s, and no 30-second floor is applied to the dynamic value.
+
 ## Best Practices
 
-- The minimum allowed delay is 30 seconds; values below this threshold will result in a validation error
+- The 30-second minimum applies only to a **static literal** `value` at deploy time; for shorter
+  or scheduled delays use a **dynamic `value` holding an absolute Unix timestamp** (see above)
 - Use reasonable delay times to avoid resource constraints
 - For variable delays, validate the parameter before reaching the Delay node
 - Consider using a Queue node for very long delays

--- a/plugins/corezoid/skills/corezoid-create/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-create/SKILL.md
@@ -160,6 +160,7 @@ Use the `Read` tool to load these files when specific node or validation details
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/call-process-node.md` | Call a Process node, semaphores, cross-folder calls |
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/reply-to-process-node.md` | Reply formats, object stringification |
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/api-call-node.md` | HTTP API call configuration |
+| `${CLAUDE_PLUGIN_ROOT}/docs/nodes/delay-node.md` | Delay/timer node; 30s limit is static-literal only — dynamic absolute-timestamp `value` for scheduled or sub-30s delays |
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/end-node.md` | End node success/error configuration |
 | `${CLAUDE_PLUGIN_ROOT}/docs/process/process-json-validation.md` | Validation rules and common errors |
 | `${CLAUDE_PLUGIN_ROOT}/docs/process/error-handling.md` | Error handling patterns |

--- a/plugins/corezoid/skills/corezoid-edit/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-edit/SKILL.md
@@ -109,7 +109,7 @@ Use the `Read` tool to load these files when specific node or validation details
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/api-call-node.md` | HTTP API call configuration |
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/end-node.md` | End node success/error configuration |
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/condition-node.md` | Condition node (branching logic) |
-| `${CLAUDE_PLUGIN_ROOT}/docs/nodes/delay-node.md` | Delay node (timers and waiting) |
+| `${CLAUDE_PLUGIN_ROOT}/docs/nodes/delay-node.md` | Delay node (timers and waiting); 30s limit is static-literal only — dynamic absolute-timestamp `value` for scheduled or sub-30s delays |
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/copy-task-node.md` | Copy Task node (task duplication) |
 | `${CLAUDE_PLUGIN_ROOT}/docs/process/process-json-validation.md` | Validation rules and common errors |
 | `${CLAUDE_PLUGIN_ROOT}/docs/process/error-handling.md` | Error handling patterns (hardware vs software errors) |


### PR DESCRIPTION
## What

The Delay node's 30-second minimum is documented as a hard limit (\"values below this limit are not allowed\"). In practice it is enforced **only as a deploy-time validation of a static numeric literal** in the time-semaphore `value` — it is **not** a runtime floor. A **dynamic** `value` (a `{{placeholder}}` resolved at runtime) is not subject to the check, and is interpreted as an **absolute Unix timestamp** (the moment to fire), not a relative number of seconds.

This unlocks two things the current docs say are impossible:
- **scheduled** releases at an exact moment, and
- **sub-30s** delays — set `value` to `now + 3` and the task is held ~3s.

## Verification (live process)

A throwaway process `Start → set_param(timeout=$.math($.unixtime()+{{delta}})) → Delay(value={{timeout}}, sec) → Final`:

| delta | timeout (= start+delta) | arrived at Final | actual hold |
|------:|------------------------:|-----------------:|------------:|
| 3     | start+3                 | start+4          | **~3s**     |
| 10    | start+10                | exactly start+10 | **10s**     |

Firing precision ~1s; no 30s runtime floor observed. Because the value is absolute, it must be computed as `now + delta` — a bare dynamic `3` would mean epoch second 3 (1970) and fire immediately.

The fire-moment can be produced by a Set Parameter node (`$.math($.unixtime()+{{delta}})`), a Code node, or passed in from another process / the incoming task data.

## Changes

- `docs/nodes/delay-node.md` — correct the Parameters + Best Practices claims; add a **\"Scheduled & sub-30s timers via a dynamic absolute timestamp\"** section with the verified pattern.
- `skills/corezoid-create/SKILL.md`, `skills/corezoid-edit/SKILL.md` — surface the nuance in the node-doc reference tables.

Docs-only; no code or schema changes.