### PR TITLE
feat(mcp): connection-profile registry for multi-environment switching

### DIFF
--- a/plugins/corezoid/docs/connection-profiles.md
+++ b/plugins/corezoid/docs/connection-profiles.md
@@ -1,0 +1,71 @@
+# Connection profiles (multi-environment switching)
+
+> Status: **proposal / convention**. The `registry.example.json` template ships now; the
+> MCP-server wiring described under "Implementation notes" is the developer task this PR asks for.
+
+## Problem
+
+The MCP server holds a single set of auth globals (`accountURL`, `apiURL`, `workspaceID`,
+`stageID`, `apiToken`) loaded once at startup from the nearest `.env`
+(`loadConfig` → `findAndLoadDotEnv` in `main.go`). Every tool call reads that single set
+via `authSnapshot()` (`executor.go`). Consequences:
+
+- One running process = one environment. Switching dev↔prod or market↔market requires
+  swapping `.env` **and restarting** the process.
+- The server has no concept of "which environment" — only "the nearest `.env`". Running
+  from sibling folders that share a parent `.env` silently collapses several environments
+  into one config (a real footgun teams hit).
+
+## Concept: a "connection profile"
+
+A **profile** is a named connection target — the generic abstraction, like `kubectl context`
+or `aws --profile`. A market, a project, a prod/dev pair are all just profiles. A profile is:
+
+```
+account_url + workspace_id + stage_id  (coordinates)
++ match rules                          (how to recognise it from a signal)
++ is_prod flag                         (the one piece of semantics the server needs, for guardrails)
+```
+
+Tokens are **not** part of the profile — they stay per-user (`~/.corezoid/credentials` or the
+profile's own `.env`), so the registry can be shared/committed within a team without leaking secrets.
+
+## Registry
+
+A single data file lists all profiles: `~/.corezoid/profiles/registry.json`
+(template: `mcp-server/registry.example.json`). It is plain data — adding a new environment
+is a registry edit, no code change.
+
+## Resolution rules
+
+Given a signal, the resolver picks one profile by matching, in priority order:
+
+1. **Host** in a Corezoid URL (e.g. a process/env link) → `match.hosts`
+2. **JIRA key prefix** (e.g. `PROJ-123`) → `match.jira_prefix`
+3. **Alias / free text** (e.g. "the dev market") → `match.aliases`
+
+Safety (dev is the safe zone):
+
+- If a prefix/alias maps to several profiles, the **`is_prod:false`** one wins **unless** the
+  signal explicitly names prod or carries a prod host.
+- Activating an `is_prod:true` profile requires explicit user confirmation.
+- Resolve once per session (on the first signal) and lock — not per-call switching.
+
+## Setup behaviour
+
+- `login`/setup writes config into a **new** profile folder; it must **never** silently merge a
+  second environment into an existing profile. Merging multiple configs into one profile is
+  only allowed on an explicit flag.
+
+## Implementation notes (for the MCP server — the ask of this PR)
+
+The mechanism to swap the auth globals already exists: `handleLogin` reloads
+`accountURL`/`workspaceID`/`stageID`/`apiToken` under `withAuthLock`. A profile feature can reuse it:
+
+1. Load `~/.corezoid/profiles/registry.json` (fall back to `.env` if absent — fully backward compatible).
+2. Add a `use-profile` tool (and/or a resolver helper) that takes a signal, picks a profile per the
+   rules above, and writes its coordinates into the globals via `withAuthLock` — no OAuth needed.
+3. Keep `is_prod` confirmation as a guardrail.
+
+No per-call `env` argument is needed: the established workflow is one chat = one environment, so
+resolve-and-lock at session start is enough.

--- a/plugins/corezoid/docs/connection-profiles.md
+++ b/plugins/corezoid/docs/connection-profiles.md
@@ -1,7 +1,6 @@
 # Connection profiles (multi-environment switching)
 
-> Status: **proposal / convention**. The `registry.example.json` template ships now; the
-> MCP-server wiring described under "Implementation notes" is the developer task this PR asks for.
+> Status: **implemented**. Ships the `use-profile` MCP tool + `registry.example.json` template.
 
 ## Problem
 
@@ -57,15 +56,23 @@ Safety (dev is the safe zone):
   second environment into an existing profile. Merging multiple configs into one profile is
   only allowed on an explicit flag.
 
-## Implementation notes (for the MCP server — the ask of this PR)
+## The `use-profile` tool
 
-The mechanism to swap the auth globals already exists: `handleLogin` reloads
-`accountURL`/`workspaceID`/`stageID`/`apiToken` under `withAuthLock`. A profile feature can reuse it:
+```
+use-profile profile=az-dev            # by registry key
+use-profile signal=AZ-123             # by JIRA prefix
+use-profile signal=https://host/...   # by Corezoid URL host
+use-profile profile=az-prod confirm=true   # production requires confirm
+```
 
-1. Load `~/.corezoid/profiles/registry.json` (fall back to `.env` if absent — fully backward compatible).
-2. Add a `use-profile` tool (and/or a resolver helper) that takes a signal, picks a profile per the
-   rules above, and writes its coordinates into the globals via `withAuthLock` — no OAuth needed.
-3. Keep `is_prod` confirmation as a guardrail.
+It loads the resolved profile's coordinates into the running server's auth globals via
+`withAuthLock`, and the `ACCESS_TOKEN` from the profile's `env_file` if set (otherwise the
+current session token is kept). Crucially it does **not** write the shared `cwd/.env` — so two
+chats rooted in the same directory no longer clobber each other's environment.
+
+Implemented in `mcp-server/mcp_handlers_profile.go` (`loadProfileRegistry`, `resolveProfile`,
+`handleUseProfile`); registered in `mcp_handlers.go` and `tools_registry.go`. The registry is
+optional — with no `registry.json`, behaviour is unchanged (the server still uses `.env`).
 
 No per-call `env` argument is needed: the established workflow is one chat = one environment, so
 resolve-and-lock at session start is enough.

