### PR TITLE
docs(api-call): correct customize_response=false behavior; document response-body placement & silent mapping failure

### DIFF
--- a/plugins/corezoid/docs/nodes/api-call-node.md
+++ b/plugins/corezoid/docs/nodes/api-call-node.md
@@ -75,9 +75,11 @@
 
 10. **Customize Response** (Boolean)
     - Default: `false`.
-    - When set to `true`, allows defining custom mapping rules in the `response` and `response_type`
-      parameters. If `false`, the default mapping (`{"header": "{{header}}", "body": "{{body}}"}`)
-      is used.
+    - When `false`, the parsed JSON response body is **spread into the task data root** — each
+      top-level field of the body becomes a top-level task parameter (response headers are not
+      captured, and the `response`/`response_type` mapping is ignored). When `true`, only the
+      fields you declare in `response`/`response_type` are written, nested under the keys you
+      choose. See [Reading the response body](#reading-the-response-body-customize_response-false-vs-true).
 11. **Response Type** (Object)
     - Used only when `customize_response` is `true`.
     - Defines the expected data types for the fields mapped in the `response` parameter.
@@ -151,8 +153,44 @@ The API Call node allows customization of how response data is processed:
 
 2. **Response Mapping**
    - Maps response data to task parameters
-   - Default fields: `header` (response headers) and `body` (response content)
-   - Custom mapping allows selecting specific fields from the response
+   - With `customize_response: false` (default), no mapping is applied — the response body is
+     spread into the task data root (see below); headers are discarded
+   - With `customize_response: true`, only the fields declared in `response`/`response_type` are
+     written, under the keys you name (`{{body}}` = full body, `{{header}}` = full headers)
+
+## Reading the response body: `customize_response` false vs true
+
+How the response body reaches the task depends entirely on `customize_response`. The two modes
+behave very differently (verified against a live endpoint returning
+`{"data":{...},"json":{...},"url":"..."}`):
+
+| `customize_response` | `response`/`response_type` | Where the body lands |
+| --- | --- | --- |
+| `false` (default) | **ignored** | Body is **spread into the task root**: each top-level field becomes a task parameter. A body `{"data":{"id":42}}` is read as `{{data.id}}` (task path `data.data.id`). Response **headers are not captured**. |
+| `true` | applied | Only the declared fields are written, **nested under your keys**. `response: {"body":"{{body}}"}` puts the whole body under `{{body}}`, so the same id is `{{body.data.id}}` (task path `data.body.data.id`). |
+
+`rfc_format` does not change this placement.
+
+### Prefer `customize_response: false` to capture a body
+
+For most cases — especially reading an ID or object the API just created — `customize_response: false`
+is the robust choice: the whole body is available at the task root with no mapping to get wrong.
+
+### ⚠️ Silent failure with `customize_response: true`
+
+Custom mapping is **sensitive to the real response shape**, and a mismatch fails quietly:
+
+- **Mapped path absent.** `response: {"new_id":"{{body.data.id}}"}` against a body that has no
+  `data.id` sets `new_id` to an **empty string** and routes the task to the **success** path — no
+  error, no `err_node`. Downstream nodes then run with an empty value.
+- **Type mismatch is coerced, not rejected.** `response_type` accepts only `string`, `object`, or
+  `array`; declaring `array` for an object body wraps it (`[ {...} ]`) rather than erroring.
+- A genuine `err_node` exit happens only when the response is not parseable JSON at all (e.g. an
+  HTML 5xx page → tag `api_no_valid_json`, with `__conveyor_api_return_*` fields populated).
+
+Therefore: use `customize_response: true` only after confirming the **actual** response shape, and
+validate the mapped value downstream (e.g. a Condition node checking it is non-empty) instead of
+assuming the mapping succeeded.
 
 ## Validation Rules
 
@@ -262,14 +300,14 @@ default error escalation pattern connection.
         "extra_type": {}, // Corresponding types for extra parameters (empty)
         "max_threads": 5, // Maximum concurrent requests allowed for this node
         "debug_info": false, // Do not include extra debug info in the task
-        "customize_response": false, // Use default response mapping (header and body)
+        "customize_response": false, // false → response body is spread into the task root; response/response_type below are IGNORED
         "response": {
-          // Default response mapping (used when customize_response is false)
+          // Ignored while customize_response is false (only used when it is true)
           "header": "{{header}}",
           "body": "{{body}}"
         },
         "response_type": {
-          // Default response types (used when customize_response is false)
+          // Ignored while customize_response is false (only used when it is true)
           "header": "object",
           "body": "object"
         },


### PR DESCRIPTION
## What

`docs/nodes/api-call-node.md` states that with `customize_response: false` the node uses a default mapping `{"header":"{{header}}","body":"{{body}}"}`. **That is incorrect** and misleads users into reading `{{body}}` when the body is actually elsewhere.

## Verification (live process)

Against an endpoint returning `{"data":{...},"json":{...},"url":...}`:

| `customize_response` | `response`/`response_type` | Where the body lands |
|---|---|---|
| `false` (default) | **ignored** | Body **spread into the task root** — `{"data":{"id":42}}` → `{{data.id}}`. Headers **not** captured. |
| `true` | applied | Only declared fields, **nested under your keys** — `{"body":"{{body}}"}` → `{{body.data.id}}`. |

`rfc_format` does not change placement.

### Silent failure with `customize_response: true`
- A mapped path absent in the real response → value set to **empty string** and task routes to **success** (no error, no `err_node`). Downstream then runs on an empty value.
- `response_type` accepts only `string|object|array` and **coerces** (e.g. wraps an object as `[ {...} ]`) instead of rejecting.
- A real `err_node` exit happens only on non-parseable JSON (tag `api_no_valid_json`, `__conveyor_api_return_*` populated).

## Changes
- Correct the **Customize Response** parameter and **Response Customization** section.
- Add a **"Reading the response body: false vs true"** section (comparison table, recommendation to prefer `false` for capturing a body, explicit warning about the silent `true`-mode failure).
- Fix the misleading comments in the GET configuration example.

Docs-only; no code or schema changes.