### PR TITLE
feat(skills): add corezoid-stage-scan pre-merge validator

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "corezoid",
       "source": "./plugins/corezoid",
       "description": "Corezoid BPM platform skills, MCP server, docs, and samples for Claude Code.",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "author": {
         "name": "Corezoid",
         "email": "support@corezoid.com"

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ coverage.out
 # Root-level only — plugins/corezoid/.mcp.json must stay tracked (it ships in the marketplace package).
 # Do NOT change to **/.mcp.json.
 /.mcp.json
+
+# Python
+__pycache__/
+*.pyc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.7.0]
+
+- Feat: `corezoid-stage-scan` skill — offline pre-merge/pre-deploy static validator for exported stage `.zip`s (or extracted dirs). Detects non-active processes, empty/battered processes, broken intra-process node links (`to_node_id`/`err_node_id`), and broken/inactive cross-process `conv_id` references. Maps findings to the platform's merge "Errors list" messages ("Only active process can be used", "referenced node X does not exist", "Access user to conveyor is denied in logic"). Ships a stdlib-only Python scanner with CI-friendly exit codes (`scripts/scan_stage.py`). Each finding carries a `folder` field with the human-readable folder path in the stage tree.
+
 ## [2.6.0]
 
 - Feat: `send-feedback` MCP tool — submits user feedback to a dedicated Corezoid process (`conv_id 1871779`) and returns a ticket id. Does not require authentication so users can report auth-related issues too.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The plugin bundles a Go MCP server that exposes Corezoid operations as MCP tools
 | `corezoid-edit`                | "edit", "modify", "update" a process     | Modifying existing `.conv.json` files             |
 | `corezoid-review`              | "review", "audit", "check" a process     | Analysis, dead code, best-practice violations     |
 | `corezoid-project-review`      | "review project", "audit folder"         | Cross-process audit of an entire folder           |
+| `corezoid-stage-scan`          | "scan stage", "check stage before merge", "why does the merge fail" | Offline pre-merge validation of exported stage `.zip`s: non-active/empty processes, broken node links, broken/inactive `conv_id` refs |
 | `corezoid-dashboard-manager`   | "create dashboard", "add chart", "visualize metrics" | Dashboards, charts, node metrics, real-time monitoring |
 | `corezoid-process-tech-writer` | "document", "write docs", "describe process" | Markdown docs + enriched JSON with node descriptions |
 