--- a/plugins/corezoid/mcp-server/mcp_handlers.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers.go
@@ -19,8 +19,9 @@ type toolHandler func(ctx context.Context, args map[string]interface{}) (result 
 // behavior doesn't pull in unrelated diffs to login/push/etc.
 var toolHandlers = map[string]toolHandler{
 	// auth
-	"login":  handleLogin,
-	"logout": handleLogout,
+	"login":       handleLogin,
+	"logout":      handleLogout,
+	"use-profile": handleUseProfile,
 
 	// process / folder / alias
 	"pull-process":         handlePullProcess,
@@ -86,6 +87,7 @@ var noAuthTools = map[string]struct{}{
 	"lint-process": {},
 	"login":        {},
 	"logout":       {},
+	"use-profile":  {},
 }
 
 // tokenOnlyTools need an OAuth token but not a fully configured workspace or

--- a/plugins/corezoid/mcp-server/mcp_handlers_profile.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_profile.go
@@ -1,0 +1,228 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// Connection profiles let one running server target many Corezoid environments
+// (markets / projects / dev+prod) by name, WITHOUT rewriting the shared
+// cwd/.env that login persists to. login writing to cwd/.env is what lets two
+// parallel chats rooted in the same directory clobber each other's environment;
+// use-profile sidesteps that by mutating only this process's in-memory auth
+// state. Each chat is a separate MCP process, so in-memory state is isolated.
+
+type profileMatch struct {
+	Aliases    []string `json:"aliases"`
+	Hosts      []string `json:"hosts"`
+	JiraPrefix []string `json:"jira_prefix"`
+}
+
+type profileEntry struct {
+	AccountURL  string       `json:"account_url"`
+	WorkspaceID string       `json:"workspace_id"`
+	StageID     int          `json:"stage_id"`
+	Match       profileMatch `json:"match"`
+	IsProd      bool         `json:"is_prod"`
+	// EnvFile (optional): path to a .env holding ACCESS_TOKEN for this profile.
+	// Tokens are NOT stored in the registry; this points at a per-user file.
+	EnvFile string `json:"env_file"`
+}
+
+type profileRegistry struct {
+	Profiles map[string]profileEntry `json:"profiles"`
+}
+
+func profileRegistryPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".corezoid", "profiles", "registry.json"), nil
+}
+
+func loadProfileRegistry() (*profileRegistry, error) {
+	path, err := profileRegistryPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("cannot read profile registry %s: %w", path, err)
+	}
+	var reg profileRegistry
+	if err := json.Unmarshal(data, &reg); err != nil {
+		return nil, fmt.Errorf("invalid JSON in %s: %w", path, err)
+	}
+	return &reg, nil
+}
+
+// readEnvKey returns a single key's value from a .env file without mutating the
+// process environment (unlike loadDotEnv, which Setenv's everything). Used so a
+// profile's env_file contributes only its ACCESS_TOKEN, never stale coords.
+func readEnvKey(path, key string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, key+"=") {
+			continue
+		}
+		v := strings.TrimSpace(line[len(key)+1:])
+		if len(v) >= 2 && ((v[0] == '"' && v[len(v)-1] == '"') || (v[0] == '\'' && v[len(v)-1] == '\'')) {
+			v = v[1 : len(v)-1]
+		}
+		return v
+	}
+	return ""
+}
+
+// resolveProfile picks a profile from a free-form signal. Priority:
+//  1. exact registry key
+//  2. host substring (a Corezoid URL implies its environment, unambiguously)
+//  3. JIRA prefix (e.g. "AZ-123" -> "AZ")
+//  4. alias substring
+//
+// For prefix/alias matches that hit several profiles (e.g. AZ dev + prod share
+// prefix "AZ"), the non-prod profile wins unless the signal contains "prod" —
+// dev is the safe default.
+func resolveProfile(reg *profileRegistry, signal string) (string, profileEntry, error) {
+	s := strings.ToLower(strings.TrimSpace(signal))
+	wantsProd := strings.Contains(s, "prod")
+
+	// 1. exact key
+	if e, ok := reg.Profiles[signal]; ok {
+		return signal, e, nil
+	}
+	if e, ok := reg.Profiles[s]; ok {
+		return s, e, nil
+	}
+
+	// 2. host substring — unambiguous, return immediately.
+	for k, e := range reg.Profiles {
+		for _, h := range e.Match.Hosts {
+			if h != "" && strings.Contains(s, strings.ToLower(h)) {
+				return k, e, nil
+			}
+		}
+	}
+
+	pickWithProdPref := func(candidates map[string]profileEntry) (string, profileEntry, bool) {
+		if len(candidates) == 0 {
+			return "", profileEntry{}, false
+		}
+		var fallbackKey string
+		var fallbackEntry profileEntry
+		for k, e := range candidates {
+			if e.IsProd == wantsProd {
+				return k, e, true
+			}
+			fallbackKey, fallbackEntry = k, e
+		}
+		return fallbackKey, fallbackEntry, true
+	}
+
+	// 3. JIRA prefix
+	upper := strings.ToUpper(s)
+	jiraCands := map[string]profileEntry{}
+	for k, e := range reg.Profiles {
+		for _, p := range e.Match.JiraPrefix {
+			if p != "" && strings.HasPrefix(upper, strings.ToUpper(p)+"-") {
+				jiraCands[k] = e
+			}
+		}
+	}
+	if k, e, ok := pickWithProdPref(jiraCands); ok {
+		return k, e, nil
+	}
+
+	// 4. alias substring
+	aliasCands := map[string]profileEntry{}
+	for k, e := range reg.Profiles {
+		for _, a := range e.Match.Aliases {
+			if a != "" && strings.Contains(s, strings.ToLower(a)) {
+				aliasCands[k] = e
+			}
+		}
+	}
+	if k, e, ok := pickWithProdPref(aliasCands); ok {
+		return k, e, nil
+	}
+
+	keys := make([]string, 0, len(reg.Profiles))
+	for k := range reg.Profiles {
+		keys = append(keys, k)
+	}
+	return "", profileEntry{}, fmt.Errorf("no profile matched %q. Available profiles: %s", signal, strings.Join(keys, ", "))
+}
+
+// handleUseProfile activates a connection profile for THIS process only.
+func handleUseProfile(_ context.Context, args map[string]interface{}) (string, bool) {
+	signal := optStrArg(args, "profile")
+	if signal == "" {
+		signal = optStrArg(args, "signal")
+	}
+	if signal == "" {
+		return "Provide 'profile' (a registry key) or 'signal' (a market name, JIRA key like AZ-123, or a Corezoid URL).", true
+	}
+
+	reg, err := loadProfileRegistry()
+	if err != nil {
+		return err.Error(), true
+	}
+	key, e, err := resolveProfile(reg, signal)
+	if err != nil {
+		return err.Error(), true
+	}
+	if e.AccountURL == "" {
+		return fmt.Sprintf("Profile %q has no account_url in registry.json — fill it in first.", key), true
+	}
+	if e.IsProd && optStrArg(args, "confirm") != "true" {
+		return fmt.Sprintf("Profile %q is PRODUCTION (%s). Re-call use-profile with confirm=true to activate.", key, e.AccountURL), true
+	}
+
+	token := ""
+	if e.EnvFile != "" {
+		token = readEnvKey(e.EnvFile, "ACCESS_TOKEN")
+	}
+
+	withAuthLock(func() {
+		accountURL = e.AccountURL
+		apiURL = e.AccountURL // in FF installs the account host IS the API host
+		workspaceID = e.WorkspaceID
+		stageID = e.StageID
+		if token != "" {
+			apiToken = token
+		}
+	})
+	// Mirror into this process's env so any os.Getenv reads stay consistent —
+	// but deliberately NOT into the shared cwd/.env file.
+	os.Setenv("ACCOUNT_URL", e.AccountURL)
+	os.Setenv("COREZOID_API_URL", e.AccountURL)
+	os.Setenv("WORKSPACE_ID", e.WorkspaceID)
+	os.Setenv("COREZOID_STAGE_ID", strconv.Itoa(e.StageID))
+
+	_, tok, _, _, _ := authSnapshot()
+	tokNote := "token: kept current session token"
+	if token != "" {
+		tokNote = "token: loaded from " + e.EnvFile
+	}
+	if tok == "" {
+		tokNote += " — WARNING: no token set; run login or set env_file in the registry"
+	}
+	prodNote := ""
+	if e.IsProd {
+		prodNote = " [PRODUCTION]"
+	}
+	return fmt.Sprintf(
+		"Active profile: %s%s\n  account_url = %s\n  workspace_id = %s\n  stage_id = %d\n  %s\n(in-memory only — shared .env untouched, so parallel chats won't collide)",
+		key, prodNote, e.AccountURL, e.WorkspaceID, e.StageID, tokNote,
+	), false
+}

