### PR TITLE
fix: detect and disallow passthrough escalation nodes

### DIFF
--- a/plugins/corezoid/docs/node-structures.md
+++ b/plugins/corezoid/docs/node-structures.md
@@ -446,8 +446,8 @@ Complete JSON structures for all node types used when modifying Corezoid process
 
 ## Escalation Node (`obj_type: 3`)
 
-Escalation nodes handle errors and timeouts. They always contain `api_rpc_reply` with
-`throw_exception: true` and route to a Final Error node.
+Escalation nodes handle errors that require active logic: replying to the calling process,
+conditional retry routing, or performing any action before terminating.
 
 ```json
 {
@@ -484,17 +484,46 @@ Escalation nodes handle errors and timeouts. They always contain `api_rpc_reply`
 ```
 
 **Rules:**
-- `obj_type: 3` marks this node as an escalation (reply) node
-- Must always contain `api_rpc_reply` with `throw_exception: true`
+- `obj_type: 3` marks this node as an escalation node
 - Must always end with `go` routing to a Final Error node (`obj_type: 2`)
 - `{{__conveyor_api_return_description__}}` is the system variable that captures the error message from the failed node
-- Every functional node that can fail (`api`, `api_code`, `api_rpc`, `api_copy`, `set_param`, `db_call`, `git_call`, `api_sum`) needs `err_node_id` pointing to an escalation node
 - API Call nodes also need a separate timeout escalation node via `semaphors`
 
-**Error handling pattern:**
+**When to use an escalation node vs. a direct final node:**
+
+Use an escalation node (`obj_type: 3`) only when the error path needs actual logic:
+- Replying to the calling process (`api_rpc_reply` with `throw_exception: true`)
+- Conditional routing based on error type (`go_if_const` on `__conveyor_*_return_type_tag__`)
+- Any other action before terminating
+
+Wire `err_node_id` **directly to a Final Error node** (`obj_type: 2`) when the error path
+simply needs to terminate with no additional logic:
+
 ```
-[Functional Node] --err_node_id--> [Escalation obj_type:3] --go--> [Final Error obj_type:2]
-[API Call Node]   --semaphor-----> [Timeout Escalation]    --go--> [Timeout Final obj_type:2]
+[Functional Node] --err_node_id--> [Final Error obj_type:2]      ✓ no logic needed
+[Functional Node] --err_node_id--> [Escalation obj_type:3]       ✓ reply / routing needed
+                                          └──go──> [Final Error obj_type:2]
+[API Call Node]   --semaphor-----> [Timeout Escalation obj_type:3] --go--> [Timeout Final obj_type:2]
+```
+
+**Anti-pattern — passthrough escalation (flagged by `lint-process`):**
+
+An escalation node with only a bare `go` and no action logic is pointless clutter.
+Replace it with a direct `err_node_id` pointer to the final node:
+
+```json
+// ✗ wrong — empty escalation node, no logic inside
+{
+  "id": "...",
+  "obj_type": 3,
+  "condition": {
+    "logics": [{"type": "go", "to_node_id": "<final_error_id>"}],
+    "semaphors": []
+  }
+}
+
+// ✓ correct — err_node_id points straight at the final error node
+"err_node_id": "<final_error_id>"
 ```
 
 ---

--- a/plugins/corezoid/docs/process/error-handling.md
+++ b/plugins/corezoid/docs/process/error-handling.md
@@ -57,24 +57,30 @@ Condition nodes:
 
 ### 1. Basic Error Routing
 
-The simplest error handling pattern routes tasks to a dedicated error node when an error occurs:
+The simplest pattern routes `err_node_id` directly to a Final Error node when no action
+is needed on the error path:
 
 ```
 Operation Node ──→ Success Path
       │
-      └─── [error] ──→ Error Node → End Node
+      └─── [err_node_id] ──→ Final Error Node (obj_type:2)
 ```
 
 Implementation:
 
 ```json
 {
-  "type": "api",
-  "method": "GET",
-  "url": "https://api.example.com",
-  "err_node_id": "error_node_id"
+  "type": "api_rpc",
+  "conv_id": 12345,
+  "err_node_id": "<final_error_node_id>"
 }
 ```
+
+> **Rule:** Wire `err_node_id` directly to a Final Error node (`obj_type: 2`) when the
+> error path needs no logic. Only interpose an Escalation node (`obj_type: 3`) when the
+> error path requires an action such as replying to the caller or conditional retry routing.
+> An escalation node that only contains a bare `go` with no action logic is an anti-pattern
+> and is flagged by `lint-process` as a **passthrough escalation**.
 
 ### 2. Error Type Differentiation
 

