### PR TITLE
fix(pull-process): fallback to list API for undeployed process nodes

### DIFF
--- a/plugins/corezoid/mcp-server/executor_process.go
+++ b/plugins/corezoid/mcp-server/executor_process.go
@@ -179,7 +179,72 @@ func (v *Executor) ExportProcess() (any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal process: %v", err)
 	}
+
+	// Fallback for undeployed processes: export_process returns empty scheme.nodes
+	// for processes that were imported but never deployed (broken reference).
+	// Retry via the list API which returns nodes for draft/undeployed processes.
+	if len(process) > 0 {
+		if proc, ok := process[0].(map[string]any); ok {
+			scheme, hasScheme := proc["scheme"].(map[string]any)
+			nodes, _ := scheme["nodes"].([]any)
+			if hasScheme && len(nodes) == 0 {
+				fallbackNodes, err := v.GetProcessNodes()
+				if err == nil && len(fallbackNodes) > 0 {
+					scheme["nodes"] = fallbackNodes
+					proc["scheme"] = scheme
+					process[0] = proc
+					logger.Info("pull-process: used fallback nodes for undeployed process %d (%d nodes)", v.ProcessID, len(fallbackNodes))
+				}
+			}
+		}
+	}
 	return process, nil
+}
+
+// GetProcessNodes fetches process nodes via the list API, used as a fallback
+// for undeployed processes where export_process returns empty scheme.nodes.
+func (v *Executor) GetProcessNodes() ([]interface{}, error) {
+	ops := []map[string]any{
+		{
+			"type":          "list",
+			"obj":           "conv",
+			"obj_id":        v.ProcessID,
+			"company_id":    v.WorkspaceID,
+			"include_nodes": true,
+		},
+	}
+	response, err := v.req("get_process", ops)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get process nodes: %w", err)
+	}
+	if response["request_proc"] != "ok" {
+		return nil, fmt.Errorf("failed to get process nodes: %v", response)
+	}
+	ops1, ok := response["ops"].([]any)
+	if !ok || len(ops1) == 0 {
+		return nil, fmt.Errorf("no ops in get_process response")
+	}
+	firstOp, ok := ops1[0].(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+	list, ok := firstOp["list"].([]any)
+	if !ok || len(list) == 0 {
+		return nil, nil
+	}
+	proc, ok := list[0].(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+	scheme, ok := proc["scheme"].(map[string]any)
+	if !ok {
+		return nil, nil
+	}
+	nodes, ok := scheme["nodes"].([]any)
+	if !ok {
+		return nil, nil
+	}
+	return nodes, nil
 }
 
 // ProcessJSON is the main orchestrator: parses JSON, creates/updates nodes, compiles code, commits.

--- a/plugins/corezoid/mcp-server/pull-project.go
+++ b/plugins/corezoid/mcp-server/pull-project.go
@@ -208,7 +208,7 @@ func downloadStageRecursively(e *Executor, folderID int, filePath string) error 
 	if err != nil {
 		return fmt.Errorf("failed to rename files: %v", err)
 	}
-	err = formatJSON(filePath)
+	err = formatJSONWithFallback(e, filePath)
 	if err != nil {
 		return fmt.Errorf("failed to format json: %v", err)
 	}
@@ -299,6 +299,14 @@ func renameFiles2Folders(filePath string) error {
 }
 
 func formatJSON(filePath string) error {
+	return formatJSONWithFallback(nil, filePath)
+}
+
+// formatJSONWithFallback formats all JSON files under filePath, pretty-printing
+// them and stripping uuid fields. When e is non-nil, it also applies a fallback
+// for undeployed processes whose scheme.nodes is empty: it fetches nodes via the
+// list API (GetProcessNodes) and patches the file in place before writing.
+func formatJSONWithFallback(e *Executor, filePath string) error {
 	// теперь везде где json файлы форматировать их через MarshalIndent
 	files, err := os.ReadDir(filePath)
 	if err != nil {
@@ -308,7 +316,7 @@ func formatJSON(filePath string) error {
 	for _, f := range files {
 		if f.IsDir() {
 			//fmt.Println("Downloaded folder", filepath.Join(filePath, f.Name()))
-			err := formatJSON(filepath.Join(filePath, f.Name()))
+			err := formatJSONWithFallback(e, filepath.Join(filePath, f.Name()))
 			if err != nil {
 				return fmt.Errorf("Failed to format json in directory: %v", err)
 			}
@@ -327,15 +335,47 @@ func formatJSON(filePath string) error {
 			return fmt.Errorf("failed to unmarshal file: %v", err)
 		}
 		// везде где есть uuid в scheme.nodes объект удалить
-		if nodes, ok := dataRsp.(map[string]interface{}); ok {
-			if nodes, ok := nodes["scheme"].(map[string]interface{}); ok {
-				if nodes1, ok := nodes["nodes"].([]interface{}); ok {
-					for _, node := range nodes1 {
-						if nodeMap, ok := node.(map[string]interface{}); ok {
-							delete(nodeMap, "uuid")
+		if procMap, ok := dataRsp.(map[string]interface{}); ok {
+			if schemeMap, ok := procMap["scheme"].(map[string]interface{}); ok {
+				// nodes1 is nil when the key is absent and empty when the ZIP
+				// contains "nodes": [] — both mean "no nodes", so treat them the
+				// same via len() and trigger the fallback in either case, matching
+				// ExportProcess.
+				nodes1, _ := schemeMap["nodes"].([]interface{})
+				if len(nodes1) == 0 && e != nil {
+					// Fallback for undeployed processes: scheme.nodes is absent or empty
+					// (export_process returns "nodes": [] for imported-but-never-deployed
+					// processes). Look up the process ID from the file and fetch nodes via
+					// the list API.
+					if rawID, ok := procMap["obj_id"].(float64); ok && rawID > 0 {
+						procID := int(rawID)
+						fallback := &Executor{
+							Ctx:         e.Ctx,
+							ProcessID:   procID,
+							Token:       e.Token,
+							APIUrl:      e.APIUrl,
+							WorkspaceID: e.WorkspaceID,
+							StageID:     e.StageID,
+							Debug:       e.Debug,
+							NodeIDMap:   make(map[string]NodeInfo),
+						}
+						fallbackNodes, ferr := fallback.GetProcessNodes()
+						if ferr == nil && len(fallbackNodes) > 0 {
+							nodes1 = fallbackNodes
+							schemeMap["nodes"] = fallbackNodes
+							logger.Info("pull-folder: used fallback nodes for undeployed process %d (%d nodes)", procID, len(fallbackNodes))
 						}
 					}
 				}
+				// Strip uuid from every node, including fallback nodes fetched via
+				// the list API (pull-folder always writes uuid-free files).
+				for _, node := range nodes1 {
+					if nodeMap, ok := node.(map[string]interface{}); ok {
+						delete(nodeMap, "uuid")
+					}
+				}
+				procMap["scheme"] = schemeMap
+				dataRsp = procMap
 			}
 		}
 


### PR DESCRIPTION
## Problem

`pull-process` and `pull-folder` return `"nodes": []` for processes that were imported from a file containing a reference to a non-existent process. Because the import triggers are broken, such processes are never auto-deployed.

The `export_process` API endpoint returns empty `scheme.nodes` for undeployed processes. The Corezoid UI, however, correctly displays all nodes by reading from the internal draft/list state.

**Reported context:**
- Folder `683151` (Google API) — 23 processes, 15 returned `nodes: []`
- Process `1875092`: node `6a42054de552e8da3dc123e1` ("Escalation") confirmed present via `list-node-tasks` / `get-node-stat`, but downloaded JSON had empty scheme

## Solution

Added a fallback in `ExportProcess()` (used by `pull-process`) and in the ZIP extraction path (used by `pull-folder`):

1. Primary path — `export_process` API (unchanged, works for deployed processes)
2. Fallback path — if `scheme.nodes` is empty after export, retry via `get_process` list API which returns nodes for draft/undeployed processes
3. Fallback is transparent to callers — same JSON structure is returned with `scheme.nodes` populated

## How to test

1. Import a process from a JSON file that references a non-existent process (so it stays undeployed)
2. Confirm via `list-node-tasks` or `get-node-stat` that nodes exist
3. Run `pull-process` — before this fix: `"nodes": []`; after: full node list returned
4. Run `pull-folder` on the parent folder — same verification

## Version
Plugin: 2.3.5 → patch release
Contact: andrii.chaban@corezoid.com