--- a/plugins/corezoid/mcp-server/registry.example.json
+++ b/plugins/corezoid/mcp-server/registry.example.json
@@ -1,0 +1,27 @@
+{
+  "_comment": "Connection-profile registry for the Corezoid MCP server. Copy this file to ~/.corezoid/profiles/registry.json and fill in your own environments. Coordinates only — NEVER put ACCESS_TOKEN here; tokens stay per-user in ~/.corezoid/credentials or each profile's .env. The resolver picks a profile from a signal (alias / jira_prefix / host URL). When a JIRA prefix maps to several profiles (e.g. a dev + a prod of the same project), the dev one (is_prod:false) wins unless the signal explicitly names prod or carries a prod host.",
+  "profiles": {
+    "myproject-dev": {
+      "account_url": "https://account.dev.example.com",
+      "workspace_id": "i000000000",
+      "stage_id": 10001,
+      "match": {
+        "aliases": ["myproject", "myproject dev"],
+        "hosts": ["account.dev.example.com"],
+        "jira_prefix": ["PROJ"]
+      },
+      "is_prod": false
+    },
+    "myproject-prod": {
+      "account_url": "https://account.example.com",
+      "workspace_id": "i000000001",
+      "stage_id": 20001,
+      "match": {
+        "aliases": ["myproject prod"],
+        "hosts": ["account.example.com"],
+        "jira_prefix": ["PROJ"]
+      },
+      "is_prod": true
+    }
+  }
+}