--- a/plugins/corezoid/mcp-server/lint.go
+++ b/plugins/corezoid/mcp-server/lint.go
@@ -9,14 +9,15 @@ import (
 
 // LintResult holds the combined lint output
 type LintResult struct {
-	ProcessTitle    string
-	NoopConditions  []NoopCondition
-	UnusedSetParams []UnusedSetParam
-	OrphanedNodes   []OrphanedNode
-	TotalNodes      int
-	ReachableCount  int
-	SchemaValid     bool
-	SchemaError     string
+	ProcessTitle             string
+	NoopConditions           []NoopCondition
+	UnusedSetParams          []UnusedSetParam
+	OrphanedNodes            []OrphanedNode
+	PassthroughEscalations   []PassthroughEscalation
+	TotalNodes               int
+	ReachableCount           int
+	SchemaValid              bool
+	SchemaError              string
 }
 
 type NoopCondition struct {
@@ -39,6 +40,17 @@ type OrphanedNode struct {
 	ID      string
 	Title   string
 	ObjType string
+}
+
+// PassthroughEscalation represents an escalation node (obj_type:3) whose only logic
+// is a bare `go` — it adds no value and should be replaced by a direct err_node_id
+// pointing straight to the final error node.
+type PassthroughEscalation struct {
+	ID          string
+	Title       string
+	TargetID    string
+	TargetTitle string
+	Issue       string
 }
 
 // processNode is the typed representation of a Corezoid node used throughout lint checks.
@@ -98,6 +110,7 @@ func lintProcess(filePath string) (*LintResult, error) {
 	typed := parseProcessNodes(nodes)
 	result.NoopConditions, result.UnusedSetParams = findNoopNodes(typed)
 	result.OrphanedNodes, result.ReachableCount = findOrphanedNodes(typed)
+	result.PassthroughEscalations = findPassthroughEscalations(typed)
 
 	schemaErr := ValidateJSONSchema(filePath, debug)
 	if schemaErr != nil {
@@ -223,6 +236,75 @@ func findNoopNodes(nodes []processNode) ([]NoopCondition, []UnusedSetParam) {
 	return noopConditions, unusedSetParams
 }
 
+// findPassthroughEscalations detects escalation nodes (obj_type:3) that contain only
+// a bare `go` logic and no action logic (api_rpc_reply, set_param, etc.).
+// Such nodes are pure pass-throughs: the err_node_id should point directly to the
+// final error node instead of routing through an empty escalation node.
+func findPassthroughEscalations(nodes []processNode) []PassthroughEscalation {
+	nodeMap := make(map[string]processNode, len(nodes))
+	for _, n := range nodes {
+		nodeMap[n.id] = n
+	}
+
+	actionTypes := map[string]bool{
+		"api_rpc_reply": true,
+		"api_rpc":       true,
+		"api_copy":      true,
+		"api":           true,
+		"api_code":      true,
+		"set_param":     true,
+		"api_sum":       true,
+		"db_call":       true,
+		"api_git":       true,
+		"api_queue":     true,
+		"api_get_task":  true,
+	}
+
+	var result []PassthroughEscalation
+	for _, n := range nodes {
+		if n.objType != 3 {
+			continue
+		}
+		hasAction := false
+		goTarget := ""
+		for _, lg := range n.logics {
+			lgType, _ := lg["type"].(string)
+			if actionTypes[lgType] {
+				hasAction = true
+				break
+			}
+			if lgType == "go" {
+				goTarget, _ = lg["to_node_id"].(string)
+			}
+		}
+		if hasAction || goTarget == "" {
+			continue
+		}
+		targetTitle := ""
+		if target, ok := nodeMap[goTarget]; ok {
+			targetTitle = target.title
+			if targetTitle == "" {
+				targetTitle = "(untitled)"
+			}
+		}
+		displayTitle := n.title
+		if displayTitle == "" {
+			displayTitle = "(untitled)"
+		}
+		result = append(result, PassthroughEscalation{
+			ID:          n.id,
+			Title:       displayTitle,
+			TargetID:    goTarget,
+			TargetTitle: targetTitle,
+			Issue: fmt.Sprintf(
+				"Escalation node (obj_type:3) has no action logic — wire err_node_id directly to '%s' (%s)",
+				targetTitle, goTarget,
+			),
+		})
+	}
+	return result
+}
+
 // findOrphanedNodes does a BFS from the Start node and returns unreachable nodes
 func findOrphanedNodes(nodes []processNode) ([]OrphanedNode, int) {
 	typeLabels := map[float64]string{0: "standard", 1: "start", 2: "final", 3: "escalation"}
@@ -343,6 +425,15 @@ func FormatLintResult(result *LintResult) string {
 		}
 	}
 
+	if len(result.PassthroughEscalations) > 0 {
+		hasIssues = true
+		sb.WriteString(fmt.Sprintf("\n=== PASSTHROUGH ESCALATION NODES (%d) ===\n", len(result.PassthroughEscalations)))
+		for _, pe := range result.PassthroughEscalations {
+			sb.WriteString(fmt.Sprintf("  [%s] %s\n", pe.ID, pe.Title))
+			sb.WriteString(fmt.Sprintf("  Issue: %s\n", pe.Issue))
+		}
+	}
+
 	if !hasIssues {
 		sb.WriteString("\nNo issues found.")
 	} else {
@@ -350,7 +441,7 @@ func FormatLintResult(result *LintResult) string {
 		if !result.SchemaValid {
 			schemaIssues = 1
 		}
-		total := len(result.NoopConditions) + len(result.UnusedSetParams) + len(result.OrphanedNodes) + schemaIssues
+		total := len(result.NoopConditions) + len(result.UnusedSetParams) + len(result.OrphanedNodes) + len(result.PassthroughEscalations) + schemaIssues
 		sb.WriteString(fmt.Sprintf("\nTotal issues: %d\n", total))
 	}
 

--- a/plugins/corezoid/mcp-server/lint_test.go
+++ b/plugins/corezoid/mcp-server/lint_test.go
@@ -53,6 +53,20 @@ func TestLintProcess_NoopCondition(t *testing.T) {
 	}
 }
 
+// TestLintProcess_PassthroughEscalation verifies passthrough escalation node detection.
+func TestLintProcess_PassthroughEscalation(t *testing.T) {
+	result, err := lintProcess("samples/passthrough_escalation.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.PassthroughEscalations) != 1 {
+		t.Errorf("expected 1 passthrough escalation, got %d", len(result.PassthroughEscalations))
+	}
+	if result.PassthroughEscalations[0].TargetTitle != "rpc_error" {
+		t.Errorf("expected target title 'rpc_error', got %q", result.PassthroughEscalations[0].TargetTitle)
+	}
+}
+
 // TestLintProcess_MalformedJSON verifies graceful error on invalid JSON.
 func TestLintProcess_MalformedJSON(t *testing.T) {
 	f, err := os.CreateTemp("", "bad-*.json")

--- a/plugins/corezoid/mcp-server/samples/passthrough_escalation.json
+++ b/plugins/corezoid/mcp-server/samples/passthrough_escalation.json
@@ -1,0 +1,79 @@
+{
+  "obj_type": 1,
+  "obj_id": 0,
+  "title": "Passthrough Escalation Example",
+  "scheme": {
+    "nodes": [
+      {
+        "id": "aabbccddaabbccddaabbcc01",
+        "obj_type": 1,
+        "condition": {
+          "logics": [
+            {"type": "go", "to_node_id": "aabbccddaabbccddaabbcc02"}
+          ],
+          "semaphors": []
+        },
+        "title": "Start",
+        "x": 0, "y": 0,
+        "extra": "{\"modeForm\":\"collapse\",\"icon\":\"\"}"
+      },
+      {
+        "id": "aabbccddaabbccddaabbcc02",
+        "obj_type": 0,
+        "condition": {
+          "logics": [
+            {
+              "type": "api_rpc",
+              "conv_id": 12345,
+              "user_id": 1,
+              "group": "",
+              "extra": {},
+              "extra_type": {},
+              "err_node_id": "aabbccddaabbccddaabbcc03"
+            },
+            {"type": "go", "to_node_id": "aabbccddaabbccddaabbcc05"}
+          ],
+          "semaphors": []
+        },
+        "title": "Call Payment",
+        "x": 0, "y": 200,
+        "extra": "{\"modeForm\":\"expand\",\"icon\":\"\"}"
+      },
+      {
+        "id": "aabbccddaabbccddaabbcc03",
+        "obj_type": 3,
+        "condition": {
+          "logics": [
+            {"type": "go", "to_node_id": "aabbccddaabbccddaabbcc04"}
+          ],
+          "semaphors": []
+        },
+        "title": "",
+        "x": 300, "y": 200,
+        "extra": "{\"modeForm\":\"collapse\",\"icon\":\"error\"}"
+      },
+      {
+        "id": "aabbccddaabbccddaabbcc04",
+        "obj_type": 2,
+        "condition": {
+          "logics": [],
+          "semaphors": []
+        },
+        "title": "rpc_error",
+        "x": 300, "y": 400,
+        "extra": "{\"modeForm\":\"collapse\",\"icon\":\"error\"}"
+      },
+      {
+        "id": "aabbccddaabbccddaabbcc05",
+        "obj_type": 2,
+        "condition": {
+          "logics": [],
+          "semaphors": []
+        },
+        "title": "Final",
+        "x": 0, "y": 400,
+        "extra": "{\"modeForm\":\"collapse\",\"icon\":\"success\"}"
+      }
+    ]
+  }
+}

--- a/plugins/corezoid/skills/corezoid-create/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-create/SKILL.md
@@ -110,7 +110,7 @@ Produce a valid `.conv.json` file.
 
 - Node IDs must be unique 24-character hex strings: `^[0-9a-f]{24}$`. These are **temporary placeholders** for new nodes — on `push-process` Corezoid reassigns its own canonical IDs (and rewires references within the push). Run `pull-process` after pushing to get the canonical IDs before any further edits. See [Node ID Lifecycle](${CLAUDE_PLUGIN_ROOT}/docs/process/process-development-guide.md#node-id-lifecycle-server-assignment--stability-on-push).
 - Connect nodes only through the `go` field
-- Every node that can fail must have `err_node_id` pointing to a dedicated error node
+- Every node that can fail must have `err_node_id` — point it **directly at a Final Error node** (`obj_type: 2`) unless the error path needs logic (reply to caller, retry routing). Never create an Escalation node (`obj_type: 3`) that only contains a bare `go` — that is a passthrough anti-pattern flagged by `lint-process`
 - All constants (URLs, tokens, IDs) must be Corezoid variables — never hardcoded:
   1. Check for existing variables: read `_ENV_VARS_.json` (from `pull-folder`) or `.processes/variables.json` (from this session)
   2. Create a new variable if needed: call MCP tool **`create-variable`** with `name`, `description`, `value`

--- a/plugins/corezoid/skills/corezoid-edit/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-edit/SKILL.md
@@ -44,7 +44,7 @@ Apply changes to `PROCESS_PATH`.
 ### Core rules
 
 - Connect nodes only through the `go` field
-- Every node that can fail must have `err_node_id` pointing to a dedicated error node
+- Every node that can fail must have `err_node_id` — point it **directly at a Final Error node** (`obj_type: 2`) unless the error path needs logic (reply to caller, retry routing). Never create an Escalation node (`obj_type: 3`) that only contains a bare `go` — that is a passthrough anti-pattern flagged by `lint-process`
 - Node IDs must be unique 24-character hex strings: `^[0-9a-f]{24}$`. **Always `pull-process` before editing** and reference only canonical, server-assigned IDs — IDs you invented in a previous push were reassigned by the server and no longer exist. New nodes added now get placeholder IDs that the server will likewise reassign on push. Existing nodes' IDs are preserved. See [Node ID Lifecycle](${CLAUDE_PLUGIN_ROOT}/docs/process/process-development-guide.md#node-id-lifecycle-server-assignment--stability-on-push).
 - Use descriptive node `title` values (e.g., "Call Payment Process", not "RPC")
 - Place new nodes below existing ones, incrementing `y` by 200–250px


### PR DESCRIPTION
## Problem

An escalation node (`obj_type: 3`) containing only a bare `go` logic — no `api_rpc_reply`, no conditional routing — is pure clutter. It adds a node to the diagram without doing any work. The correct pattern is to wire `err_node_id` directly to the final error node (`obj_type: 2`).

**Before (anti-pattern):**
```
functional_node --err_node_id--> escalation_node (obj_type:3, only go) --go--> final_error (obj_type:2)
```

**After (correct):**
```
functional_node --err_node_id--> final_error (obj_type:2)
```

## Changes

### `mcp-server/lint.go`
- New `PassthroughEscalation` type
- New `findPassthroughEscalations()` function: detects `obj_type:3` nodes whose logics array contains only a `go` and no action logic (`api_rpc_reply`, `set_param`, `api_rpc`, etc.)
- `LintResult` gains `PassthroughEscalations []PassthroughEscalation`
- `FormatLintResult` prints new `=== PASSTHROUGH ESCALATION NODES ===` section
- Total issue count updated

### `mcp-server/lint_test.go`
- `TestLintProcess_PassthroughEscalation` test case

### `mcp-server/samples/passthrough_escalation.json`
- Minimal sample process with one passthrough escalation node for test fixture

### `docs/node-structures.md`
- Escalation Node section rewritten: clarifies *when* to use `obj_type:3` vs wiring `err_node_id` directly to a final node
- Adds anti-pattern block with before/after JSON examples

### `docs/process/error-handling.md`
- Basic Error Routing updated: direct `err_node_id → final` shown as the default
- Added passthrough-escalation note pointing to `lint-process`

### `skills/corezoid-create/SKILL.md` and `skills/corezoid-edit/SKILL.md`
- Core rules updated with the direct rule

## Tests

All existing lint tests pass. New test `TestLintProcess_PassthroughEscalation` added and green.