### PR TITLE
fix(schema): allow templated/dynamic conv_id in api_copy (align with api_rpc)

### DIFF
--- a/plugins/corezoid/mcp-server/json-schema/logics/api_copy.json
+++ b/plugins/corezoid/mcp-server/json-schema/logics/api_copy.json
@@ -24,18 +24,8 @@
       "description": "Internal user ID associated with the operation"
     },
     "conv_id": {
-      "oneOf": [
-        {
-          "type": "integer",
-          "description": "Numeric ID of the target Process"
-        },
-        {
-          "type": "string",
-          "pattern": "^@.*",
-          "description": "String ID of the target Process, must start with '@'"
-        }
-      ],
-      "description": "ID of the target Process to receive the copied task or where the task to modify resides. Can be either a numeric ID or a string starting with '@'"
+      "type": ["integer", "string"],
+      "description": "ID of the target Process to receive the copied task or where the task to modify resides. Numeric ID, an '@alias', or a dynamic reference like '{{param}}' (aligned with api_rpc conv_id)."
     },
     "convTitle": {
       "type": "string",


### PR DESCRIPTION
## Summary
- `api_copy` conv_id schema rejects valid dynamic references. Its `oneOf` forces a string conv_id to match `^@.*`, so a runtime template like `"{{doubleTapConfig.stateId}}"` fails client-side validation in `push-process`, even though the platform accepts it.
- `api_rpc` already allows this: its conv_id is `type: ["integer", "string"]` with no pattern. This PR aligns `api_copy` with `api_rpc`.

## Repro
1. A process with an `api_copy` node whose `conv_id` is `"{{someConfig.stateId}}"` (a normal config-driven target, deployable via the Corezoid UI).
2. `push-process` -> fails: `'{{...}}' does not match pattern '^@.*'`.
3. The identical conv_id in an `api_rpc` node passes. Inconsistent.

## Fix
- Relax `plugins/corezoid/mcp-server/json-schema/logics/api_copy.json` conv_id to `type: ["integer", "string"]`, matching `api_rpc.json`. Numeric IDs and `@alias` strings remain valid.

## Test plan
- [ ] push a process with `api_copy` conv_id = `{{param}}` -> passes validation
- [ ] push with `api_copy` conv_id = `@alias` -> still passes
- [ ] push with `api_copy` conv_id = `12345` -> still passes

cc @MalishkinMV

🤖 Generated with [Claude Code](https://claude.com/claude-code)