### PR TITLE
docs(params): exact valid params element shape; params optional for receiving data

### DIFF
--- a/plugins/corezoid/docs/process/process-with-parameters.md
+++ b/plugins/corezoid/docs/process/process-with-parameters.md
@@ -109,6 +109,49 @@ validation rules, and flags. This pattern is useful when you need to:
 }
 ```
 
+## Required `params` element shape (deploy validation)
+
+`params` is a required top-level field, but it may be an **empty array** — use `"params": []` when
+the process declares no inputs.
+
+When you DO declare a parameter, the server validates each element strictly. **Every element must
+contain all six keys** below, or the deploy fails with `Params are not valid`:
+
+| Key | Type | Value |
+| --- | --- | --- |
+| `name` | string | a real parameter name |
+| `type` | string | one of `string`, `number`, `boolean`, `object`, `array` |
+| `descr` | string | may be `""` |
+| `flags` | array | may be `[]`; otherwise a subset of `required`, `input`, `output`, `auto-clear` |
+| `regex` | string | may be `""` |
+| `regex_error_text` | string | may be `""` |
+
+The keys must be **present** even when their value is empty — `descr: ""`, `flags: []`,
+`regex: ""`, and `regex_error_text: ""` are each accepted; `name` and `type` carry the parameter's
+actual definition. The JSON schema is laxer than the server here — it lists only `name`/`type`/`flags`
+and marks nothing as required, so an incomplete element passes client-side validation and is
+rejected only at deploy.
+
+Minimal valid single-parameter declaration:
+
+```json
+"params": [
+  { "name": "x", "type": "string", "descr": "", "flags": ["input"], "regex": "", "regex_error_text": "" }
+]
+```
+
+Verified by deploy: omitting any one of `descr`, `flags`, `regex`, or `regex_error_text` — or
+shrinking the element to `{ "name": "x", "type": "string" }` — is rejected with `Params are not
+valid`; the full element (and `"params": []`) deploy cleanly.
+
+### `params` is not required to receive data
+
+A process does **not** need declared `params` to accept input. When one process calls another via an
+`api_rpc` (Call a Process) or `api_copy` (Copy Task) node, the payload is passed through that node's
+`extra`, and the callee reads those keys directly from its task data — no `params` declaration
+required. Declare `params` only to enforce types / required-ness or to drive a UI; otherwise keep
+`"params": []`.
+
 ## Input Parameters
 
 The process defines five input parameters with different types, validation rules, and flags:
@@ -209,7 +252,8 @@ To call this process with valid parameters:
 
 When defining process parameters:
 
-1. Use the `required` flag for parameters that must be provided
+1. Include all six keys in every `params` element (`name`, `type`, `descr`, `flags`, `regex`, `regex_error_text`) — an incomplete element fails deploy with `Params are not valid` (see [Required `params` element shape](#required-params-element-shape-deploy-validation)); use `"params": []` when no inputs are declared
+2. Use the `required` flag for parameters that must be provided
 2. Provide clear descriptions for each parameter
 3. Use appropriate data types for parameters
 4. Add regex validation for string parameters that need to follow specific patterns


### PR DESCRIPTION
## What

Two gaps in `process-with-parameters.md`:
1. It shows a full `params` element but never states that the shape is **strictly required** — an incomplete element fails deploy with `Params are not valid`.
2. It doesn't mention that `params` is **optional for receiving data** (a callee reads an `api_rpc`/`api_copy` caller's `extra` from task data without declaring params).

## Verified live (9 deploys on one process)

A `params` element must contain **all six keys** or the deploy is rejected with `Params are not valid`:

| Element | Result |
|---|---|
| `[]` | ✅ deploys |
| `{name, type}` | ❌ Params are not valid |
| full minus `descr` | ❌ |
| full minus `flags` | ❌ |
| full minus `regex` | ❌ |
| full minus `regex_error_text` | ❌ |
| `{name, type, descr, flags, regex, regex_error_text}` | ✅ deploys |
| full with `flags: []` | ✅ deploys |

Each of `descr`, `flags`, `regex`, `regex_error_text` was dropped individually and each one alone triggers the error. Keys must be present even when empty (`descr:""`, `flags:[]`, `regex:""`, `regex_error_text:""` are accepted).

Root cause of the silent slip-through: `json-schema/process.json` defines `params.items` with only `name`/`type`/`flags` and **no** `required` list, so an incomplete element passes client-side validation and is rejected only by the server at deploy.

## Change (docs-only)

`docs/process/process-with-parameters.md`:
- New **"Required `params` element shape (deploy validation)"** section: required-keys table, minimal valid example, and a **"`params` is not required to receive data"** note.
- A Best Practices bullet cross-linking to it.

## Optional follow-up (not in this PR)

Tighten `json-schema/process.json` so `params.items` requires `name`/`type`/`descr`/`flags`/`regex`/`regex_error_text` — then an incomplete element fails fast at client validation instead of at deploy. Schema/code change; happy to open separately.

Targeted at `develop` per maintainer preference.