### PR TITLE
feat(mcp): add delete-process tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ validation errors, and summarize what each process does.
 | `list-folders`      | List immediate children of a folder (no disk I/O)  |
 | `modify-folder`     | Rename a folder or update its description          |
 | `delete-folder`     | Move a folder to the recycle bin                   |
+| `delete-process`    | Move a process or state diagram to the recycle bin |
 | `create-alias`      | Create a short alias for a process                 |
 | `create-variable`   | Create a Corezoid environment variable             |
 | `create-dashboard`  | Create a new dashboard for visualizing node metrics |
@@ -267,7 +268,7 @@ Claude Code / Codex
         │                 create-project, modify-project, delete-project, show-project
         ├── Processes     pull-process, pull-folder, push-process, lint-process
         │                 create-process, create-folder, create-alias, create-variable
-        │                 show-folder, list-folders, modify-folder, delete-folder
+        │                 show-folder, list-folders, modify-folder, delete-folder, delete-process
         ├── Tasks         run-task, list-node-tasks, list-task-history
         │                 modify-task, delete-task
         ├── Dashboards    create-dashboard, get-dashboard, add-chart,

--- a/plugins/corezoid/mcp-server/executor_folders.go
+++ b/plugins/corezoid/mcp-server/executor_folders.go
@@ -153,6 +153,27 @@ func (v *Executor) ModifyFolder(folderID int, title, description string) error {
 	return nil
 }
 
+// DeleteProcess moves a process (conv) to the recycle bin. The operation is
+// reversible from the Corezoid UI's Trash. Permanent destruction is not
+// exposed via this tool — the same intentional policy as delete-folder and
+// delete-project.
+func (v *Executor) DeleteProcess(processID int) error {
+	op := map[string]any{
+		"type":       "delete",
+		"obj":        "conv",
+		"obj_id":     processID,
+		"company_id": v.WorkspaceID,
+	}
+	resp, err := v.req("delete_conv", []map[string]any{op})
+	if err != nil {
+		return fmt.Errorf("DeleteProcess request failed: %w", err)
+	}
+	if _, err := firstOp(resp); err != nil {
+		return err
+	}
+	return nil
+}
+
 // DeleteFolder moves a folder to the recycle bin. Like delete-project this is
 // reversible from the Corezoid UI's Trash; permanent destruction is not
 // exposed via this tool.

--- a/plugins/corezoid/mcp-server/mcp_handlers.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers.go
@@ -36,6 +36,7 @@ var toolHandlers = map[string]toolHandler{
 	"list-folders":         handleListFolders,
 	"modify-folder":        handleModifyFolder,
 	"delete-folder":        handleDeleteFolder,
+	"delete-process":       handleDeleteProcess,
 	"create-alias":         handleCreateAlias,
 
 	// discovery

--- a/plugins/corezoid/mcp-server/mcp_handlers_process.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_process.go
@@ -487,6 +487,22 @@ func handleModifyFolder(ctx context.Context, args map[string]interface{}) (strin
 	return fmt.Sprintf("Folder #%d updated (%s)", folderID, strings.Join(parts, ", ")), false
 }
 
+// handleDeleteProcess moves a process (conv) to the Corezoid recycle bin
+// (Trash). The operation is reversible from the UI; permanent destruction is
+// intentionally not exposed via this tool.
+func handleDeleteProcess(ctx context.Context, args map[string]interface{}) (string, bool) {
+	processID, err := intArg(args, "process_id")
+	if err != nil {
+		return "Error: " + err.Error(), true
+	}
+
+	v := NewValidator(ctx, 0)
+	if err := v.DeleteProcess(processID); err != nil {
+		return fmt.Sprintf("Error: %v", err), true
+	}
+	return fmt.Sprintf("Process #%d moved to Trash.", processID), false
+}
+
 // handleDeleteFolder moves a folder to the recycle bin. The Corezoid UI's
 // Trash view restores it; permanent destruction is intentionally not exposed.
 func handleDeleteFolder(ctx context.Context, args map[string]interface{}) (string, bool) {

--- a/plugins/corezoid/mcp-server/tools_registry.go
+++ b/plugins/corezoid/mcp-server/tools_registry.go
@@ -223,6 +223,20 @@ var toolRegistry = []mcpTool{
 		},
 	},
 	{
+		Name:        "delete-process",
+		Description: "Move a Corezoid process (or state diagram) to the recycle bin (Trash). Can be restored from the Corezoid UI. Use pull-process first if you want a local backup before deleting.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"process_id": map[string]interface{}{
+					"type":        "integer",
+					"description": "Corezoid process ID to delete",
+				},
+			},
+			"required": []string{"process_id"},
+		},
+	},
+	{
 		Name:        "create-alias",
 		Description: "Create a short alias for a Corezoid process.",
 		InputSchema: map[string]interface{}{


### PR DESCRIPTION
## Summary

- Adds the missing `delete-process` MCP tool that moves a Corezoid process (or state diagram) to the recycle bin by `process_id`
- Implements `DeleteProcess(processID int) error` in `executor_folders.go` using the same `type=delete, obj=conv` API pattern as the existing `delete-folder` and `delete-project` operations
- Adds `handleDeleteProcess` handler in `mcp_handlers_process.go` and registers it in the tool dispatch table (`mcp_handlers.go`)
- Adds the tool schema to `tools_registry.go` and the README MCP tools table

## Why it is needed

Users reported they cannot delete Corezoid processes from Claude Code and must do it manually in the UI. Every other major object type (project, folder, task, group, API key) already has a `delete-*` counterpart — processes were the only exception.

The operation is intentionally reversible: it moves the process to Trash (same behavior as `delete-folder` and `delete-project`), so the process can be restored from the Corezoid UI if deleted by mistake.

## How to test

- [ ] Start the MCP server (`go run . mcp-server` or via the inspector)
- [ ] Call `delete-process` with a valid `process_id` — verify the process disappears from the Corezoid UI folder and appears in Trash
- [ ] Call `delete-process` with an invalid/non-existent `process_id` — verify a descriptive error is returned
- [ ] Call `delete-process` with no arguments — verify the schema validation rejects the call
- [ ] Run `go test ./...` — `TestToolRegistryMatchesREADME` must pass

## Related

Requested via plugin feedback — contact: andrii.chaban@corezoid.com | install: 4e9ee380-0e8e-4db8-889b-60f1e05b072e | ts: 2026-06-24T13:17:26Z

🤖 Generated with [Claude Code](https://claude.com/claude-code)