--- a/plugins/corezoid/.claude-plugin/plugin.json
+++ b/plugins/corezoid/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "corezoid",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Corezoid AI Documentation and Templates — skills and MCP server for working with Corezoid BPM processes.",
   "author": {
     "name": "Corezoid",

--- a/plugins/corezoid/skills/corezoid-stage-scan/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-stage-scan/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: corezoid-stage-scan
+description: >
+  Pre-merge / pre-deploy static validator for exported Corezoid stages. Use when
+  the user has one or more exported stage files (.zip) or extracted stage folders
+  and wants to find, BEFORE merging or deploying, what will break: processes that
+  are not active, empty/battered processes, broken intra-process node links
+  (to_node_id / err_node_id pointing at a missing node), and broken or inactive
+  cross-process conv_id references (api_rpc / api_copy / api_get_task). Activate
+  when the user says "scan stage", "check stage before merge", "validate export",
+  "why does the merge fail", "find broken links", "find non-active processes",
+  "Can't create more start nodes", "Only active process can be used",
+  "referenced node ... does not exist", "Access user to conveyor is denied",
+  "проверь стейдж", "почему не мерджится", "битые ссылки", "найди неактивные процессы",
+  or attaches two stage ZIPs and asks what is wrong with the merge.
+---
+
+# Scan a Corezoid Stage (pre-merge / pre-deploy validation)
+
+You statically validate **exported** Corezoid stages — `.zip` exports or extracted
+folders — without touching the live environment. This is the fast first answer to
+"why does my merge / deploy fail" and the safe pre-flight check before any
+cross-stage merge.
+
+The check is grep/AST-level over every `*.conv.json` in the export. It is fully
+offline and deterministic, so it works on attachments (e.g. files pulled from a
+Jira ticket) even with no Corezoid credentials.
+
+## What it detects
+
+These map 1:1 to the errors the platform shows in the merge **Errors list** dialog:
+
+| Finding | Platform error it explains |
+|---|---|
+| `[1]` process `status != active` | `Only active process can be used` |
+| `[1b]` empty (no-nodes) process | battered / half-recreated shell; deploy of an empty conv |
+| `[2a]` broken **node** link (`to_node_id` / `err_node_id` / `go_to` → missing node in same process) | `Key 'to_node_id'. 'referenced node X does not exist'` |
+| `[2b]` broken / inactive **conv_id** ref (`api_rpc` / `api_copy` / `api_get_task` → process missing from stage or not active) | `Only active process can be used` · `Key 'conv_id'. 'Access user to conveyor is denied in logic'` |
+| `[2c]` `api_get_task.node_id` missing in the **target** process | invalid get-task node reference |
+
+`{{...}}` and `@alias` conv_id references are reported as *unresolvable* (counted,
+never flagged as broken) — they resolve at deploy time against the live stage.
+
+> Note: `api_get_task.node_id` points at a node in the **target** `conv_id` process,
+> not the current one — the scanner checks it cross-process, so it does not produce
+> false "missing node" positives for get-task logics.
+
+## How to run
+
+The skill ships a self-contained Python 3 scanner (stdlib only — `zipfile`, `json`,
+`re`; no install). Run it directly on the export(s):
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/corezoid-stage-scan/scripts/scan_stage.py" \
+  <stage.zip | stage_dir> [more ...] [--json report.json] [--quiet]
+```
+
+- One input → scans that stage.
+- Two inputs → scans both (e.g. **source** and **target** of a merge) and prints a
+  report per stage so you can compare.
+- `--json` writes a machine-readable report (array if multiple inputs).
+- Exit code `1` if any blocker is found, `0` if clean → drop it into CI before merge.
+
+Pass the stage exports as positional args. If the user attached ZIPs to a ticket,
+download them first, then point the scanner at the local files.
+
+## Workflow
+
+1. **Gather inputs.** Identify the exported stage file(s). For a merge problem ask
+   for / locate **both** the source (откуда) and target (куда) exports — most
+   merge failures are explained by comparing the two.
+2. **Run the scanner** on each (or both at once).
+3. **Map findings to the user's symptom.** If they quoted a specific error, point at
+   the exact `conv_id` / node from the matching section above.
+4. **Recommend the fix** per finding:
+   - `status != active` → set the process `active`, or delete it if unused. Do this on
+     **both** stages so the merge sees a consistent state.
+   - empty / battered process → deploy real content or delete the shell.
+   - broken node link → re-point or remove the dangling `to_node_id` / `err_node_id`.
+     If the export is internally consistent but the **live** stage still errors, the
+     live process is in a half-merged state — re-deploy or roll back that one process
+     on the environment (a stale merge that was never rolled back).
+   - broken / inactive conv_id ref → fix the target (create / activate it, or point to
+     the correct existing process / alias). If the error is
+     `Access user to conveyor is denied`, the referenced object is owned by a removed
+     user — reassign ownership to a live account.
+5. **Re-export and re-scan** after fixes; merge only when the scan is clean on both.
+
+## Prevent recurrence (advise the user)
+
+- Always **roll back** a failed or aborted merge — never leave processes in merge state.
+- Avoid **cross-version** merges (newer-version structures into an older `capi` validate
+  differently). Align versions first.
+- Run this scan in CI / before every merge as a gate (`--quiet`, non-zero exit).
+
+## Notes
+
+- Read-only and offline; it never calls the API or mutates anything.
+- Folder/file names in exports may show garbled non-ASCII (UTF-8 shown as latin-1) —
+  cosmetic only; matching is by `conv_id` / `uuid`, not by name.
+- The export schema this relies on: top-level `status`, `obj_id`, `uuid`, `conv_type`,
+  and `scheme.nodes[].condition.logics[]` with `type`, `to_node_id`, `err_node_id`,
+  `conv_id`, `node_id`.

--- a/plugins/corezoid/skills/corezoid-stage-scan/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-stage-scan/SKILL.md
@@ -61,6 +61,13 @@ python3 "${CLAUDE_PLUGIN_ROOT}/skills/corezoid-stage-scan/scripts/scan_stage.py"
 - `--json` writes a machine-readable report (array if multiple inputs).
 - Exit code `1` if any blocker is found, `0` if clean → drop it into CI before merge.
 
+Every finding carries both `path` (full file path inside the export) and `folder` (the
+human-readable folder location in the tree, e.g. `4570_CRM / 4526_Push: Pin block`), so you
+can always tell the user **where** to find the object. When reporting back, include the folder
+for each `conv_id` — "what's broken" without "where it is" is not actionable. Exported folder
+names keep their `id_` prefix (and may show mojibake for non-ASCII); the folder id always locates
+the object even if the display name is garbled.
+
 Pass the stage exports as positional args. If the user attached ZIPs to a ticket,
 download them first, then point the scanner at the local files.
 

--- a/plugins/corezoid/skills/corezoid-stage-scan/scripts/scan_stage.py
+++ b/plugins/corezoid/skills/corezoid-stage-scan/scripts/scan_stage.py
@@ -44,6 +44,21 @@ def is_dynamic(v):
     return isinstance(v, str) and bool(DYN.search(v))
 
 
+def folder_of(rel_path):
+    """Human-readable folder location (where to find the object in the tree).
+
+    Drops the filename and the ".folder" suffix from each path segment, so
+    "4570_CRM.folder/4526_Push.folder/9009_x.conv.json" -> "4570_CRM / 4526_Push".
+    Exported names may carry mojibake (UTF-8 shown as latin-1); the id_ prefix
+    is kept so the object is always locatable by folder id.
+    """
+    parts = rel_path.split('/')[:-1]
+    # drop the export wrapper segments ("<name>.zip", "<id>_<name>.stage")
+    parts = [p for p in parts if not (p.endswith('.zip') or p.endswith('.stage'))]
+    return ' / '.join(p[:-len('.folder')] if p.endswith('.folder') else p
+                      for p in parts) or '(stage root)'
+
+
 def collect_conv_files(path):
     """Return (root_dir, [conv.json paths]). Extracts zips to a temp dir."""
     tmp = None
@@ -151,9 +166,11 @@ def scan(path, label=None):
         'stage': label,
         'totals': {'parsed': len(procs), 'active': len(active_ids),
                    'parse_errors': len(parse_errors)},
-        'inactive': [{k: m[k] for k in ('obj_id', 'status', 'conv_type', 'title', 'path')}
+        'inactive': [{**{k: m[k] for k in ('obj_id', 'status', 'conv_type', 'title', 'path')},
+                      'folder': folder_of(m['path'])}
                      for m in sorted(inactive, key=lambda x: (str(x['status']), x['obj_id'] or 0))],
-        'empty': [{k: m[k] for k in ('obj_id', 'status', 'title', 'path')}
+        'empty': [{**{k: m[k] for k in ('obj_id', 'status', 'title', 'path')},
+                   'folder': folder_of(m['path'])}
                   for m in sorted(empty, key=lambda x: x['obj_id'] or 0)],
         'broken_node_links': broken_node_links,
         'broken_conv_refs': broken_conv_refs,
@@ -161,6 +178,10 @@ def scan(path, label=None):
         'dynamic_refs_count': len(dynamic_refs),
         'parse_errors': [{'path': p, 'error': e} for p, e in parse_errors],
     }
+    # annotate every finding with its folder location ("where to find it")
+    for key in ('broken_node_links', 'broken_conv_refs', 'broken_gettask'):
+        for x in report[key]:
+            x['folder'] = folder_of(x['path'])
     return report
 
 
@@ -178,13 +199,14 @@ def print_report(r, quiet=False):
     if not quiet:
         for m in r['inactive']:
             print(f"    id={m['obj_id']:<7} {str(m['status']):<8} {m['conv_type']:<8} "
-                  f"{m['title']!r}\n        {m['path']}")
+                  f"{m['title']!r}\n        folder: {m['folder']}\n        file:   {m['path']}")
 
     print(f"\n[1b] empty (no nodes): {len(r['empty'])} "
           f"-> {distinct(r['empty'], 'obj_id')}")
     if not quiet:
         for m in r['empty']:
-            print(f"    id={m['obj_id']:<7} {str(m['status']):<8} {m['title']!r}  {m['path']}")
+            print(f"    id={m['obj_id']:<7} {str(m['status']):<8} {m['title']!r}"
+                  f"\n        folder: {m['folder']}")
 
     bnl = r['broken_node_links']
     print(f"\n[2a] broken node links: {len(bnl)} link(s) in "
@@ -192,7 +214,8 @@ def print_report(r, quiet=False):
     if not quiet:
         for x in bnl:
             print(f"    conv={x['conv_id']:<7} node={x['node']} "
-                  f"{x['type']}.{x['field']} -> {x['target']}  MISSING\n        {x['path']}")
+                  f"{x['type']}.{x['field']} -> {x['target']}  MISSING"
+                  f"\n        folder: {x['folder']}")
 
     bcr = r['broken_conv_refs']
     print(f"\n[2b] broken/inactive conv refs: {len(bcr)} in "
@@ -200,14 +223,14 @@ def print_report(r, quiet=False):
     if not quiet:
         for x in bcr:
             print(f"    conv={x['conv_id']:<7} node={x['node']} {x['type']} -> "
-                  f"conv_id={x['target_conv']}  [{x['reason']}]\n        {x['path']}")
+                  f"conv_id={x['target_conv']}  [{x['reason']}]\n        folder: {x['folder']}")
 
     bgt = r['broken_gettask']
     print(f"\n[2c] api_get_task node missing in target: {len(bgt)}")
     if not quiet:
         for x in bgt:
             print(f"    conv={x['conv_id']:<7} -> conv {x['target_conv']} "
-                  f"node {x['target_node']} MISSING\n        {x['path']}")
+                  f"node {x['target_node']} MISSING\n        folder: {x['folder']}")
 
     print(f"\n(unresolvable dynamic/@alias conv refs, not checked: {r['dynamic_refs_count']})")
 

--- a/plugins/corezoid/skills/corezoid-stage-scan/scripts/scan_stage.py
+++ b/plugins/corezoid/skills/corezoid-stage-scan/scripts/scan_stage.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""
+scan_stage.py — pre-merge / pre-deploy static validator for exported Corezoid stages.
+
+Detects the defect classes that block a stage merge or deploy on the Corezoid
+platform, without touching the live environment:
+
+  [1]  status != active           processes/diagrams  -> "Only active process can be used"
+  [1b] empty (no-nodes) processes (battered / recreated shells)
+  [2a] broken intra-process node links (to_node_id / err_node_id / go_to pointing at a
+       node id absent from the SAME process)  -> "Key 'to_node_id'. 'referenced node X does not exist'"
+  [2b] broken / inactive cross-process conv_id references (api_rpc / api_copy / api_get_task
+       conv_id pointing at a process missing from the stage, or one that is not active)
+       -> "Only active process can be used" / "Access user to conveyor is denied in logic"
+  [2c] api_get_task.node_id absent in the TARGET conv_id process
+
+Input may be a .zip export, an extracted directory, or several of them (compare two stages).
+Aliases ({{...}} / @alias conv_id) are reported as "unresolvable", never as broken,
+because they resolve at deploy time against the live stage.
+
+Usage:
+  scan_stage.py PATH [PATH ...] [--label NAME] [--json OUT.json] [--quiet]
+
+Examples:
+  scan_stage.py stage_1305.zip
+  scan_stage.py ./extracted_stage_dir --json report.json
+  scan_stage.py source_735.zip target_1305.zip      # scan both, one report each
+
+Exit code: 0 if no blockers found across all inputs, 1 otherwise (CI-friendly).
+"""
+import argparse, json, os, re, sys, glob, zipfile, tempfile, collections
+
+HEX24 = re.compile(r'^[0-9a-f]{24}$')
+DYN = re.compile(r'\{\{|^@')
+NODE_LINK_FIELDS = ('to_node_id', 'err_node_id', 'go_to', 'goto')
+CONV_REF_LOGICS = ('api_rpc', 'api_copy', 'api_get_task')
+
+
+def is_static_node(v):
+    return isinstance(v, str) and bool(HEX24.match(v))
+
+
+def is_dynamic(v):
+    return isinstance(v, str) and bool(DYN.search(v))
+
+
+def collect_conv_files(path):
+    """Return (root_dir, [conv.json paths]). Extracts zips to a temp dir."""
+    tmp = None
+    if path.lower().endswith('.zip'):
+        tmp = tempfile.mkdtemp(prefix='czscan_')
+        with zipfile.ZipFile(path) as z:
+            z.extractall(tmp)
+        root = tmp
+    elif os.path.isdir(path):
+        root = path
+    else:
+        raise SystemExit(f"error: {path} is neither a .zip nor a directory")
+    files = sorted(glob.glob(os.path.join(root, '**', '*.conv.json'), recursive=True))
+    return root, files, tmp
+
+
+def scan(path, label=None):
+    label = label or os.path.basename(path.rstrip('/')).replace('.zip', '')
+    root, files, tmp = collect_conv_files(path)
+
+    procs = {}            # obj_id -> meta
+    parse_errors = []
+    for f in files:
+        try:
+            d = json.load(open(f, encoding='utf-8'))
+        except Exception as e:
+            parse_errors.append((os.path.relpath(f, root), str(e)))
+            continue
+        if not isinstance(d, dict):
+            continue
+        nodes = (d.get('scheme') or {}).get('nodes') or []
+        procs[d.get('obj_id')] = {
+            'obj_id': d.get('obj_id'),
+            'status': d.get('status'),
+            'conv_type': d.get('conv_type'),
+            'title': d.get('title'),
+            'uuid': d.get('uuid'),
+            'path': os.path.relpath(f, root),
+            'node_ids': {n.get('id') for n in nodes if isinstance(n, dict)},
+            'nodes': nodes,
+        }
+
+    active_ids = {i for i, m in procs.items() if m['status'] == 'active'}
+    inactive = [m for m in procs.values() if m['status'] != 'active']
+    empty = [m for m in procs.values()
+             if m['conv_type'] in ('process', 'state') and not m['node_ids']]
+
+    broken_node_links, broken_conv_refs, broken_gettask, dynamic_refs = [], [], [], []
+
+    for m in procs.values():
+        valid = m['node_ids']
+        for n in m['nodes']:
+            if not isinstance(n, dict):
+                continue
+            nid = n.get('id')
+            for lg in ((n.get('condition') or {}).get('logics') or []):
+                if not isinstance(lg, dict):
+                    continue
+                t = lg.get('type')
+                # [2a] intra-process node links
+                for fld in NODE_LINK_FIELDS:
+                    tgt = lg.get(fld)
+                    if is_static_node(tgt) and tgt not in valid:
+                        broken_node_links.append(
+                            {'conv_id': m['obj_id'], 'node': nid, 'type': t,
+                             'field': fld, 'target': tgt, 'path': m['path']})
+                # [2b]/[2c] cross-process conv_id references
+                if t in CONV_REF_LOGICS:
+                    cv = lg.get('conv_id')
+                    if cv is None:
+                        continue
+                    if is_dynamic(cv):
+                        dynamic_refs.append(
+                            {'conv_id': m['obj_id'], 'node': nid, 'type': t,
+                             'ref': cv, 'path': m['path']})
+                        continue
+                    try:
+                        cvi = int(cv)
+                    except (TypeError, ValueError):
+                        dynamic_refs.append(
+                            {'conv_id': m['obj_id'], 'node': nid, 'type': t,
+                             'ref': cv, 'path': m['path']})
+                        continue
+                    if cvi not in procs:
+                        broken_conv_refs.append(
+                            {'conv_id': m['obj_id'], 'node': nid, 'type': t,
+                             'target_conv': cvi, 'reason': 'missing (not in stage)',
+                             'path': m['path']})
+                    else:
+                        if procs[cvi]['status'] != 'active':
+                            broken_conv_refs.append(
+                                {'conv_id': m['obj_id'], 'node': nid, 'type': t,
+                                 'target_conv': cvi,
+                                 'reason': f"target status={procs[cvi]['status']}",
+                                 'path': m['path']})
+                        if t == 'api_get_task':
+                            tn = lg.get('node_id')
+                            if is_static_node(tn) and tn not in procs[cvi]['node_ids']:
+                                broken_gettask.append(
+                                    {'conv_id': m['obj_id'], 'node': nid,
+                                     'target_conv': cvi, 'target_node': tn,
+                                     'path': m['path']})
+
+    report = {
+        'stage': label,
+        'totals': {'parsed': len(procs), 'active': len(active_ids),
+                   'parse_errors': len(parse_errors)},
+        'inactive': [{k: m[k] for k in ('obj_id', 'status', 'conv_type', 'title', 'path')}
+                     for m in sorted(inactive, key=lambda x: (str(x['status']), x['obj_id'] or 0))],
+        'empty': [{k: m[k] for k in ('obj_id', 'status', 'title', 'path')}
+                  for m in sorted(empty, key=lambda x: x['obj_id'] or 0)],
+        'broken_node_links': broken_node_links,
+        'broken_conv_refs': broken_conv_refs,
+        'broken_gettask': broken_gettask,
+        'dynamic_refs_count': len(dynamic_refs),
+        'parse_errors': [{'path': p, 'error': e} for p, e in parse_errors],
+    }
+    return report
+
+
+def distinct(rows, key='conv_id'):
+    return sorted({r[key] for r in rows})
+
+
+def print_report(r, quiet=False):
+    print(f"\n{'='*78}\nSTAGE: {r['stage']}\n{'='*78}")
+    t = r['totals']
+    print(f"parsed={t['parsed']}  active={t['active']}  parse_errors={t['parse_errors']}")
+
+    print(f"\n[1] status != active : {len(r['inactive'])} "
+          f"-> {distinct(r['inactive'], 'obj_id')}")
+    if not quiet:
+        for m in r['inactive']:
+            print(f"    id={m['obj_id']:<7} {str(m['status']):<8} {m['conv_type']:<8} "
+                  f"{m['title']!r}\n        {m['path']}")
+
+    print(f"\n[1b] empty (no nodes): {len(r['empty'])} "
+          f"-> {distinct(r['empty'], 'obj_id')}")
+    if not quiet:
+        for m in r['empty']:
+            print(f"    id={m['obj_id']:<7} {str(m['status']):<8} {m['title']!r}  {m['path']}")
+
+    bnl = r['broken_node_links']
+    print(f"\n[2a] broken node links: {len(bnl)} link(s) in "
+          f"{len(distinct(bnl))} process(es) -> {distinct(bnl)}")
+    if not quiet:
+        for x in bnl:
+            print(f"    conv={x['conv_id']:<7} node={x['node']} "
+                  f"{x['type']}.{x['field']} -> {x['target']}  MISSING\n        {x['path']}")
+
+    bcr = r['broken_conv_refs']
+    print(f"\n[2b] broken/inactive conv refs: {len(bcr)} in "
+          f"{len(distinct(bcr))} process(es) -> {distinct(bcr)}")
+    if not quiet:
+        for x in bcr:
+            print(f"    conv={x['conv_id']:<7} node={x['node']} {x['type']} -> "
+                  f"conv_id={x['target_conv']}  [{x['reason']}]\n        {x['path']}")
+
+    bgt = r['broken_gettask']
+    print(f"\n[2c] api_get_task node missing in target: {len(bgt)}")
+    if not quiet:
+        for x in bgt:
+            print(f"    conv={x['conv_id']:<7} -> conv {x['target_conv']} "
+                  f"node {x['target_node']} MISSING\n        {x['path']}")
+
+    print(f"\n(unresolvable dynamic/@alias conv refs, not checked: {r['dynamic_refs_count']})")
+
+
+def has_blockers(r):
+    return bool(r['inactive'] or r['empty'] or r['broken_node_links']
+                or r['broken_conv_refs'] or r['broken_gettask'] or r['totals']['parse_errors'])
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('paths', nargs='+', help='stage .zip file(s) or extracted dir(s)')
+    ap.add_argument('--label', help='label for a single input (default: filename)')
+    ap.add_argument('--json', dest='json_out', help='write combined JSON report to this file')
+    ap.add_argument('--quiet', action='store_true', help='summary counts only')
+    args = ap.parse_args()
+
+    reports = []
+    for i, p in enumerate(args.paths):
+        lbl = args.label if (args.label and len(args.paths) == 1) else None
+        r = scan(p, lbl)
+        print_report(r, quiet=args.quiet)
+        reports.append(r)
+
+    if args.json_out:
+        json.dump(reports if len(reports) > 1 else reports[0],
+                  open(args.json_out, 'w'), indent=2, ensure_ascii=False)
+        print(f"\n[written {args.json_out}]")
+
+    blockers = any(has_blockers(r) for r in reports)
+    print(f"\n{'BLOCKERS FOUND' if blockers else 'No blockers found'}.")
+    sys.exit(1 if blockers else 0)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/corezoid/skills/corezoid/SKILL.md
+++ b/plugins/corezoid/skills/corezoid/SKILL.md
@@ -124,6 +124,7 @@ For domain-specific workflows use the specialized skills:
 - `/corezoid-state-diagram-edit` — modifying an existing state diagram
 - `/corezoid-review` — auditing and analyzing a single process
 - `/corezoid-project-review` — auditing an entire project or folder (cross-process analysis)
+- `/corezoid-stage-scan` — pre-merge/pre-deploy static check of exported stage `.zip`s: non-active processes, empty/battered processes, broken node links, broken/inactive `conv_id` references (explains "Only active process can be used", "referenced node X does not exist", "Access user to conveyor is denied")
 - `/corezoid-dashboard-manager` — creating dashboards and charts for process metrics
 - `/corezoid-process-tech-writer` — documenting a process (Markdown + enriched JSON)
 - `/corezoid-alias-manager` — creating, listing, modifying, deleting, and using aliases

--- a/public/.well-known/skills/index.json
+++ b/public/.well-known/skills/index.json
@@ -8,6 +8,27 @@
       ]
     },
     {
+      "name": "corezoid-access",
+      "description": "Corezoid access-control specialist. Use when the user wants to share a process, folder, stage or project with another user / group / API key, create or delete a user group, create or rotate an API key, invite an external user, or audit who currently has access to a Corezoid object. Activate when the user says \"share\", \"give access\", \"grant access\", \"share to\", \"доступ\", \"пошарь\", \"create group\", \"создай группу\", \"create api key\", \"создай API ключ\", \"invite user\", \"пригласи\", \"revoke access\", \"unshare\", \"who has access\".",
+      "files": [
+        "https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-access/SKILL.md"
+      ]
+    },
+    {
+      "name": "corezoid-alias-manager",
+      "description": "Manages Corezoid aliases — create, list, modify, delete, link/unlink, and use aliases in process JSON. Activate when the user mentions \"alias\", \"short_name\", \"short name\", \"create alias\", \"list aliases\", \"delete alias\", \"modify alias\", \"rename alias\", \"unlink alias\", \"link alias\", \"get callback hash\", \"conv[@\", or asks how to reference a process by name instead of numeric ID. Also activate when reviewing a process that uses numeric conv_id values and the user wants to replace them with aliases.",
+      "files": [
+        "https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-alias-manager/SKILL.md"
+      ]
+    },
+    {
+      "name": "corezoid-api-connector",
+      "description": "Corezoid API connector specialist. Use when the user wants to create a process that calls the Corezoid public API (/api/2/json/), works with Corezoid objects (nodes, processes, tasks, users) via the API, or needs to automate Corezoid platform operations. Activate when the user says \"call Corezoid API\", \"Corezoid API connector\", \"node list\", \"api/2/json\", \"api_secret_outer\", or references openapi.corezoid.com operations.",
+      "files": [
+        "https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-api-connector/SKILL.md"
+      ]
+    },
+    {
       "name": "corezoid-create",
       "description": "Corezoid process creation specialist. Use when the user wants to create a new Corezoid process from scratch, build a new automation flow, design a new BPM process, or implement a new API connector. Activate when the user says \"create a process\", \"build a new flow\", \"new process\", \"design from scratch\", \"implement a connector\", \"create an automation\", or \"add a new process\".",
       "files": [
@@ -36,6 +57,13 @@
       ]
     },
     {
+      "name": "corezoid-process-optimizer",
+      "description": "Optimizes a Corezoid process JSON — reduces tact consumption by merging nodes, cleans data flow, fills missing node titles, and adds resilience patterns. Activate when the user says \"optimize\", \"improve\", \"reduce tacts\", \"merge nodes\", \"clean up process\", \"what can be improved\", \"show optimizations\", or any phrase implying they want to make a process faster, cheaper, or more readable. Two modes: plan-only (analysis + report, no changes) and auto (plan + execute immediately).",
+      "files": [
+        "https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-process-optimizer/SKILL.md"
+      ]
+    },
+    {
       "name": "corezoid-process-tech-writer",
       "description": "Documents a Corezoid process — produces a human-readable Markdown file AND enriches the process JSON with descriptions on every node and parameter. Output is designed for team wikis, internal portals, and future product integration. Activate whenever a user asks to document a process, write docs for a connector, add descriptions to a process, create documentation for a logic, describe what a process does, or any similar phrasing. Also activate when the user shares a process JSON and asks to explain it or make it self-documenting. Always produce BOTH outputs (Markdown file + enriched JSON) — never just one.",
       "files": [
@@ -54,6 +82,34 @@
       "description": "Corezoid process review and audit specialist. Use when the user wants to analyze, review, audit, or improve an existing Corezoid process. Activate when the user says \"review a process\", \"analyze\", \"check\", \"audit\", \"find issues\", \"explain this process\", \"what's wrong with\", \"optimize\", or \"check for hardcoded values\".",
       "files": [
         "https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-review/SKILL.md"
+      ]
+    },
+    {
+      "name": "corezoid-stage-scan",
+      "description": "Pre-merge / pre-deploy static validator for exported Corezoid stages. Use when the user has one or more exported stage files (.zip) or extracted stage folders and wants to find, BEFORE merging or deploying, what will break: processes that are not active, empty/battered processes, broken intra-process node links (to_node_id / err_node_id pointing at a missing node), and broken or inactive cross-process conv_id references (api_rpc / api_copy / api_get_task). Activate when the user says \"scan stage\", \"check stage before merge\", \"validate export\", \"why does the merge fail\", \"find broken links\", \"find non-active processes\", \"Can't create more start nodes\", \"Only active process can be used\", \"referenced node ... does not exist\", \"Access user to conveyor is denied\", \"проверь стейдж\", \"почему не мерджится\", \"битые ссылки\", \"найди неактивные процессы\", or attaches two stage ZIPs and asks what is wrong with the merge.",
+      "files": [
+        "https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-stage-scan/SKILL.md"
+      ]
+    },
+    {
+      "name": "corezoid-state-diagram-create",
+      "description": "Corezoid state diagram creation specialist. Use when the user wants to create a new Corezoid state diagram, build a state machine, design a status / lifecycle store, or set up a \"state\" object with conv_type \"state\". Activate when the user says \"create a state diagram\", \"build a state machine\", \"new state diagram\", \"design states\", \"track status\", \"user lifecycle\", \"состояния\", \"стейт диаграмма\", \"создать state diagram\", or mentions storing state-by-ref between processes.",
+      "files": [
+        "https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-state-diagram-create/SKILL.md"
+      ]
+    },
+    {
+      "name": "corezoid-state-diagram-edit",
+      "description": "Corezoid state diagram editing specialist. Use when the user wants to modify, update, or fix an existing Corezoid state diagram — add or remove a state, change a transition, add a side effect on transition, fix the wiring of an api_callback state node, or rework transitions. Activate when the user says \"edit a state diagram\", \"add a state\", \"remove a state\", \"change transitions\", \"fix state diagram\", \"update state machine\", \"поправить state diagram\", \"изменить состояния\", or refers to modifying a .conv.json with conv_type \"state\".",
+      "files": [
+        "https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-state-diagram-edit/SKILL.md"
+      ]
+    },
+    {
+      "name": "corezoid-variable-manager",
+      "description": "Manages Corezoid environment variables (env_var) — create, list, modify, delete, and use variables in process JSON. Activate when the user mentions \"variable\", \"env var\", \"environment variable\", \"secret\", \"create variable\", \"list variables\", \"delete variable\", \"modify variable\", \"env_var\", \"{{env_var\", or asks how to store a URL, token, API key, or any constant that should not be hardcoded in a process. Also activate when a process references {{env_var[@name]}} and the variable does not exist yet.",
+      "files": [
+        "https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-variable-manager/SKILL.md"
       ]
     },
     {

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -5,13 +5,21 @@
 ## Skills
 
 - [corezoid](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid/SKILL.md): Universal Corezoid assistant
+- [corezoid-access](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-access/SKILL.md): Corezoid access-control specialist
+- [corezoid-alias-manager](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-alias-manager/SKILL.md): Manages Corezoid aliases — create, list, modify, delete, link/unlink, and use aliases in process JSON
+- [corezoid-api-connector](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-api-connector/SKILL.md): Corezoid API connector specialist
 - [corezoid-create](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-create/SKILL.md): Corezoid process creation specialist
 - [corezoid-dashboard-manager](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-dashboard-manager/SKILL.md): Creates and manages Corezoid dashboards — adds charts (column, pie, funnel, table), binds metrics to process nodes, configures real-time mode, and sets up drill-down linking between dashboards
 - [corezoid-edit](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-edit/SKILL.md): Corezoid process editing specialist
 - [corezoid-init](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-init/SKILL.md): Corezoid environment setup specialist
+- [corezoid-process-optimizer](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-process-optimizer/SKILL.md): Optimizes a Corezoid process JSON — reduces tact consumption by merging nodes, cleans data flow, fills missing node titles, and adds resilience patterns
 - [corezoid-process-tech-writer](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-process-tech-writer/SKILL.md): Documents a Corezoid process — produces a human-readable Markdown file AND enriches the process JSON with descriptions on every node and parameter
 - [corezoid-project-review](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-project-review/SKILL.md): Corezoid project review and audit specialist
 - [corezoid-review](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-review/SKILL.md): Corezoid process review and audit specialist
+- [corezoid-stage-scan](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-stage-scan/SKILL.md): Pre-merge / pre-deploy static validator for exported Corezoid stages
+- [corezoid-state-diagram-create](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-state-diagram-create/SKILL.md): Corezoid state diagram creation specialist
+- [corezoid-state-diagram-edit](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-state-diagram-edit/SKILL.md): Corezoid state diagram editing specialist
+- [corezoid-variable-manager](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-variable-manager/SKILL.md): Manages Corezoid environment variables (env_var) — create, list, modify, delete, and use variables in process JSON
 - [marketplace-publish-validation](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/marketplace-publish-validation/SKILL.md): Corezoid  marketplace pre-publication validator
 
 ## MCP Tools


### PR DESCRIPTION
## What

Adds a new universal skill **`corezoid-stage-scan`** — an offline, static pre-merge / pre-deploy validator for exported Corezoid stages (`.zip` export or extracted dir). It answers the recurring support question *"why does my stage merge / deploy fail?"* without touching the live environment, so it works directly on attachments (e.g. stage ZIPs pulled from a Jira ticket, no credentials needed).

## Why

Cross-stage / cross-version merges repeatedly fail with a handful of platform errors that are tedious to diagnose by hand across 1000+ processes. This skill greps every `*.conv.json` in the export and maps each finding 1:1 to the platform's merge **Errors list**:

| Finding | Platform error |
|---|---|
| `status != active` process | `Only active process can be used` |
| empty / battered (no-node) process | deploy of an empty conv |
| broken node link (`to_node_id`/`err_node_id`/`go_to` → missing node in same process) | `Key 'to_node_id'. 'referenced node X does not exist'` |
| broken / inactive `conv_id` ref (`api_rpc`/`api_copy`/`api_get_task`) | `Only active process can be used` · `Key 'conv_id'. 'Access user to conveyor is denied in logic'` |
| `api_get_task.node_id` missing in target process | invalid get-task reference |

`{{...}}` / `@alias` `conv_id` refs are reported as *unresolvable* (counted, never flagged broken — they resolve at deploy). `api_get_task.node_id` is checked **cross-process** (it points at a node in the target conv, not the current one) to avoid false positives.

## Contents

- `skills/corezoid-stage-scan/SKILL.md` — triggers, finding→error mapping, fix guidance, recurrence prevention.
- `skills/corezoid-stage-scan/scripts/scan_stage.py` — stdlib-only scanner (`zipfile`/`json`/`re`). Scans one stage or two (source + target) for merge comparison; `--json` machine output; CI-friendly exit code (`1` on blockers) so it can gate a merge.
- Registered in main `corezoid` SKILL.md, `README.md`, `CHANGELOG.md`, and regenerated discovery files (`public/llms.txt`, `public/.well-known/skills/index.json`).

## Validation

Built and verified against a real production incident (FF UZ Prod cross-version merge v6.12.0 → v6.10.3, internal ticket COR-12949). Running the shipped scanner on the two exported stages reproduced **all four** merge "Errors list" messages and pinpointed the exact offending `conv_id`s and nodes:

```
source 735:  9 non-active; 1 broken conv ref (6832 Change login → conv_id 23776, cross-stage, missing/denied)
target 1305: 3 non-active; 12 empty; 14 broken node links in 3 procs (9009, 24374, 24376)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)