### PR TITLE
docs(node-ids): document server reassignment & stability of node IDs on push

### DIFF
--- a/plugins/corezoid/docs/process/process-development-guide.md
+++ b/plugins/corezoid/docs/process/process-development-guide.md
@@ -236,6 +236,38 @@ Before deploying a process, validate its JSON structure to ensure it meets all r
    - Duplicate node IDs
    - Missing Start node (every process must have exactly one Start node)
 
+### Node ID Lifecycle: Server Assignment & Stability on Push
+
+Node IDs you write locally are **temporary** for any node the server does not yet recognize. On
+`push-process`, Corezoid assigns its own canonical 24-character hex ID to every **new** node and
+rewrites all references to it. This is expected, not an error.
+
+What is preserved vs. reassigned:
+
+| Node | On push |
+| ---- | ------- |
+| **New** node (locally invented ID, even a valid `^[0-9a-f]{24}$` string) | ID is **reassigned** to a server-generated value; format/plausibility of your ID does not matter |
+| **Existing** node (already carries a server-assigned ID) | ID is **preserved** — stable across all subsequent pushes |
+
+Each node also carries a server-managed `uuid`, which is likewise assigned on first push and stable
+thereafter.
+
+Practical workflow:
+
+1. For new nodes, supply any unique, format-valid placeholder ID (`^[0-9a-f]{24}$`) so the JSON
+   validates and intra-push references resolve. **Within a single push**, references between your
+   new nodes (`go`, `to_node_id`, `err_node_id`) are remapped to the canonical IDs automatically —
+   you do **not** need to know the final IDs in advance.
+2. `push-process` writes the canonical IDs back into your local process file and rewires references.
+3. Run **`pull-process`** afterward to fully resync server-managed fields (canonical `id`, `uuid`,
+   and any normalized values) before you make further edits.
+4. In a **later** editing session, never reference an ID you invented in a previous push — it no
+   longer exists. Use the canonical ID from the latest pull. (Node `title` is **not** a safe
+   substitute: titles are not unique and may be empty.)
+
+> Common failure: editing a process across sessions using stale, locally-invented IDs. The
+> connection silently points to a non-existent node. Always `pull` first and work from canonical IDs.
+
 ### Automatic Node Positioning
 
 To ensure clean, readable process diagrams with minimal edge intersections, use the provided node

--- a/plugins/corezoid/skills/corezoid-create/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-create/SKILL.md
@@ -108,7 +108,7 @@ Produce a valid `.conv.json` file.
 
 ### Core rules
 
-- Node IDs must be unique 24-character hex strings: `^[0-9a-f]{24}$`
+- Node IDs must be unique 24-character hex strings: `^[0-9a-f]{24}$`. These are **temporary placeholders** for new nodes — on `push-process` Corezoid reassigns its own canonical IDs (and rewires references within the push). Run `pull-process` after pushing to get the canonical IDs before any further edits. See [Node ID Lifecycle](${CLAUDE_PLUGIN_ROOT}/docs/process/process-development-guide.md#node-id-lifecycle-server-assignment--stability-on-push).
 - Connect nodes only through the `go` field
 - Every node that can fail must have `err_node_id` pointing to a dedicated error node
 - All constants (URLs, tokens, IDs) must be Corezoid variables — never hardcoded:

--- a/plugins/corezoid/skills/corezoid-edit/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-edit/SKILL.md
@@ -45,7 +45,7 @@ Apply changes to `PROCESS_PATH`.
 
 - Connect nodes only through the `go` field
 - Every node that can fail must have `err_node_id` pointing to a dedicated error node
-- Node IDs must be unique 24-character hex strings: `^[0-9a-f]{24}$`
+- Node IDs must be unique 24-character hex strings: `^[0-9a-f]{24}$`. **Always `pull-process` before editing** and reference only canonical, server-assigned IDs — IDs you invented in a previous push were reassigned by the server and no longer exist. New nodes added now get placeholder IDs that the server will likewise reassign on push. Existing nodes' IDs are preserved. See [Node ID Lifecycle](${CLAUDE_PLUGIN_ROOT}/docs/process/process-development-guide.md#node-id-lifecycle-server-assignment--stability-on-push).
 - Use descriptive node `title` values (e.g., "Call Payment Process", not "RPC")
 - Place new nodes below existing ones, incrementing `y` by 200–250px
 - Position error nodes to the right of their parent (`x + 300`)


### PR DESCRIPTION
## What

Node IDs you author locally are **temporary** for any node the server does not yet recognize. On `push-process`, Corezoid assigns its own canonical 24-char hex ID to every **new** node and rewrites references to it. The docs (and the create/edit skills) currently present `^[0-9a-f]{24}$` IDs as if they were authoritative, with nothing about this reassignment — leading to broken cross-session edits that reference IDs that no longer exist.

## Verification (live process)

| Check | Result |
|---|---|
| New node given a **valid, plausible** client ObjectId (`5f3a1b2c4d5e6f7a8b9c0d1e`) | **Reassigned** by server to `6a3a91cf…` on push — format/plausibility irrelevant |
| Existing nodes' `id` **and** server `uuid` across a re-push | **Preserved / stable** |
| Title edit on an existing node | ID untouched, title persisted |
| Intra-push references using temp IDs (`go` / `to_node_id` / `err_node_id`) | **Auto-remapped** to canonical IDs by `push-process` |
| Local file after `push-process` (before any pull) | Canonical IDs **written back** into the file |

Conclusion: the server assigns canonical IDs to nodes it doesn't yet own; once assigned they are stable. The practical rule is **pull-process before editing and reference only canonical IDs** — node `title` is not a safe substitute (not unique, may be empty).

## Changes

- `docs/process/process-development-guide.md` — new **"Node ID Lifecycle: Server Assignment & Stability on Push"** subsection (preserved-vs-reassigned table + workflow).
- `skills/corezoid-create/SKILL.md`, `skills/corezoid-edit/SKILL.md` — clarify the "24-char hex" rule and link to the new section.

Docs-only; no code or schema changes.