--- a/plugins/corezoid/mcp-server/registry.example.json
+++ b/plugins/corezoid/mcp-server/registry.example.json
@@ -1,10 +1,11 @@
 {
-  "_comment": "Connection-profile registry for the Corezoid MCP server. Copy this file to ~/.corezoid/profiles/registry.json and fill in your own environments. Coordinates only — NEVER put ACCESS_TOKEN here; tokens stay per-user in ~/.corezoid/credentials or each profile's .env. The resolver picks a profile from a signal (alias / jira_prefix / host URL). When a JIRA prefix maps to several profiles (e.g. a dev + a prod of the same project), the dev one (is_prod:false) wins unless the signal explicitly names prod or carries a prod host.",
+  "_comment": "Connection-profile registry for the Corezoid MCP server. Copy this file to ~/.corezoid/profiles/registry.json and fill in your own environments. Coordinates only — NEVER put ACCESS_TOKEN here; point env_file at a per-user .env that holds it. The use-profile tool resolves a profile from a signal (registry key / Corezoid URL host / JIRA prefix / alias) and loads it into the session WITHOUT rewriting the shared cwd/.env. When a JIRA prefix maps to several profiles (e.g. a dev + a prod of the same project), the dev one (is_prod:false) wins unless the signal explicitly names prod or carries a prod host.",
   "profiles": {
     "myproject-dev": {
       "account_url": "https://account.dev.example.com",
       "workspace_id": "i000000000",
       "stage_id": 10001,
+      "env_file": "/home/me/.corezoid/profiles/myproject-dev.env",
       "match": {
         "aliases": ["myproject", "myproject dev"],
         "hosts": ["account.dev.example.com"],
@@ -16,6 +17,7 @@
       "account_url": "https://account.example.com",
       "workspace_id": "i000000001",
       "stage_id": 20001,
+      "env_file": "/home/me/.corezoid/profiles/myproject-prod.env",
       "match": {
         "aliases": ["myproject prod"],
         "hosts": ["account.example.com"],

--- a/plugins/corezoid/mcp-server/tools_registry.go
+++ b/plugins/corezoid/mcp-server/tools_registry.go
@@ -398,6 +398,27 @@ var toolRegistry = []mcpTool{
 		},
 	},
 	{
+		Name:        "use-profile",
+		Description: "Switch this session to a named Corezoid connection profile from ~/.corezoid/profiles/registry.json, WITHOUT rewriting the shared .env (so parallel chats don't clobber each other). Resolves by registry key, Corezoid URL host, JIRA prefix (e.g. AZ-123), or alias. Production profiles require confirm=true.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"profile": map[string]interface{}{
+					"type":        "string",
+					"description": "Registry key of the profile (e.g. az-dev, india-dev).",
+				},
+				"signal": map[string]interface{}{
+					"type":        "string",
+					"description": "Free-form signal to resolve a profile: a market name, a JIRA key (AZ-123), or a Corezoid URL. Used when 'profile' is not given.",
+				},
+				"confirm": map[string]interface{}{
+					"type":        "string",
+					"description": "Set to \"true\" to confirm activating a production (is_prod) profile.",
+				},
+			},
+		},
+	},
+	{
 		Name:        "create-dashboard",
 		Description: "Create a new Corezoid dashboard for visualizing process node metrics. Returns dashboard_id needed for adding charts.",
 		InputSchema: map[string]interface{}{


### PR DESCRIPTION
## Summary
- Adds **connection profiles** so one MCP server can target many Corezoid environments (markets / projects / dev+prod) without per-folder `.env` juggling + restarts.
- New `use-profile` MCP tool: switches the running session to a named profile from `~/.corezoid/profiles/registry.json`, resolved by registry key / Corezoid URL host / JIRA prefix (`AZ-123`) / alias. It sets the auth globals via the existing `withAuthLock` path and loads the token from a per-profile `env_file` — **without rewriting the shared `cwd/.env`**.
- Ships `registry.example.json` (coordinates only — tokens stay per-user) + `docs/connection-profiles.md`.

## Why
- One running process = one environment; switching needs a `.env` swap + restart.
- Worse for parallel work: `login` persists to `cwd/.env`, so two chats rooted in the same directory **clobber each other's environment** (observed live: a chat meant for env A started hitting env B's host). `use-profile` mutates in-memory state only, so parallel chats stay isolated.
- Registry is **optional** — with no `registry.json`, behaviour is unchanged (`.env` as before).

## Changes
- `mcp-server/mcp_handlers_profile.go` — registry load, signal resolver (dev-preferred on ambiguous prefix; prod requires `confirm=true`), `handleUseProfile`.
- `mcp-server/mcp_handlers.go`, `mcp-server/tools_registry.go` — register the tool.
- `mcp-server/registry.example.json`, `docs/connection-profiles.md`.

## Test plan
- [x] `go build ./...` passes
- [x] `registry.example.json` is valid JSON
- [x] Resolver verified by key / JIRA key / URL host; prod gate enforced; no-match lists profiles
- [ ] Confirm no secrets / real hosts committed

@MalishkinMV — review please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
