### PR TITLE
docs(api-call): require the full canonical api logic shape (a "light" node hangs push)

### DIFF
--- a/plugins/corezoid/docs/nodes/api-call-node.md
+++ b/plugins/corezoid/docs/nodes/api-call-node.md
@@ -154,6 +154,41 @@ The API Call node allows customization of how response data is processed:
    - Default fields: `header` (response headers) and `body` (response content)
    - Custom mapping allows selecting specific fields from the response
 
+## Required node shape: author the full canonical `api` logic
+
+Although the JSON schema marks only `type`, `method`, `url`, and `err_node_id` as strictly
+required, an `api` logic written with just those fields is **incomplete** and breaks deployment.
+A "light" node passes client-side validation (and `lint-process`), but the server cannot complete
+the **commit** of an under-specified `api` logic: it stops responding, and after ~15–20 s
+`push-process` fails with `Error deploying process: failed to commit changes: no response from
+server` instead of deploying. (Verified live: the identical process commits cleanly in ~10 s once
+the node carries the full field set; the light variant failed this way on every attempt.) This is a
+common, easily-misdiagnosed cause of a `push` that does not complete on a process containing an API
+Call node.
+
+**Always author an API Call node with the full canonical field set**, even when a value is the
+default:
+
+| Field | Typical value | Notes |
+| --- | --- | --- |
+| `type` | `"api"` | |
+| `method` | `"GET"` / `"POST"` / … | required |
+| `url` | endpoint | required; use a variable, never hardcoded |
+| `extra` / `extra_type` | request params + their types | both required, may be `{}` |
+| `format` | `""` (default) or `"raw"` | |
+| `max_threads` | `5` | |
+| `send_sys` | `true` | `false` for non-Corezoid endpoints |
+| `customize_response` | `false` or `true` | see "Reading the response body" below |
+| `response` / `response_type` | mapping objects | only consulted when `customize_response: true` |
+| `rfc_format` | `true` | |
+| `debug_info` | `false` | |
+| `cert_pem` | `""` | a PEM string only when signing by certificate |
+| `version` | `2` | |
+| `err_node_id` | error-node id | required |
+
+Copy the [GET configuration example](#configuration-example-get-request) as a template rather than
+writing a minimal block from scratch. Do **not** set `is_migrate` by hand — it is server-managed.
+
 ## Validation Rules
 
 The API Call node undergoes validation during process commit with these checks:
@@ -164,8 +199,14 @@ The API Call node undergoes validation during process commit with these checks:
 4. If `err_node_id` is specified, it must reference a valid node
 5. `max_threads` must be a positive integer if specified
 
+> Note: schema validation only enforces `type`, `method`, `url`, and `err_node_id`. Omitting the
+> other canonical fields is **not** caught client-side and makes the deploy fail at commit
+> (`no response from server`) — see
+> [Required node shape](#required-node-shape-author-the-full-canonical-api-logic).
+
 ## Best Practices
 
+- Author the **full canonical `api` field set** (see [Required node shape](#required-node-shape-author-the-full-canonical-api-logic)); a minimal/"light" node passes validation but makes `push-process` fail at commit (`no response from server`)
 - Include proper error handling for all API calls
 - After an API Call node, add a "Reply to process" node to return the data
 - Set reasonable timeouts based on the expected response time


### PR DESCRIPTION
## What

A common, easily-misdiagnosed failure: a process containing an API Call node authored with a minimal/"light" field set **fails to deploy** — `push-process` errors with `failed to commit changes: no response from server`. The docs don't warn about this, and neither the schema nor lint catches it.

## Verified live

Same process, same network, three pushes:

| Node shape | Result | Time |
|---|---|---|
| light (`type`/`method`/`url`/`err_node_id` only) | `failed to commit changes: no response from server` | ~22 s |
| light (retry) | same error | ~15 s |
| **full canonical field set** | **deployed successfully** | ~10 s |

So the failure is caused by the under-specified `api` logic, not by the network: the server stops responding at the **commit** step and the client surfaces `no response from server` after ~15–20 s.

## Root cause (MCP push path)

- `json-schema/logics/api.json` `required` = `[type, method, url, err_node_id]` — the canonical fields (`customize_response`, `send_sys`, `max_threads`, `rfc_format`, `version`, `response`/`response_type`, `format`, `cert_pem`, `debug_info`) are **not** required.
- `fixStruct` (`main.go`) special-cases `type:"api"` but only normalizes `extra`/`extra_type`.
- `CreateNodesFromJSON` sends the logic as-is; there is **no completeness guard** in the client path.

A light node therefore passes client validation, reaches the server under-specified, and the commit never completes.

## Change (docs-only)

`docs/nodes/api-call-node.md`:
- New **"Required node shape"** section: table of the full canonical field set, the exact failure (`no response from server` at commit), and a pointer to the GET example as a copy-paste template (`is_migrate` is server-managed).
- Cross-links from **Validation Rules** (schema only enforces 4 fields) and **Best Practices**.

## Stronger fix (follow-up, not in this PR)

Inject defaults for the missing canonical fields in `fixStruct` (it already special-cases api nodes), so a light node is auto-completed instead of failing. Code change with test implications — happy to open separately if wanted.

Targeted at `develop` per maintainer preference.