### PR TITLE
docs(error-handling): dedicated per-node error cluster pattern

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "corezoid",
       "source": "./plugins/corezoid",
       "description": "Corezoid BPM platform skills, MCP server, docs, and samples for Claude Code.",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "author": {
         "name": "Corezoid",
         "email": "support@corezoid.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.5.1]
+
+- Docs: Standardise error handling on a dedicated per-node error cluster — each error-prone node gets its own collapsed Reply to Process node leading to its own descriptively-named (expanded) Error node, instead of funnelling failures into one shared terminal.
+- Docs: Pin each error cluster tight to the node it protects (same `y`, small `x` offset) for cleaner, more readable process layouts.
+
 ## [2.5.0]
 
 - Feat: Project CRUD MCP tools — create-project, modify-project, delete-project, show-project — for managing Corezoid projects without leaving the IDE.

--- a/plugins/corezoid/.claude-plugin/plugin.json
+++ b/plugins/corezoid/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "corezoid",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Corezoid AI Documentation and Templates — skills and MCP server for working with Corezoid BPM processes.",
   "author": {
     "name": "Corezoid",

--- a/plugins/corezoid/docs/process/error-handling.md
+++ b/plugins/corezoid/docs/process/error-handling.md
@@ -327,17 +327,31 @@ Standardize error responses using this format:
 | Process call error        | Invalid process ID, access denied   | Verify process ID, check permissions                     |
 | Validation error          | Invalid input data                  | Improve input validation, provide clear error messages   |
 
-## Dedicated Error Nodes Pattern
+## Dedicated Error Cluster Pattern (standard)
 
-Each Code node should have its own dedicated error escalation node rather than sharing a common
-error node:
+Every node that can return an error must have its **own** error cluster — never funnel several
+failing nodes into a single shared Reply/Error node. Each failure point gets a distinct, descriptively
+named Error node so the diagram reads clearly.
 
-1. Create a basic "error" END node positioned to the right of each Code node
-2. Connect the Code node's error path (via the "err_node_id" parameter) to its dedicated error node
-3. This one-to-one mapping between Code nodes and their error nodes improves error isolation and
-   troubleshooting
+A cluster is two nodes pinned tight to the node they protect:
 
-Example Code Node with Dedicated Error Node:
+1. **Reply to Process** node (`api_rpc_reply`) that returns the error to the caller, kept
+   **collapsed** (`"extra": "{\"modeForm\":\"collapse\",\"icon\":\"\"}"`). Placed at the **same `y`**
+   as the failing node, just to its right (`x + ~250`) so the small collapsed node sits right next to it.
+2. **Error** END node (`obj_type: 2`, **expanded** so its name stays visible:
+   `"extra": "{\"modeForm\":\"expand\",\"icon\":\"error\"}"`) **named after the specific failure**
+   (e.g. `Charge Payment Error`, not a generic `Error`/`Final`). Placed immediately to the right of
+   the Reply node (`x + ~500`), same `y`.
+
+Wiring: failing node `err_node_id` → its Reply node; the Reply node's `go` → its Error node.
+
+For fire-and-forget processes that do not reply to a caller, omit the Reply node and wire
+`err_node_id` directly to the dedicated named Error node.
+
+This one-to-one mapping between each error-prone node and its named Error node — instead of one shared
+terminal — improves error isolation, troubleshooting, and readability.
+
+Example Code Node with its dedicated Reply + Error cluster (Reply collapsed and pinned to the node):
 
 ```json
 {
@@ -348,7 +362,7 @@ Example Code Node with Dedicated Error Node:
       {
         "type": "api_code",
         "code": "data.result = data.a + data.b;",
-        "err_node_id": "code_error_node_id",
+        "err_node_id": "code_reply_error_node_id",
         "extra": {},
         "extra_type": {}
       },
@@ -365,7 +379,42 @@ Example Code Node with Dedicated Error Node:
 }
 ```
 
-Corresponding dedicated error node:
+Its dedicated **Reply** node (collapsed, pinned to the right of the failing node, same `y`):
+
+```json
+{
+  "id": "code_reply_error_node_id",
+  "obj_type": 0,
+  "condition": {
+    "logics": [
+      {
+        "type": "api_rpc_reply",
+        "mode": "key_value",
+        "res_data": {
+          "status": "error",
+          "description": "{{__conveyor_code_return_description__}}"
+        },
+        "res_data_type": {
+          "status": "string",
+          "description": "string"
+        },
+        "throw_exception": false
+      },
+      {
+        "type": "go",
+        "to_node_id": "code_error_node_id"
+      }
+    ],
+    "semaphors": []
+  },
+  "title": "Reply: Calculate Sum Error",
+  "x": 450,
+  "y": 300,
+  "extra": "{\"modeForm\":\"collapse\",\"icon\":\"\"}"
+}
+```
+
+Its dedicated, descriptively-named **Error** node (expanded so the name is visible, immediately to the right, same `y`):
 
 ```json
 {
@@ -376,12 +425,14 @@ Corresponding dedicated error node:
     "semaphors": []
   },
   "title": "Calculate Sum Error",
-  "x": 450,
-  "y": 300
+  "x": 700,
+  "y": 300,
+  "extra": "{\"modeForm\":\"expand\",\"icon\":\"error\"}"
 }
 ```
 
-This dedicated error node pattern is the standard practice for error handling in Corezoid processes.
+This dedicated error cluster pattern — one Reply + one named Error node per error-prone node — is the
+standard practice for error handling in Corezoid processes.
 
 ## Related Documentation
 

--- a/plugins/corezoid/docs/process/node-positioning-best-practices.md
+++ b/plugins/corezoid/docs/process/node-positioning-best-practices.md
@@ -109,6 +109,11 @@ alignment:
    - Position error handling nodes to the right of the main flow
    - Connect error nodes with horizontal lines from the main flow
    - Maintain consistent horizontal spacing (recommended: 200px from main flow)
+   - **Dedicated error cluster per error-prone node:** each failing node gets its own collapsed
+     **Reply to Process** node (`x + ~250`, same `y`) leading to its own descriptively-named **Error**
+     node (`x + ~500`, same `y`). Keep the cluster pinned tight to the node it protects — at the same
+     `y` with a small horizontal offset — so it reads as attached, not drifting off with a large gap.
+     See [Dedicated Error Cluster Pattern](error-handling.md#dedicated-error-cluster-pattern-standard).
 
 2. **Escalation Paths**
 

--- a/plugins/corezoid/skills/corezoid-create/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-create/SKILL.md
@@ -58,8 +58,8 @@ Every process follows this base structure:
 | 2 | Code Node _(optional)_ | 0 | Prepare / transform input data |
 | 3 | **API Call** _or_ **Call a Process** | 0 | Core action (one or more) |
 | 4 | Reply to Process (Success) | 0 | Return result to caller |
-| 5 | Reply to Process (Error) | 0 | Return error to caller (one per failure point) |
-| 6 | Error | 2 | Terminal error node |
+| 5 | Reply to Process (Error) | 0 | Return error to caller — **one dedicated node per failure point** |
+| 6 | Error | 2 | Terminal error node — **one dedicated, descriptively-named node per failure point** |
 | 7 | Final | 2 | Terminal success node |
 
 **API connector** uses `type: "api"` in Step 3.
@@ -110,14 +110,20 @@ Produce a valid `.conv.json` file.
 
 - Node IDs must be unique 24-character hex strings: `^[0-9a-f]{24}$`. These are **temporary placeholders** for new nodes — on `push-process` Corezoid reassigns its own canonical IDs (and rewires references within the push). Run `pull-process` after pushing to get the canonical IDs before any further edits. See [Node ID Lifecycle](${CLAUDE_PLUGIN_ROOT}/docs/process/process-development-guide.md#node-id-lifecycle-server-assignment--stability-on-push).
 - Connect nodes only through the `go` field
-- Every node that can fail must have `err_node_id` — point it **directly at a Final Error node** (`obj_type: 2`) unless the error path needs logic (reply to caller, retry routing). Never create an Escalation node (`obj_type: 3`) that only contains a bare `go` — that is a passthrough anti-pattern flagged by `lint-process`
+- **Dedicated error cluster per error-prone node.** Every node that can fail (`set_param`, `api`, `api_rpc`, `api_code`, `api_copy`, `db_call`, `git_call`, `api_sum`) gets its **own** error path — never funnel several failing nodes into one shared Reply/Error node. Each cluster is:
+  1. A **Reply to Process** node (`api_rpc_reply`) that returns the error to the caller — set to **collapsed**: `"extra": "{\"modeForm\":\"collapse\",\"icon\":\"\"}"`.
+  2. → an **Error** end node (`obj_type: 2`, **expanded** so its name is visible: `"extra": "{\"modeForm\":\"expand\",\"icon\":\"error\"}"`) **named after the specific failure** so the error is obvious at a glance (e.g. `Charge Payment Error`, not generic `Error`).
+  - Wire `err_node_id` of the failing node → its Reply node; the Reply node's `go` → its Error node.
+  - Separate Error nodes per failure point (instead of one shared terminal) make the process far more readable.
+  - For fire-and-forget processes that do not reply to a caller, skip the Reply node and wire `err_node_id` directly to the dedicated named Error node.
+  - Never create an Escalation node (`obj_type: 3`) that only contains a bare `go` — that is a passthrough anti-pattern flagged by `lint-process`.
 - All constants (URLs, tokens, IDs) must be Corezoid variables — never hardcoded:
   1. Check for existing variables: read `_ENV_VARS_.json` (from `pull-folder`) or `.processes/variables.json` (from this session)
   2. Create a new variable if needed: call MCP tool **`create-variable`** with `name`, `description`, `value`
   3. Reference in logic: `{{env_var[@variable-name]}}`
 - Use descriptive `title` values (e.g., "Call Payment Process", not "RPC")
-- Position nodes top-to-bottom, incrementing `y` by 200–250px; place error nodes to the right (`x + 300`)
-- Place each Reply Error node at the **same `y`** as the Call/API node it handles — this creates a straight horizontal connector line for the error path
+- Position main-flow nodes top-to-bottom, incrementing `y` by 200–250px
+- **Pin each error cluster tight to the node it protects.** Place the Reply node at the **same `y`** as its failing node and just to the right (`x + ~250`) so the collapsed Reply sits right next to it; place its Error node immediately to the right of the Reply (`x + ~500`), same `y`. Same `y` gives a straight horizontal connector; the small offset keeps the cluster visually attached instead of drifting off with a large gap
 
 ### Common pitfalls
 


### PR DESCRIPTION
## What

Standardise error handling on a **dedicated per-node error cluster**. Each error-prone node now gets its own collapsed *Reply to Process* node leading to its own descriptively-named, expanded *Error* node — pinned tight to the node it protects — instead of funnelling every failure into one shared error terminal.

## Why

Per-failure-point error nodes make processes far more readable: at a glance you can see *which* step failed (e.g. `Charge Payment Error`) instead of a generic shared `Error`.

## Changes

- `docs/process/error-handling.md` — document the dedicated per-node error cluster pattern.
- `docs/process/node-positioning-best-practices.md` — pin each cluster tight to its node (same `y`, small `x` offset).
- `skills/corezoid-create/SKILL.md` — core rule + positioning guidance for error clusters.
- Bump plugin version to **2.5.1** (`marketplace.json`, `plugin.json`) + `CHANGELOG.md` entry.

## Type

Docs / guidance only — no MCP server or schema changes.