### PR TITLE
fix(push-process): update process title on deploy

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "corezoid",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "MIT",
       "source": {
         "source": "local",

--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "corezoid",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "license": "MIT",
       "source": {
         "source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "corezoid",
       "source": "./plugins/corezoid",
       "description": "Corezoid BPM platform skills, MCP server, docs, and samples for Claude Code.",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "author": {
         "name": "Corezoid",
         "email": "support@corezoid.com"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "corezoid",
       "source": "./plugins/corezoid",
       "description": "Corezoid BPM platform skills, MCP server, docs, and samples for Claude Code.",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "author": {
         "name": "Corezoid",
         "email": "support@corezoid.com"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "corezoid",
       "source": "./plugins/corezoid",
       "description": "Corezoid BPM platform skills, MCP server, docs, and samples for Claude Code.",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "author": {
         "name": "Corezoid",
         "email": "support@corezoid.com"

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ coverage.out
 # Root-level only — plugins/corezoid/.mcp.json must stay tracked (it ships in the marketplace package).
 # Do NOT change to **/.mcp.json.
 /.mcp.json
+
+# Python
+__pycache__/
+*.pyc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.7.0]
+
+- Feat: `corezoid-stage-scan` skill — offline pre-merge/pre-deploy static validator for exported stage `.zip`s (or extracted dirs). Detects non-active processes, empty/battered processes, broken intra-process node links (`to_node_id`/`err_node_id`), and broken/inactive cross-process `conv_id` references. Maps findings to the platform's merge "Errors list" messages ("Only active process can be used", "referenced node X does not exist", "Access user to conveyor is denied in logic"). Ships a stdlib-only Python scanner with CI-friendly exit codes (`scripts/scan_stage.py`). Each finding carries a `folder` field with the human-readable folder path in the stage tree.
+
 ## [2.6.0]
 
 - Feat: `send-feedback` MCP tool — submits user feedback to a dedicated Corezoid process (`conv_id 1871779`) and returns a ticket id. Does not require authentication so users can report auth-related issues too.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.5.0]
+
+- Feat: Project CRUD MCP tools — create-project, modify-project, delete-project, show-project — for managing Corezoid projects without leaving the IDE.
+- Feat: Folder CRUD MCP tools — show-folder, list-folders, modify-folder, delete-folder — for working with the folder hierarchy.
+- Feat: corezoid-api-connector skill with a sample API-node-list process for wiring external API integrations.
+- Refactor: API-key Principal uses login obj_id (int) instead of the login string; drops the extra show_api_key round-trip. Note: changes the on-disk format under ~/.corezoid/api-keys/ — `login` is now a JSON number.
+- Fix: bump OAuth PKCE token-exchange timeout from 30s to 60s to avoid silent failures on slow networks.
+
 ## [2.4.0]
 
 - Feat: corezoid-access skill and MCP tools for user groups, API keys, and object/folder sharing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## [2.6.0]
+
+- Feat: `send-feedback` MCP tool — submits user feedback to a dedicated Corezoid process (`conv_id 1871779`) and returns a ticket id. Does not require authentication so users can report auth-related issues too.
+- Feat: `corezoid-feedback` skill — UX layer for the feedback flow: detects when a result was unexpected, collects problem/expected/solution, shows the full payload for confirmation, then calls `send-feedback`.
+- Feat: opt-in email telemetry — after first successful login, users are asked (via elicitation) if they want to share their email with the Corezoid team; stored in `~/.corezoid/preferences.json`, included as `user_email` in analytics events.
+- Refactor: all telemetry values (analytics + feedback endpoint and conv_id) centralised in `telemetry_config.go`; individually overridable via `COREZOID_ANALYTICS_ENDPOINT`, `COREZOID_ANALYTICS_CONV_ID`, `COREZOID_FEEDBACK_ENDPOINT`, `COREZOID_FEEDBACK_CONV_ID`. Existing default behavior unchanged.
+- Security: secret redaction applied to all feedback fields before transmission (Bearer tokens, JWTs, `api_key`/`token`/`password`/`secret` values, hex strings ≥ 32 chars). Feedback disabled by `COREZOID_FEEDBACK_DISABLED=1`.
+- Fix: allow templated/dynamic `conv_id` in `api_copy` nodes (align schema with `api_rpc`).
+- Fix: detect and disallow passthrough escalation nodes during lint.
+- Docs: api-call — require the full canonical api logic shape; a "light" node fails the deploy.
+- Docs: api-call — correct `customize_response=false` behavior; document response-body placement and silent mapping failure.
+- Docs: params — document the exact valid params element shape and that params are optional for receiving data.
+- Docs: set-param — document nested env_var keys and expand `conv[].ref[]` rules.
+- Docs: delay-node — clarify the 30s limit is static-literal only; document dynamic absolute-timestamp timers.
+- Docs: delay-node — make timestamp source explicitly irrelevant (set_param is one example).
+- Docs: node-ids — document server reassignment and stability of node IDs on push.
+- Docs: updated SECURITY.md telemetry section to disclose optional email opt-in and how to remove it.
+- Chore: MCP server log file moved from `/tmp/corezoid.log` to `~/.corezoid/mcp.log` for easier discoverability.
+
 ## [2.5.0]
 
 - Feat: Project CRUD MCP tools — create-project, modify-project, delete-project, show-project — for managing Corezoid projects without leaving the IDE.
@@ -10,9 +29,6 @@
 
 ## [2.4.0]
 
-- Feat: `send-feedback` MCP tool — submits user feedback to a dedicated Corezoid process (`conv_id 1871779`) and returns a ticket id. Does not require authentication so users can report auth-related issues too.
-- Feat: `corezoid-feedback` skill — UX layer for the feedback flow: detects when a result was unexpected, collects problem/expected/solution, shows the full payload for confirmation, then calls `send-feedback`.
-- Feat: opt-in email telemetry — after first successful login, users are asked (via elicitation) if they want to share their email with the Corezoid team; stored in `~/.corezoid/preferences.json`, included as `user_email` in analytics events.
 - Feat: corezoid-access skill and MCP tools for user groups, API keys, and object/folder sharing.
 - Feat: corezoid-state-diagram-create and corezoid-state-diagram-edit skills with a create-state-diagram MCP tool for building and modifying state-diagram processes.
 - Feat: corezoid-process-optimizer skill for auditing existing processes for performance and structural issues.
@@ -20,13 +36,9 @@
 - Feat: get-node-stat MCP tool exposing node archive statistics.
 - Feat: AI discovery files — llms.txt and .well-known/skills/index.json — with a generator script under scripts/.
 - Feat: context7 integration for live documentation lookups.
-- Refactor: all telemetry values (analytics + feedback endpoint and conv_id) centralised in `telemetry_config.go`; individually overridable via `COREZOID_ANALYTICS_ENDPOINT`, `COREZOID_ANALYTICS_CONV_ID`, `COREZOID_FEEDBACK_ENDPOINT`, `COREZOID_FEEDBACK_CONV_ID`. Existing default behavior unchanged.
-- Security: secret redaction applied to all feedback fields before transmission (Bearer tokens, JWTs, `api_key`/`token`/`password`/`secret` values, hex strings ≥ 32 chars). Feedback disabled by `COREZOID_FEEDBACK_DISABLED=1`.
 - Docs: full state-diagram documentation set under plugins/corezoid/docs/state-diagrams/ (overview, node structures, process interaction).
 - Docs: clarifications in call-process, copy-task, set-state, set-parameters dynamic values, and variables-guide nodes.
 - Docs: bundle docs/corezoid-swagger.json as a canonical Corezoid REST API reference.
-- Docs: updated SECURITY.md telemetry section to disclose optional email opt-in and how to remove it.
-- Chore: MCP server log file moved from `/tmp/corezoid.log` to `~/.corezoid/mcp.log` for easier discoverability.
 - Chore: unit tests for mcp-server analytics, access, config, and helpers.
 - CI: minor tweak to release.yml.
 

--- a/README.md
+++ b/README.md
@@ -206,6 +206,10 @@ validation errors, and summarize what each process does.
 | `create-process`    | Create a new empty process in a folder             |
 | `create-state-diagram` | Create a new empty state diagram (conv_type "state") in a folder |
 | `create-folder`     | Create a new subfolder                             |
+| `show-folder`       | Show folder metadata (title, kind, parent)         |
+| `list-folders`      | List immediate children of a folder (no disk I/O)  |
+| `modify-folder`     | Rename a folder or update its description          |
+| `delete-folder`     | Move a folder to the recycle bin                   |
 | `create-alias`      | Create a short alias for a process                 |
 | `create-variable`   | Create a Corezoid environment variable             |
 | `create-dashboard`  | Create a new dashboard for visualizing node metrics |
@@ -240,6 +244,7 @@ Claude Code / Codex
         │                 create-project, modify-project, delete-project, show-project
         ├── Processes     pull-process, pull-folder, push-process, lint-process
         │                 create-process, create-folder, create-alias, create-variable
+        │                 show-folder, list-folders, modify-folder, delete-folder
         ├── Tasks         run-task, list-node-tasks, list-task-history
         │                 modify-task, delete-task
         ├── Dashboards    create-dashboard, get-dashboard, add-chart,

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The plugin bundles a Go MCP server that exposes Corezoid operations as MCP tools
 | `corezoid-edit`                | "edit", "modify", "update" a process     | Modifying existing `.conv.json` files             |
 | `corezoid-review`              | "review", "audit", "check" a process     | Analysis, dead code, best-practice violations     |
 | `corezoid-project-review`      | "review project", "audit folder"         | Cross-process audit of an entire folder           |
+| `corezoid-stage-scan`          | "scan stage", "check stage before merge", "why does the merge fail" | Offline pre-merge validation of exported stage `.zip`s: non-active/empty processes, broken node links, broken/inactive `conv_id` refs |
 | `corezoid-dashboard-manager`   | "create dashboard", "add chart", "visualize metrics" | Dashboards, charts, node metrics, real-time monitoring |
 | `corezoid-process-tech-writer` | "document", "write docs", "describe process" | Markdown docs + enriched JSON with node descriptions |
 

--- a/plugins/corezoid/.claude-plugin/plugin.json
+++ b/plugins/corezoid/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "corezoid",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Corezoid AI Documentation and Templates — skills and MCP server for working with Corezoid BPM processes.",
   "author": {
     "name": "Corezoid",

--- a/plugins/corezoid/.claude-plugin/plugin.json
+++ b/plugins/corezoid/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "corezoid",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Corezoid AI Documentation and Templates — skills and MCP server for working with Corezoid BPM processes.",
   "author": {
     "name": "Corezoid",

--- a/plugins/corezoid/.claude-plugin/plugin.json
+++ b/plugins/corezoid/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "corezoid",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Corezoid AI Documentation and Templates — skills and MCP server for working with Corezoid BPM processes.",
   "author": {
     "name": "Corezoid",

--- a/plugins/corezoid/.codex-plugin/plugin.json
+++ b/plugins/corezoid/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "corezoid",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Corezoid BPM platform assistant. Exposes Corezoid operations as an MCP server and provides skills for creating, editing, reviewing, and deploying business processes.",
   "author": {
     "name": "Corezoid",

--- a/plugins/corezoid/.codex-plugin/plugin.json
+++ b/plugins/corezoid/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "corezoid",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "Corezoid BPM platform assistant. Exposes Corezoid operations as an MCP server and provides skills for creating, editing, reviewing, and deploying business processes.",
   "author": {
     "name": "Corezoid",

--- a/plugins/corezoid/docs/node-structures.md
+++ b/plugins/corezoid/docs/node-structures.md
@@ -446,8 +446,8 @@ Complete JSON structures for all node types used when modifying Corezoid process
 
 ## Escalation Node (`obj_type: 3`)
 
-Escalation nodes handle errors and timeouts. They always contain `api_rpc_reply` with
-`throw_exception: true` and route to a Final Error node.
+Escalation nodes handle errors that require active logic: replying to the calling process,
+conditional retry routing, or performing any action before terminating.
 
 ```json
 {
@@ -484,17 +484,46 @@ Escalation nodes handle errors and timeouts. They always contain `api_rpc_reply`
 ```
 
 **Rules:**
-- `obj_type: 3` marks this node as an escalation (reply) node
-- Must always contain `api_rpc_reply` with `throw_exception: true`
+- `obj_type: 3` marks this node as an escalation node
 - Must always end with `go` routing to a Final Error node (`obj_type: 2`)
 - `{{__conveyor_api_return_description__}}` is the system variable that captures the error message from the failed node
-- Every functional node that can fail (`api`, `api_code`, `api_rpc`, `api_copy`, `set_param`, `db_call`, `git_call`, `api_sum`) needs `err_node_id` pointing to an escalation node
 - API Call nodes also need a separate timeout escalation node via `semaphors`
 
-**Error handling pattern:**
+**When to use an escalation node vs. a direct final node:**
+
+Use an escalation node (`obj_type: 3`) only when the error path needs actual logic:
+- Replying to the calling process (`api_rpc_reply` with `throw_exception: true`)
+- Conditional routing based on error type (`go_if_const` on `__conveyor_*_return_type_tag__`)
+- Any other action before terminating
+
+Wire `err_node_id` **directly to a Final Error node** (`obj_type: 2`) when the error path
+simply needs to terminate with no additional logic:
+
 ```
-[Functional Node] --err_node_id--> [Escalation obj_type:3] --go--> [Final Error obj_type:2]
-[API Call Node]   --semaphor-----> [Timeout Escalation]    --go--> [Timeout Final obj_type:2]
+[Functional Node] --err_node_id--> [Final Error obj_type:2]      ✓ no logic needed
+[Functional Node] --err_node_id--> [Escalation obj_type:3]       ✓ reply / routing needed
+                                          └──go──> [Final Error obj_type:2]
+[API Call Node]   --semaphor-----> [Timeout Escalation obj_type:3] --go--> [Timeout Final obj_type:2]
+```
+
+**Anti-pattern — passthrough escalation (flagged by `lint-process`):**
+
+An escalation node with only a bare `go` and no action logic is pointless clutter.
+Replace it with a direct `err_node_id` pointer to the final node:
+
+```json
+// ✗ wrong — empty escalation node, no logic inside
+{
+  "id": "...",
+  "obj_type": 3,
+  "condition": {
+    "logics": [{"type": "go", "to_node_id": "<final_error_id>"}],
+    "semaphors": []
+  }
+}
+
+// ✓ correct — err_node_id points straight at the final error node
+"err_node_id": "<final_error_id>"
 ```
 
 ---

--- a/plugins/corezoid/docs/nodes/api-call-node.md
+++ b/plugins/corezoid/docs/nodes/api-call-node.md
@@ -75,9 +75,11 @@
 
 10. **Customize Response** (Boolean)
     - Default: `false`.
-    - When set to `true`, allows defining custom mapping rules in the `response` and `response_type`
-      parameters. If `false`, the default mapping (`{"header": "{{header}}", "body": "{{body}}"}`)
-      is used.
+    - When `false`, the parsed JSON response body is **spread into the task data root** — each
+      top-level field of the body becomes a top-level task parameter (response headers are not
+      captured, and the `response`/`response_type` mapping is ignored). When `true`, only the
+      fields you declare in `response`/`response_type` are written, nested under the keys you
+      choose. See [Reading the response body](#reading-the-response-body-customize_response-false-vs-true).
 11. **Response Type** (Object)
     - Used only when `customize_response` is `true`.
     - Defines the expected data types for the fields mapped in the `response` parameter.
@@ -151,8 +153,44 @@ The API Call node allows customization of how response data is processed:
 
 2. **Response Mapping**
    - Maps response data to task parameters
-   - Default fields: `header` (response headers) and `body` (response content)
-   - Custom mapping allows selecting specific fields from the response
+   - With `customize_response: false` (default), no mapping is applied — the response body is
+     spread into the task data root (see below); headers are discarded
+   - With `customize_response: true`, only the fields declared in `response`/`response_type` are
+     written, under the keys you name (`{{body}}` = full body, `{{header}}` = full headers)
+
+## Reading the response body: `customize_response` false vs true
+
+How the response body reaches the task depends entirely on `customize_response`. The two modes
+behave very differently (verified against a live endpoint returning
+`{"data":{...},"json":{...},"url":"..."}`):
+
+| `customize_response` | `response`/`response_type` | Where the body lands |
+| --- | --- | --- |
+| `false` (default) | **ignored** | Body is **spread into the task root**: each top-level field becomes a task parameter. A body `{"data":{"id":42}}` is read as `{{data.id}}` (task path `data.data.id`). Response **headers are not captured**. |
+| `true` | applied | Only the declared fields are written, **nested under your keys**. `response: {"body":"{{body}}"}` puts the whole body under `{{body}}`, so the same id is `{{body.data.id}}` (task path `data.body.data.id`). |
+
+`rfc_format` does not change this placement.
+
+### Prefer `customize_response: false` to capture a body
+
+For most cases — especially reading an ID or object the API just created — `customize_response: false`
+is the robust choice: the whole body is available at the task root with no mapping to get wrong.
+
+### ⚠️ Silent failure with `customize_response: true`
+
+Custom mapping is **sensitive to the real response shape**, and a mismatch fails quietly:
+
+- **Mapped path absent.** `response: {"new_id":"{{body.data.id}}"}` against a body that has no
+  `data.id` sets `new_id` to an **empty string** and routes the task to the **success** path — no
+  error, no `err_node`. Downstream nodes then run with an empty value.
+- **Type mismatch is coerced, not rejected.** `response_type` accepts only `string`, `object`, or
+  `array`; declaring `array` for an object body wraps it (`[ {...} ]`) rather than erroring.
+- A genuine `err_node` exit happens only when the response is not parseable JSON at all (e.g. an
+  HTML 5xx page → tag `api_no_valid_json`, with `__conveyor_api_return_*` fields populated).
+
+Therefore: use `customize_response: true` only after confirming the **actual** response shape, and
+validate the mapped value downstream (e.g. a Condition node checking it is non-empty) instead of
+assuming the mapping succeeded.
 
 ## Validation Rules
 
@@ -262,14 +300,14 @@ default error escalation pattern connection.
         "extra_type": {}, // Corresponding types for extra parameters (empty)
         "max_threads": 5, // Maximum concurrent requests allowed for this node
         "debug_info": false, // Do not include extra debug info in the task
-        "customize_response": false, // Use default response mapping (header and body)
+        "customize_response": false, // false → response body is spread into the task root; response/response_type below are IGNORED
         "response": {
-          // Default response mapping (used when customize_response is false)
+          // Ignored while customize_response is false (only used when it is true)
           "header": "{{header}}",
           "body": "{{body}}"
         },
         "response_type": {
-          // Default response types (used when customize_response is false)
+          // Ignored while customize_response is false (only used when it is true)
           "header": "object",
           "body": "object"
         },

--- a/plugins/corezoid/docs/nodes/delay-node.md
+++ b/plugins/corezoid/docs/nodes/delay-node.md
@@ -107,27 +107,18 @@ This lets you:
 Because the value is absolute, **always compute `now + delta`**, never a small bare number —
 a dynamic `value` of `3` would be interpreted as epoch second 3 (1970), i.e. fire immediately.
 
-The fire-moment can be produced anywhere upstream — it just has to land in task data before the
-Delay node reads it:
+**How the timestamp is produced does not matter.** The Delay node only reads the resolved value
+of its `{{placeholder}}` from task data; the only requirement is that an absolute epoch second is
+present in that key before the task reaches the node. Any of these are equivalent:
 
-- a **Set Parameter** node: `"timeout": "$.math($.unixtime()+{{delta}})"` (type `number`);
-- a **Code** node returning an epoch second;
-- passed in from **another process** or the incoming task `data`.
+- a value **passed in from another process** (or already present in the incoming task `data`);
+- a value returned by an **API Call** node;
+- a value computed in a **Code** node in JS (e.g. `return {timeout: Math.floor(Date.now()/1000) + 3}`);
+- a **Set Parameter** node: `"timeout": "$.math($.unixtime()+{{delta}})"` (type `number`).
 
 ### Pattern (verified)
 
-Upstream node computes the absolute moment:
-
-```json
-{
-  "type": "set_param",
-  "extra": { "timeout": "$.math($.unixtime()+{{delta}})" },
-  "extra_type": { "timeout": "number" },
-  "err_node_id": "error_node_id"
-}
-```
-
-Delay node holds the task until that moment, then routes onward:
+The Delay node is the only required part — set its time-semaphore `value` to the dynamic key:
 
 ```json
 {
@@ -143,9 +134,23 @@ Delay node holds the task until that moment, then routes onward:
 }
 ```
 
-**Observed behaviour** (live test, `dimension: "sec"`): with `delta = 3` the task entered the
-Delay node and reached the next node ~3 s later; with `delta = 10` it was released exactly at
-`now + 10`. Firing precision is ~1 s, and no 30-second floor is applied to the dynamic value.
+`{{timeout}}` must hold an absolute Unix second. One way to populate it (used in the live test
+below) is a Set Parameter node — but a Code node, an API response, or a value from another process
+are interchangeable:
+
+```json
+{
+  "type": "set_param",
+  "extra": { "timeout": "$.math($.unixtime()+{{delta}})" },
+  "extra_type": { "timeout": "number" },
+  "err_node_id": "error_node_id"
+}
+```
+
+**Observed behaviour** (live test, `dimension: "sec"`, `{{timeout}}` populated by Set Parameter):
+with `delta = 3` the task entered the Delay node and reached the next node ~3 s later; with
+`delta = 10` it was released exactly at `now + 10`. Firing precision is ~1 s, and no 30-second
+floor is applied to the dynamic value.
 
 ## Best Practices
 

--- a/plugins/corezoid/docs/nodes/delay-node.md
+++ b/plugins/corezoid/docs/nodes/delay-node.md
@@ -13,7 +13,7 @@
 1. **Delay Duration** (Number)
 
    - The amount of time to hold the task.
-   - Minimum value: 30 seconds. Values below this limit are not allowed (e.g., `"Timer value 15 sec is less than minimum limit 30 sec"`).
+   - Minimum value: 30 seconds — **but this limit is only enforced on a static numeric literal at deploy time** (e.g., `"value": 15` is rejected with `"Timer value 15 sec is less than minimum limit 30 sec"`). A **dynamic** `value` (a `{{placeholder}}` string resolved at runtime) is **not** subject to this static check. See [Scheduled & sub-30s timers via a dynamic absolute timestamp](#scheduled--sub-30s-timers-via-a-dynamic-absolute-timestamp).
    - Example: `"value": 30`
 
 2. **Time Unit** (String)
@@ -89,9 +89,68 @@ concurrent delayed tasks reaches the threshold, new tasks are routed to an escal
 
 This can be used to prevent system overload when many tasks are being delayed simultaneously.
 
+## Scheduled & sub-30s timers via a dynamic absolute timestamp
+
+The 30-second minimum is a **deploy-time validation of a static numeric literal** in the
+time-semaphore `value`. It is **not** a runtime floor. When `value` is a **dynamic reference**
+(a `{{placeholder}}` resolved at runtime), the static check does not apply — and the timer
+fires when that value tells it to.
+
+**Key semantic: a dynamic `value` is an _absolute Unix timestamp_ (the moment to fire), not a
+relative number of seconds.** Set it to the epoch second at which the task should be released.
+This lets you:
+
+- schedule a release at an exact moment (e.g. "tomorrow at 09:00"), and
+- release **sooner than 30 seconds** from now — set `value` to `now + 3`, and the task is held
+  for ~3 seconds. (A static `"value": 3` would be rejected at deploy; the dynamic form is not.)
+
+Because the value is absolute, **always compute `now + delta`**, never a small bare number —
+a dynamic `value` of `3` would be interpreted as epoch second 3 (1970), i.e. fire immediately.
+
+The fire-moment can be produced anywhere upstream — it just has to land in task data before the
+Delay node reads it:
+
+- a **Set Parameter** node: `"timeout": "$.math($.unixtime()+{{delta}})"` (type `number`);
+- a **Code** node returning an epoch second;
+- passed in from **another process** or the incoming task `data`.
+
+### Pattern (verified)
+
+Upstream node computes the absolute moment:
+
+```json
+{
+  "type": "set_param",
+  "extra": { "timeout": "$.math($.unixtime()+{{delta}})" },
+  "extra_type": { "timeout": "number" },
+  "err_node_id": "error_node_id"
+}
+```
+
+Delay node holds the task until that moment, then routes onward:
+
+```json
+{
+  "logics": [],
+  "semaphors": [
+    {
+      "type": "time",
+      "value": "{{timeout}}",
+      "dimension": "sec",
+      "to_node_id": "next_node_id"
+    }
+  ]
+}
+```
+
+**Observed behaviour** (live test, `dimension: "sec"`): with `delta = 3` the task entered the
+Delay node and reached the next node ~3 s later; with `delta = 10` it was released exactly at
+`now + 10`. Firing precision is ~1 s, and no 30-second floor is applied to the dynamic value.
+
 ## Best Practices
 
-- The minimum allowed delay is 30 seconds; values below this threshold will result in a validation error
+- The 30-second minimum applies only to a **static literal** `value` at deploy time; for shorter
+  or scheduled delays use a **dynamic `value` holding an absolute Unix timestamp** (see above)
 - Use reasonable delay times to avoid resource constraints
 - For variable delays, validate the parameter before reaching the Delay node
 - Consider using a Queue node for very long delays

--- a/plugins/corezoid/docs/nodes/set-parameters-dynamic-values.md
+++ b/plugins/corezoid/docs/nodes/set-parameters-dynamic-values.md
@@ -184,6 +184,32 @@ in `extra` values, in condition `arg`/`val` fields, in API Call URLs and headers
 To manage environment variables (create, list, modify, delete), see
 `${CLAUDE_PLUGIN_ROOT}/skills/corezoid-variable-manager/SKILL.md`.
 
+### Nested env_var keys
+
+When an environment variable stores a JSON object or array, downstream nodes can
+read nested fields using dot- and bracket-notation directly inside the
+`{{env_var[...]}}` reference. The runtime parses the variable value as JSON once
+and resolves the path against it.
+
+```
+{{env_var[@payment-config].host}}              // object: top-level field
+{{env_var[@payment-config].retry.max}}         // object: nested dot path
+{{env_var[@allowed-currencies][0]}}            // array: first element
+{{env_var[@allowed-currencies][2].code}}       // array of objects
+{{env_var[@routing-table].key[1].param}}       // mixed object + array
+```
+
+Rules:
+
+1. The stored env_var value must be valid JSON for nested access to work — plain
+   string variables only support the bare `{{env_var[@name]}}` form.
+2. Use dot notation for object keys (`.host`) and bracket notation for array
+   indices (`[0]`). They can be chained freely.
+3. If a key or index does not exist, the reference resolves to an empty string —
+   guard against it in the next Condition node.
+4. Dynamic indices (`[{{i}}]`) are supported and follow the same 0–100 limit as
+   regular array references.
+
 ## System Variables
 
 The following system variables are available in Set Parameters nodes:
@@ -262,9 +288,25 @@ Examples:
 // Using dynamic process and task references
 {{conv[{{my_process_id}}].ref[{{my_task_ref}}].amount_owed}}
 
-// Using special process references
+// Using special process references (state diagrams via @alias)
 {{conv[@user-states].ref[{{my_task_ref}}]}}
+
+// Both alias and ref are dynamic
+{{conv[{{conv_alias}}].ref[{{my_ref}}].balance}}
 ```
+
+Rules:
+
+1. The alias inside `conv[@...]` must exist on the **current stage** at the time
+   the process is deployed — `BeforeValidation` rejects unknown aliases.
+2. `{{my_ref}}` must resolve to a non-empty string at runtime. If the referenced
+   task does not exist in the target state diagram, the expression resolves to
+   an empty string.
+3. Append a field after `ref[...]` (e.g. `.balance`, `.status`) to read a single
+   parameter; without a trailing field the reference returns the whole task
+   object.
+4. Use a numeric `conv_id` (`{{conv[1023399].ref[...]}}`) for cross-project
+   references when no `@alias` is available.
 
 ## Built-in Functions
 

--- a/plugins/corezoid/docs/process/error-handling.md
+++ b/plugins/corezoid/docs/process/error-handling.md
@@ -57,24 +57,30 @@ Condition nodes:
 
 ### 1. Basic Error Routing
 
-The simplest error handling pattern routes tasks to a dedicated error node when an error occurs:
+The simplest pattern routes `err_node_id` directly to a Final Error node when no action
+is needed on the error path:
 
 ```
 Operation Node ──→ Success Path
       │
-      └─── [error] ──→ Error Node → End Node
+      └─── [err_node_id] ──→ Final Error Node (obj_type:2)
 ```
 
 Implementation:
 
 ```json
 {
-  "type": "api",
-  "method": "GET",
-  "url": "https://api.example.com",
-  "err_node_id": "error_node_id"
+  "type": "api_rpc",
+  "conv_id": 12345,
+  "err_node_id": "<final_error_node_id>"
 }
 ```
+
+> **Rule:** Wire `err_node_id` directly to a Final Error node (`obj_type: 2`) when the
+> error path needs no logic. Only interpose an Escalation node (`obj_type: 3`) when the
+> error path requires an action such as replying to the caller or conditional retry routing.
+> An escalation node that only contains a bare `go` with no action logic is an anti-pattern
+> and is flagged by `lint-process` as a **passthrough escalation**.
 
 ### 2. Error Type Differentiation
 

--- a/plugins/corezoid/docs/process/process-development-guide.md
+++ b/plugins/corezoid/docs/process/process-development-guide.md
@@ -236,6 +236,38 @@ Before deploying a process, validate its JSON structure to ensure it meets all r
    - Duplicate node IDs
    - Missing Start node (every process must have exactly one Start node)
 
+### Node ID Lifecycle: Server Assignment & Stability on Push
+
+Node IDs you write locally are **temporary** for any node the server does not yet recognize. On
+`push-process`, Corezoid assigns its own canonical 24-character hex ID to every **new** node and
+rewrites all references to it. This is expected, not an error.
+
+What is preserved vs. reassigned:
+
+| Node | On push |
+| ---- | ------- |
+| **New** node (locally invented ID, even a valid `^[0-9a-f]{24}$` string) | ID is **reassigned** to a server-generated value; format/plausibility of your ID does not matter |
+| **Existing** node (already carries a server-assigned ID) | ID is **preserved** — stable across all subsequent pushes |
+
+Each node also carries a server-managed `uuid`, which is likewise assigned on first push and stable
+thereafter.
+
+Practical workflow:
+
+1. For new nodes, supply any unique, format-valid placeholder ID (`^[0-9a-f]{24}$`) so the JSON
+   validates and intra-push references resolve. **Within a single push**, references between your
+   new nodes (`go`, `to_node_id`, `err_node_id`) are remapped to the canonical IDs automatically —
+   you do **not** need to know the final IDs in advance.
+2. `push-process` writes the canonical IDs back into your local process file and rewires references.
+3. Run **`pull-process`** afterward to fully resync server-managed fields (canonical `id`, `uuid`,
+   and any normalized values) before you make further edits.
+4. In a **later** editing session, never reference an ID you invented in a previous push — it no
+   longer exists. Use the canonical ID from the latest pull. (Node `title` is **not** a safe
+   substitute: titles are not unique and may be empty.)
+
+> Common failure: editing a process across sessions using stale, locally-invented IDs. The
+> connection silently points to a non-existent node. Always `pull` first and work from canonical IDs.
+
 ### Automatic Node Positioning
 
 To ensure clean, readable process diagrams with minimal edge intersections, use the provided node

--- a/plugins/corezoid/mcp-server/executor_folders.go
+++ b/plugins/corezoid/mcp-server/executor_folders.go
@@ -64,6 +64,115 @@ func (v *Executor) ShowFolder(folderID int) (*FolderInfo, error) {
 	return info, nil
 }
 
+// FolderChild describes one entry returned by ListFolder. Folders and convs
+// share the same response slice, distinguished by Obj ("folder" | "conv") and
+// — for convs — ConvType ("process" | "state").
+type FolderChild struct {
+	Obj      string // "folder" | "conv"
+	ObjID    int
+	Title    string
+	ObjType  int    // for folders: 0 normal, 2 project, 3 stage
+	ConvType string // for convs only
+	Status   string
+}
+
+// ListFolder returns the immediate children of folderID (subfolders + convs).
+// The Corezoid list-folder endpoint returns a flat slice with each entry
+// tagged by "obj"; this method preserves that shape so callers can filter.
+func (v *Executor) ListFolder(folderID int) ([]FolderChild, error) {
+	ops := []map[string]any{
+		{
+			"type":       "list",
+			"obj":        "folder",
+			"obj_id":     folderID,
+			"company_id": v.WorkspaceID,
+		},
+	}
+	response, err := v.req("list_folder", ops)
+	if err != nil {
+		return nil, fmt.Errorf("ListFolder request failed: %w", err)
+	}
+	first, err := firstOp(response)
+	if err != nil {
+		return nil, err
+	}
+	list, _ := first["list"].([]any)
+	out := make([]FolderChild, 0, len(list))
+	for _, item := range list {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		child := FolderChild{}
+		if s, ok := m["obj"].(string); ok {
+			child.Obj = s
+		}
+		if f, ok := m["obj_id"].(float64); ok {
+			child.ObjID = int(f)
+		}
+		if s, ok := m["title"].(string); ok {
+			child.Title = s
+		}
+		if f, ok := m["obj_type"].(float64); ok {
+			child.ObjType = int(f)
+		}
+		if s, ok := m["conv_type"].(string); ok {
+			child.ConvType = s
+		}
+		if s, ok := m["status"].(string); ok {
+			child.Status = s
+		}
+		out = append(out, child)
+	}
+	return out, nil
+}
+
+// ModifyFolder renames a folder and/or updates its description. At least one
+// of title/description must be non-empty — the caller is expected to enforce
+// that before calling.
+func (v *Executor) ModifyFolder(folderID int, title, description string) error {
+	op := map[string]any{
+		"type":       "modify",
+		"obj":        "folder",
+		"obj_id":     folderID,
+		"company_id": v.WorkspaceID,
+	}
+	if title != "" {
+		op["title"] = title
+	}
+	if description != "" {
+		op["description"] = description
+	}
+	resp, err := v.req("modify_folder", []map[string]any{op})
+	if err != nil {
+		return fmt.Errorf("ModifyFolder request failed: %w", err)
+	}
+	if _, err := firstOp(resp); err != nil {
+		return err
+	}
+	return nil
+}
+
+// DeleteFolder moves a folder to the recycle bin. Like delete-project this is
+// reversible from the Corezoid UI's Trash; permanent destruction is not
+// exposed via this tool.
+func (v *Executor) DeleteFolder(folderID int) error {
+	op := map[string]any{
+		"type":       "delete",
+		"obj":        "folder",
+		"obj_id":     folderID,
+		"company_id": v.WorkspaceID,
+	}
+	resp, err := v.req("delete_folder", []map[string]any{op})
+	if err != nil {
+		return fmt.Errorf("DeleteFolder request failed: %w", err)
+	}
+	if _, err := firstOp(resp); err != nil {
+		return err
+	}
+	return nil
+}
+
 // CreateFolder creates a new folder under parentFolderID and returns the new folder's obj_id.
 func (v *Executor) CreateFolder(parentFolderID int, title, desc string) (int, error) {
 	ops := []map[string]any{

--- a/plugins/corezoid/mcp-server/executor_process.go
+++ b/plugins/corezoid/mcp-server/executor_process.go
@@ -311,6 +311,12 @@ func (validator *Executor) ProcessJSON(filePath, jsonContent string) (newProcess
 			return nil, err
 		}
 	} else {
+		title, _ := processDataOfAI["title"].(string)
+		if title != "" {
+			if err = validator.RenameProcess(title); err != nil {
+				return nil, fmt.Errorf("error renaming process: %v", err)
+			}
+		}
 		oldProcessData, err := validator.GetProcessByID(validator.ProcessID)
 		if err != nil {
 			logger.Error("Failed to get process: %v", err)
@@ -585,6 +591,35 @@ func (v *Executor) SetParams(params []interface{}) error {
 	}
 	if requestProc, ok := response["request_proc"].(string); !ok || requestProc != "ok" {
 		return fmt.Errorf("failed to set params: request_proc not ok")
+	}
+	return nil
+}
+
+// RenameProcess updates the title of an existing Corezoid process.
+// It issues a "modify" / "conv" API operation so that the server-side name
+// stays in sync with the title field stored in the local .conv.json file.
+func (v *Executor) RenameProcess(title string) error {
+	ops := []map[string]any{
+		{
+			"obj_id":     v.ProcessID,
+			"type":       "modify",
+			"obj":        "conv",
+			"title":      title,
+			"company_id": v.WorkspaceID,
+		},
+	}
+	if v.Debug {
+		logger.Debug("Sending rename process request, title=%s", title)
+	}
+	response, err := v.req("set_params", ops)
+	if err != nil {
+		return fmt.Errorf("failed to rename process: %w", err)
+	}
+	if response == nil {
+		return fmt.Errorf("failed to rename process: no response from server")
+	}
+	if requestProc, ok := response["request_proc"].(string); !ok || requestProc != "ok" {
+		return fmt.Errorf("failed to rename process: request_proc not ok")
 	}
 	return nil
 }

--- a/plugins/corezoid/mcp-server/executor_process.go
+++ b/plugins/corezoid/mcp-server/executor_process.go
@@ -123,7 +123,70 @@ func (v *Executor) PullFolder(id int, objType string) ([]any, error) {
 	return processes, nil
 }
 
+// schemeNodesEmpty reports whether the exported process JSON has an empty
+// (or absent) scheme.nodes array. This is the diagnostic signal for a process
+// that was imported from a file but never successfully deployed — the
+// export_process endpoint only returns deployed node data, so non-deployed
+// processes come back with an empty scheme even though their nodes are stored
+// internally and visible in the Corezoid UI.
+func schemeNodesEmpty(proc interface{}) bool {
+	m, ok := proc.(map[string]interface{})
+	if !ok {
+		return false
+	}
+	scheme, ok := m["scheme"].(map[string]interface{})
+	if !ok {
+		return true // no scheme block at all → treat as empty
+	}
+	nodes, ok := scheme["nodes"].([]interface{})
+	return !ok || len(nodes) == 0
+}
+
+// FetchDraftNodes retrieves the current node list for processID via the
+// get_process API and converts each entry from Corezoid's internal format
+// (field "obj_id") to the export format (field "id") so that the result is
+// directly usable as scheme.nodes in a pulled process JSON.
+//
+// This is the fallback for pull-process / pull-folder when export_process
+// returns an empty scheme.nodes for a process that was imported from a file
+// but never deployed (e.g. it referenced a non-existent sub-process at
+// import time). The get_process API always returns the full, uncommitted node
+// list, matching what the Corezoid UI displays for such processes.
+func (v *Executor) FetchDraftNodes(processID int) ([]interface{}, error) {
+	proc, err := v.GetProcessByID(processID)
+	if err != nil {
+		return nil, fmt.Errorf("FetchDraftNodes: get_process failed: %w", err)
+	}
+	rawList, ok := proc["list"].([]interface{})
+	if !ok || len(rawList) == 0 {
+		return nil, fmt.Errorf("FetchDraftNodes: no nodes returned by get_process for process %d", processID)
+	}
+	nodes := make([]interface{}, 0, len(rawList))
+	for _, item := range rawList {
+		nodeMap, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		// The export format uses "id" as the node identifier while the
+		// internal get_process list uses "obj_id". Normalise the key so
+		// that the saved JSON is compatible with push-process.
+		if objID, exists := nodeMap["obj_id"]; exists {
+			if _, hasID := nodeMap["id"]; !hasID {
+				nodeMap["id"] = objID
+			}
+			delete(nodeMap, "obj_id")
+		}
+		nodes = append(nodes, nodeMap)
+	}
+	return nodes, nil
+}
+
 // ExportProcess downloads the current process definition as parsed JSON.
+// If the server returns a process with an empty scheme.nodes (which happens
+// for processes that were imported but never deployed), ExportProcess falls
+// back to FetchDraftNodes to populate the nodes from the get_process API,
+// ensuring that pull-process always returns a usable JSON regardless of the
+// process deployment status.
 func (v *Executor) ExportProcess() (any, error) {
 	ops := []map[string]any{
 		{
@@ -179,6 +242,31 @@ func (v *Executor) ExportProcess() (any, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal process: %v", err)
 	}
+
+	// If the exported process has an empty scheme.nodes, the process was
+	// likely imported but never deployed. Fall back to get_process to recover
+	// the nodes that are stored internally (and visible in the Corezoid UI).
+	if len(process) > 0 && schemeNodesEmpty(process[0]) {
+		logger.Warn("ExportProcess: process %d has empty scheme.nodes (not deployed); "+
+			"falling back to get_process to fetch draft nodes", v.ProcessID)
+		nodes, fallbackErr := v.FetchDraftNodes(v.ProcessID)
+		if fallbackErr == nil && len(nodes) > 0 {
+			if procMap, ok := process[0].(map[string]interface{}); ok {
+				scheme, _ := procMap["scheme"].(map[string]interface{})
+				if scheme == nil {
+					scheme = make(map[string]interface{})
+					procMap["scheme"] = scheme
+				}
+				scheme["nodes"] = nodes
+				process[0] = procMap
+				logger.Warn("ExportProcess: injected %d draft nodes into process %d", len(nodes), v.ProcessID)
+			}
+		} else {
+			logger.Warn("ExportProcess: draft node fallback for process %d also returned no nodes: %v",
+				v.ProcessID, fallbackErr)
+		}
+	}
+
 	return process, nil
 }
 

--- a/plugins/corezoid/mcp-server/json-schema/logics/api_copy.json
+++ b/plugins/corezoid/mcp-server/json-schema/logics/api_copy.json
@@ -24,18 +24,8 @@
       "description": "Internal user ID associated with the operation"
     },
     "conv_id": {
-      "oneOf": [
-        {
-          "type": "integer",
-          "description": "Numeric ID of the target Process"
-        },
-        {
-          "type": "string",
-          "pattern": "^@.*",
-          "description": "String ID of the target Process, must start with '@'"
-        }
-      ],
-      "description": "ID of the target Process to receive the copied task or where the task to modify resides. Can be either a numeric ID or a string starting with '@'"
+      "type": ["integer", "string"],
+      "description": "ID of the target Process to receive the copied task or where the task to modify resides. Numeric ID, an '@alias', or a dynamic reference like '{{param}}' (aligned with api_rpc conv_id)."
     },
     "convTitle": {
       "type": "string",

--- a/plugins/corezoid/mcp-server/lint.go
+++ b/plugins/corezoid/mcp-server/lint.go
@@ -9,14 +9,15 @@ import (
 
 // LintResult holds the combined lint output
 type LintResult struct {
-	ProcessTitle    string
-	NoopConditions  []NoopCondition
-	UnusedSetParams []UnusedSetParam
-	OrphanedNodes   []OrphanedNode
-	TotalNodes      int
-	ReachableCount  int
-	SchemaValid     bool
-	SchemaError     string
+	ProcessTitle             string
+	NoopConditions           []NoopCondition
+	UnusedSetParams          []UnusedSetParam
+	OrphanedNodes            []OrphanedNode
+	PassthroughEscalations   []PassthroughEscalation
+	TotalNodes               int
+	ReachableCount           int
+	SchemaValid              bool
+	SchemaError              string
 }
 
 type NoopCondition struct {
@@ -39,6 +40,17 @@ type OrphanedNode struct {
 	ID      string
 	Title   string
 	ObjType string
+}
+
+// PassthroughEscalation represents an escalation node (obj_type:3) whose only logic
+// is a bare `go` — it adds no value and should be replaced by a direct err_node_id
+// pointing straight to the final error node.
+type PassthroughEscalation struct {
+	ID          string
+	Title       string
+	TargetID    string
+	TargetTitle string
+	Issue       string
 }
 
 // processNode is the typed representation of a Corezoid node used throughout lint checks.
@@ -98,6 +110,7 @@ func lintProcess(filePath string) (*LintResult, error) {
 	typed := parseProcessNodes(nodes)
 	result.NoopConditions, result.UnusedSetParams = findNoopNodes(typed)
 	result.OrphanedNodes, result.ReachableCount = findOrphanedNodes(typed)
+	result.PassthroughEscalations = findPassthroughEscalations(typed)
 
 	schemaErr := ValidateJSONSchema(filePath, debug)
 	if schemaErr != nil {
@@ -223,6 +236,75 @@ func findNoopNodes(nodes []processNode) ([]NoopCondition, []UnusedSetParam) {
 	return noopConditions, unusedSetParams
 }
 
+// findPassthroughEscalations detects escalation nodes (obj_type:3) that contain only
+// a bare `go` logic and no action logic (api_rpc_reply, set_param, etc.).
+// Such nodes are pure pass-throughs: the err_node_id should point directly to the
+// final error node instead of routing through an empty escalation node.
+func findPassthroughEscalations(nodes []processNode) []PassthroughEscalation {
+	nodeMap := make(map[string]processNode, len(nodes))
+	for _, n := range nodes {
+		nodeMap[n.id] = n
+	}
+
+	actionTypes := map[string]bool{
+		"api_rpc_reply": true,
+		"api_rpc":       true,
+		"api_copy":      true,
+		"api":           true,
+		"api_code":      true,
+		"set_param":     true,
+		"api_sum":       true,
+		"db_call":       true,
+		"api_git":       true,
+		"api_queue":     true,
+		"api_get_task":  true,
+	}
+
+	var result []PassthroughEscalation
+	for _, n := range nodes {
+		if n.objType != 3 {
+			continue
+		}
+		hasAction := false
+		goTarget := ""
+		for _, lg := range n.logics {
+			lgType, _ := lg["type"].(string)
+			if actionTypes[lgType] {
+				hasAction = true
+				break
+			}
+			if lgType == "go" {
+				goTarget, _ = lg["to_node_id"].(string)
+			}
+		}
+		if hasAction || goTarget == "" {
+			continue
+		}
+		targetTitle := ""
+		if target, ok := nodeMap[goTarget]; ok {
+			targetTitle = target.title
+			if targetTitle == "" {
+				targetTitle = "(untitled)"
+			}
+		}
+		displayTitle := n.title
+		if displayTitle == "" {
+			displayTitle = "(untitled)"
+		}
+		result = append(result, PassthroughEscalation{
+			ID:          n.id,
+			Title:       displayTitle,
+			TargetID:    goTarget,
+			TargetTitle: targetTitle,
+			Issue: fmt.Sprintf(
+				"Escalation node (obj_type:3) has no action logic — wire err_node_id directly to '%s' (%s)",
+				targetTitle, goTarget,
+			),
+		})
+	}
+	return result
+}
+
 // findOrphanedNodes does a BFS from the Start node and returns unreachable nodes
 func findOrphanedNodes(nodes []processNode) ([]OrphanedNode, int) {
 	typeLabels := map[float64]string{0: "standard", 1: "start", 2: "final", 3: "escalation"}
@@ -343,6 +425,15 @@ func FormatLintResult(result *LintResult) string {
 		}
 	}
 
+	if len(result.PassthroughEscalations) > 0 {
+		hasIssues = true
+		sb.WriteString(fmt.Sprintf("\n=== PASSTHROUGH ESCALATION NODES (%d) ===\n", len(result.PassthroughEscalations)))
+		for _, pe := range result.PassthroughEscalations {
+			sb.WriteString(fmt.Sprintf("  [%s] %s\n", pe.ID, pe.Title))
+			sb.WriteString(fmt.Sprintf("  Issue: %s\n", pe.Issue))
+		}
+	}
+
 	if !hasIssues {
 		sb.WriteString("\nNo issues found.")
 	} else {
@@ -350,7 +441,7 @@ func FormatLintResult(result *LintResult) string {
 		if !result.SchemaValid {
 			schemaIssues = 1
 		}
-		total := len(result.NoopConditions) + len(result.UnusedSetParams) + len(result.OrphanedNodes) + schemaIssues
+		total := len(result.NoopConditions) + len(result.UnusedSetParams) + len(result.OrphanedNodes) + len(result.PassthroughEscalations) + schemaIssues
 		sb.WriteString(fmt.Sprintf("\nTotal issues: %d\n", total))
 	}
 

--- a/plugins/corezoid/mcp-server/lint_test.go
+++ b/plugins/corezoid/mcp-server/lint_test.go
@@ -53,6 +53,20 @@ func TestLintProcess_NoopCondition(t *testing.T) {
 	}
 }
 
+// TestLintProcess_PassthroughEscalation verifies passthrough escalation node detection.
+func TestLintProcess_PassthroughEscalation(t *testing.T) {
+	result, err := lintProcess("samples/passthrough_escalation.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.PassthroughEscalations) != 1 {
+		t.Errorf("expected 1 passthrough escalation, got %d", len(result.PassthroughEscalations))
+	}
+	if result.PassthroughEscalations[0].TargetTitle != "rpc_error" {
+		t.Errorf("expected target title 'rpc_error', got %q", result.PassthroughEscalations[0].TargetTitle)
+	}
+}
+
 // TestLintProcess_MalformedJSON verifies graceful error on invalid JSON.
 func TestLintProcess_MalformedJSON(t *testing.T) {
 	f, err := os.CreateTemp("", "bad-*.json")

--- a/plugins/corezoid/mcp-server/mcp_handlers.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers.go
@@ -32,6 +32,10 @@ var toolHandlers = map[string]toolHandler{
 	"create-process":       handleCreateProcess,
 	"create-state-diagram": handleCreateStateDiagram,
 	"create-folder":        handleCreateFolder,
+	"show-folder":          handleShowFolder,
+	"list-folders":         handleListFolders,
+	"modify-folder":        handleModifyFolder,
+	"delete-folder":        handleDeleteFolder,
 	"create-alias":         handleCreateAlias,
 
 	// discovery

--- a/plugins/corezoid/mcp-server/mcp_handlers_process.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_process.go
@@ -399,6 +399,109 @@ func handleCreateFolder(ctx context.Context, args map[string]interface{}) (strin
 	return fmt.Sprintf("Folder '%s' created and saved to %s", folderName, filePath), false
 }
 
+// handleShowFolder returns metadata for a single folder (title, obj_type,
+// parent). Used to introspect folders without writing anything to disk.
+func handleShowFolder(ctx context.Context, args map[string]interface{}) (string, bool) {
+	folderID, err := intArg(args, "folder_id")
+	if err != nil {
+		return "Error: " + err.Error(), true
+	}
+
+	v := NewValidator(ctx, 0)
+	info, err := v.ShowFolder(folderID)
+	if err != nil {
+		return fmt.Sprintf("Error: %v", err), true
+	}
+
+	kind := "folder"
+	switch info.ObjType {
+	case 1:
+		kind = "root"
+	case 2:
+		kind = "project"
+	case 3:
+		kind = "stage"
+	}
+	return fmt.Sprintf("Folder #%d %q (kind=%s, parent=%s#%d)",
+		info.ObjID, info.Title, kind, info.ParentObjType, info.ParentObjID), false
+}
+
+// handleListFolders prints the immediate children of a folder in a tabular
+// form. Subfolders come first, then convs (processes + state diagrams).
+func handleListFolders(ctx context.Context, args map[string]interface{}) (string, bool) {
+	folderID, err := intArg(args, "folder_id")
+	if err != nil {
+		return "Error: " + err.Error(), true
+	}
+
+	v := NewValidator(ctx, 0)
+	children, err := v.ListFolder(folderID)
+	if err != nil {
+		return fmt.Sprintf("Error: %v", err), true
+	}
+
+	if len(children) == 0 {
+		return fmt.Sprintf("Folder #%d is empty.", folderID), false
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Folder #%d children (%d total):\n\n", folderID, len(children)))
+	sb.WriteString(fmt.Sprintf("  %-10s  %-12s  %s\n", "ID", "Kind", "Title"))
+	sb.WriteString("  " + strings.Repeat("-", 50) + "\n")
+	for _, c := range children {
+		kind := c.Obj
+		if c.Obj == "conv" && c.ConvType != "" {
+			kind = c.ConvType
+		}
+		sb.WriteString(fmt.Sprintf("  %-10d  %-12s  %s\n", c.ObjID, kind, c.Title))
+	}
+	return sb.String(), false
+}
+
+// handleModifyFolder renames a folder and/or updates its description. At
+// least one of title / description must be provided — the API silently
+// accepts an empty modify so we guard client-side.
+func handleModifyFolder(ctx context.Context, args map[string]interface{}) (string, bool) {
+	folderID, err := intArg(args, "folder_id")
+	if err != nil {
+		return "Error: " + err.Error(), true
+	}
+	title := optStrArg(args, "title")
+	description := optStrArg(args, "description")
+	if title == "" && description == "" {
+		return "Error: at least one of title or description must be provided", true
+	}
+
+	v := NewValidator(ctx, 0)
+	if err := v.ModifyFolder(folderID, title, description); err != nil {
+		return fmt.Sprintf("Error: %v", err), true
+	}
+
+	parts := []string{}
+	if title != "" {
+		parts = append(parts, fmt.Sprintf("title=%q", title))
+	}
+	if description != "" {
+		parts = append(parts, fmt.Sprintf("description=%q", description))
+	}
+	return fmt.Sprintf("Folder #%d updated (%s)", folderID, strings.Join(parts, ", ")), false
+}
+
+// handleDeleteFolder moves a folder to the recycle bin. The Corezoid UI's
+// Trash view restores it; permanent destruction is intentionally not exposed.
+func handleDeleteFolder(ctx context.Context, args map[string]interface{}) (string, bool) {
+	folderID, err := intArg(args, "folder_id")
+	if err != nil {
+		return "Error: " + err.Error(), true
+	}
+
+	v := NewValidator(ctx, 0)
+	if err := v.DeleteFolder(folderID); err != nil {
+		return fmt.Sprintf("Error: %v", err), true
+	}
+	return fmt.Sprintf("Folder #%d moved to Trash.", folderID), false
+}
+
 // handleCreateAlias creates a Corezoid alias (short_name → conv) pointing at
 // the process whose ID is encoded in the file path. Requires a configured
 // COREZOID_STAGE_ID since aliases are stage-scoped.

--- a/plugins/corezoid/mcp-server/pull-project.go
+++ b/plugins/corezoid/mcp-server/pull-project.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 )
@@ -213,6 +214,17 @@ func downloadStageRecursively(e *Executor, folderID int, filePath string) error 
 		return fmt.Errorf("failed to format json: %v", err)
 	}
 
+	// Patch any process files whose scheme.nodes is empty. This happens when
+	// a process was imported from a file but never deployed (e.g. it referenced
+	// a non-existent sub-process). export_process only exports deployed content,
+	// so the ZIP contains empty scheme.nodes for those processes. We recover the
+	// node list from the get_process API, which always returns the full stored
+	// (uncommitted) node set — matching what the Corezoid UI displays.
+	if patchErr := patchEmptyNodesInDir(e, filePath); patchErr != nil {
+		logger.Warn("pull-folder: patch empty nodes partially failed: %v", patchErr)
+		// Non-fatal: we still return any successfully patched files.
+	}
+
 	return nil
 	//
 	//fmt.Println("procInfo", procInfo)
@@ -352,6 +364,110 @@ func formatJSON(filePath string) error {
 		if err != nil {
 			return fmt.Errorf("failed to write file: %v", err)
 		}
+	}
+	return nil
+}
+
+// processIDFromJSON extracts the numeric process ID stored in the "obj_id"
+// field of a parsed process JSON map. Returns 0 when the field is absent or
+// not a number.
+func processIDFromJSON(proc interface{}) int {
+	m, ok := proc.(map[string]interface{})
+	if !ok {
+		return 0
+	}
+	if f, ok := m["obj_id"].(float64); ok {
+		return int(f)
+	}
+	return 0
+}
+
+// patchEmptyNodesInDir walks the directory tree rooted at dir, finds process
+// JSON files whose scheme.nodes array is empty, and refills scheme.nodes from
+// the get_process API via FetchDraftNodes.
+//
+// Background: export_process only includes deployed node data. Processes that
+// were imported from a file but never deployed (e.g. because they contained a
+// reference to a non-existent sub-process) arrive with an empty scheme.nodes
+// in the ZIP. The get_process API always returns the full uncommitted node
+// list, so we can recover the nodes here and write them back into the file.
+//
+// Errors for individual files are logged as warnings and do not abort the
+// walk — callers receive a non-nil error only when the directory itself
+// cannot be read.
+func patchEmptyNodesInDir(v *Executor, dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		path := filepath.Join(dir, entry.Name())
+		if entry.IsDir() {
+			if subErr := patchEmptyNodesInDir(v, path); subErr != nil {
+				logger.Warn("patchEmptyNodesInDir: error in %s: %v", path, subErr)
+			}
+			continue
+		}
+		if filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			continue
+		}
+		var procJSON interface{}
+		if unmarshalErr := json.Unmarshal(data, &procJSON); unmarshalErr != nil {
+			continue
+		}
+		if !schemeNodesEmpty(procJSON) {
+			continue // nodes already present — nothing to do
+		}
+
+		// Determine the process ID: prefer the obj_id field in the JSON,
+		// fall back to the leading numeric prefix in the filename.
+		procID := processIDFromJSON(procJSON)
+		if procID == 0 {
+			base := filepath.Base(path)
+			if m := reProcessIDFromFilename.FindStringSubmatch(base); m != nil {
+				procID, _ = strconv.Atoi(m[1])
+			}
+		}
+		if procID == 0 {
+			logger.Warn("patchEmptyNodesInDir: cannot determine process ID for %s, skipping", path)
+			continue
+		}
+
+		logger.Warn("patchEmptyNodesInDir: process %d (%s) has empty scheme.nodes; "+
+			"fetching draft nodes via get_process", procID, entry.Name())
+
+		nodes, fetchErr := v.FetchDraftNodes(procID)
+		if fetchErr != nil || len(nodes) == 0 {
+			logger.Warn("patchEmptyNodesInDir: draft fallback for process %d failed: %v", procID, fetchErr)
+			continue
+		}
+
+		procMap, ok := procJSON.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		scheme, _ := procMap["scheme"].(map[string]interface{})
+		if scheme == nil {
+			scheme = make(map[string]interface{})
+			procMap["scheme"] = scheme
+		}
+		scheme["nodes"] = nodes
+
+		patched, marshalErr := json.MarshalIndent(procMap, "", "  ")
+		if marshalErr != nil {
+			logger.Warn("patchEmptyNodesInDir: failed to marshal patched process %d: %v", procID, marshalErr)
+			continue
+		}
+		if writeErr := os.WriteFile(path, patched, 0644); writeErr != nil {
+			logger.Warn("patchEmptyNodesInDir: failed to write patched file %s: %v", path, writeErr)
+			continue
+		}
+		logger.Warn("patchEmptyNodesInDir: injected %d draft nodes into process %d (%s)",
+			len(nodes), procID, entry.Name())
 	}
 	return nil
 }

--- a/plugins/corezoid/mcp-server/samples/passthrough_escalation.json
+++ b/plugins/corezoid/mcp-server/samples/passthrough_escalation.json
@@ -1,0 +1,79 @@
+{
+  "obj_type": 1,
+  "obj_id": 0,
+  "title": "Passthrough Escalation Example",
+  "scheme": {
+    "nodes": [
+      {
+        "id": "aabbccddaabbccddaabbcc01",
+        "obj_type": 1,
+        "condition": {
+          "logics": [
+            {"type": "go", "to_node_id": "aabbccddaabbccddaabbcc02"}
+          ],
+          "semaphors": []
+        },
+        "title": "Start",
+        "x": 0, "y": 0,
+        "extra": "{\"modeForm\":\"collapse\",\"icon\":\"\"}"
+      },
+      {
+        "id": "aabbccddaabbccddaabbcc02",
+        "obj_type": 0,
+        "condition": {
+          "logics": [
+            {
+              "type": "api_rpc",
+              "conv_id": 12345,
+              "user_id": 1,
+              "group": "",
+              "extra": {},
+              "extra_type": {},
+              "err_node_id": "aabbccddaabbccddaabbcc03"
+            },
+            {"type": "go", "to_node_id": "aabbccddaabbccddaabbcc05"}
+          ],
+          "semaphors": []
+        },
+        "title": "Call Payment",
+        "x": 0, "y": 200,
+        "extra": "{\"modeForm\":\"expand\",\"icon\":\"\"}"
+      },
+      {
+        "id": "aabbccddaabbccddaabbcc03",
+        "obj_type": 3,
+        "condition": {
+          "logics": [
+            {"type": "go", "to_node_id": "aabbccddaabbccddaabbcc04"}
+          ],
+          "semaphors": []
+        },
+        "title": "",
+        "x": 300, "y": 200,
+        "extra": "{\"modeForm\":\"collapse\",\"icon\":\"error\"}"
+      },
+      {
+        "id": "aabbccddaabbccddaabbcc04",
+        "obj_type": 2,
+        "condition": {
+          "logics": [],
+          "semaphors": []
+        },
+        "title": "rpc_error",
+        "x": 300, "y": 400,
+        "extra": "{\"modeForm\":\"collapse\",\"icon\":\"error\"}"
+      },
+      {
+        "id": "aabbccddaabbccddaabbcc05",
+        "obj_type": 2,
+        "condition": {
+          "logics": [],
+          "semaphors": []
+        },
+        "title": "Final",
+        "x": 0, "y": 400,
+        "extra": "{\"modeForm\":\"collapse\",\"icon\":\"success\"}"
+      }
+    ]
+  }
+}

--- a/plugins/corezoid/mcp-server/tools_registry.go
+++ b/plugins/corezoid/mcp-server/tools_registry.go
@@ -159,6 +159,70 @@ var toolRegistry = []mcpTool{
 		},
 	},
 	{
+		Name:        "show-folder",
+		Description: "Show metadata for a single Corezoid folder: title, obj_type (0 normal, 2 project, 3 stage), parent folder ID and parent type.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"folder_id": map[string]interface{}{
+					"type":        "integer",
+					"description": "Corezoid folder ID to show",
+				},
+			},
+			"required": []string{"folder_id"},
+		},
+	},
+	{
+		Name:        "list-folders",
+		Description: "List the immediate children of a Corezoid folder (subfolders + processes + state diagrams). Lighter than pull-folder — does not write anything to disk.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"folder_id": map[string]interface{}{
+					"type":        "integer",
+					"description": "Corezoid folder ID whose children to list",
+				},
+			},
+			"required": []string{"folder_id"},
+		},
+	},
+	{
+		Name:        "modify-folder",
+		Description: "Rename a Corezoid folder and/or update its description. At least one of title or description must be supplied.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"folder_id": map[string]interface{}{
+					"type":        "integer",
+					"description": "Corezoid folder ID to modify",
+				},
+				"title": map[string]interface{}{
+					"type":        "string",
+					"description": "New folder title",
+				},
+				"description": map[string]interface{}{
+					"type":        "string",
+					"description": "New folder description",
+				},
+			},
+			"required": []string{"folder_id"},
+		},
+	},
+	{
+		Name:        "delete-folder",
+		Description: "Move a Corezoid folder to the recycle bin (Trash). Can be restored from the Corezoid UI.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"folder_id": map[string]interface{}{
+					"type":        "integer",
+					"description": "Corezoid folder ID to delete",
+				},
+			},
+			"required": []string{"folder_id"},
+		},
+	},
+	{
 		Name:        "create-alias",
 		Description: "Create a short alias for a Corezoid process.",
 		InputSchema: map[string]interface{}{

--- a/plugins/corezoid/skills/corezoid-create/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-create/SKILL.md
@@ -108,7 +108,7 @@ Produce a valid `.conv.json` file.
 
 ### Core rules
 
-- Node IDs must be unique 24-character hex strings: `^[0-9a-f]{24}$`
+- Node IDs must be unique 24-character hex strings: `^[0-9a-f]{24}$`. These are **temporary placeholders** for new nodes — on `push-process` Corezoid reassigns its own canonical IDs (and rewires references within the push). Run `pull-process` after pushing to get the canonical IDs before any further edits. See [Node ID Lifecycle](${CLAUDE_PLUGIN_ROOT}/docs/process/process-development-guide.md#node-id-lifecycle-server-assignment--stability-on-push).
 - Connect nodes only through the `go` field
 - Every node that can fail must have `err_node_id` pointing to a dedicated error node
 - All constants (URLs, tokens, IDs) must be Corezoid variables — never hardcoded:

--- a/plugins/corezoid/skills/corezoid-create/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-create/SKILL.md
@@ -110,7 +110,7 @@ Produce a valid `.conv.json` file.
 
 - Node IDs must be unique 24-character hex strings: `^[0-9a-f]{24}$`. These are **temporary placeholders** for new nodes — on `push-process` Corezoid reassigns its own canonical IDs (and rewires references within the push). Run `pull-process` after pushing to get the canonical IDs before any further edits. See [Node ID Lifecycle](${CLAUDE_PLUGIN_ROOT}/docs/process/process-development-guide.md#node-id-lifecycle-server-assignment--stability-on-push).
 - Connect nodes only through the `go` field
-- Every node that can fail must have `err_node_id` pointing to a dedicated error node
+- Every node that can fail must have `err_node_id` — point it **directly at a Final Error node** (`obj_type: 2`) unless the error path needs logic (reply to caller, retry routing). Never create an Escalation node (`obj_type: 3`) that only contains a bare `go` — that is a passthrough anti-pattern flagged by `lint-process`
 - All constants (URLs, tokens, IDs) must be Corezoid variables — never hardcoded:
   1. Check for existing variables: read `_ENV_VARS_.json` (from `pull-folder`) or `.processes/variables.json` (from this session)
   2. Create a new variable if needed: call MCP tool **`create-variable`** with `name`, `description`, `value`

--- a/plugins/corezoid/skills/corezoid-create/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-create/SKILL.md
@@ -160,6 +160,7 @@ Use the `Read` tool to load these files when specific node or validation details
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/call-process-node.md` | Call a Process node, semaphores, cross-folder calls |
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/reply-to-process-node.md` | Reply formats, object stringification |
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/api-call-node.md` | HTTP API call configuration |
+| `${CLAUDE_PLUGIN_ROOT}/docs/nodes/delay-node.md` | Delay/timer node; 30s limit is static-literal only — dynamic absolute-timestamp `value` for scheduled or sub-30s delays |
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/end-node.md` | End node success/error configuration |
 | `${CLAUDE_PLUGIN_ROOT}/docs/process/process-json-validation.md` | Validation rules and common errors |
 | `${CLAUDE_PLUGIN_ROOT}/docs/process/error-handling.md` | Error handling patterns |

--- a/plugins/corezoid/skills/corezoid-create/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-create/SKILL.md
@@ -155,7 +155,10 @@ Use the `Read` tool to load these files when specific node or validation details
 
 | Path | When to read |
 |---|---|
-| `${CLAUDE_PLUGIN_ROOT}/docs/node-structures.md` | JSON schemas for all node types (canonical reference) |
+| `${CLAUDE_PLUGIN_ROOT}/docs/node-structures.md` | JSON schemas for all node types + full Logics fields reference (canonical) |
+| `${CLAUDE_PLUGIN_ROOT}/docs/nodes/set-parameters-built-in-functions.md` | Built-in functions: `$.math`, `$.date`, `$.random`, `$.sha1_hex`, `$.md5_hex`, `$.base64_encode`, `$.unixtime`, `$.map`, `$.filter` |
+| `${CLAUDE_PLUGIN_ROOT}/docs/nodes/set-parameters-dynamic-values.md` | Dynamic values: `{{var}}`, `{{node[id].count}}`, `{{node[id].SumID}}`, `{{conv[@alias].ref[...]}}`, `{{env_var[@name].key[1]}}` |
+| `${CLAUDE_PLUGIN_ROOT}/docs/tasks/task-metadata.md` | Global `root.*` fields: `root.task_id`, `root.ref`, `root.conv_id`, `root.node_id`, `root.prev_node_id`, `root.user_id`, `root.change_time`, `root.create_time` |
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/code-node.md` | Code node details and available JS libraries |
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/call-process-node.md` | Call a Process node, semaphores, cross-folder calls |
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/reply-to-process-node.md` | Reply formats, object stringification |

--- a/plugins/corezoid/skills/corezoid-edit/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-edit/SKILL.md
@@ -45,7 +45,7 @@ Apply changes to `PROCESS_PATH`.
 
 - Connect nodes only through the `go` field
 - Every node that can fail must have `err_node_id` pointing to a dedicated error node
-- Node IDs must be unique 24-character hex strings: `^[0-9a-f]{24}$`
+- Node IDs must be unique 24-character hex strings: `^[0-9a-f]{24}$`. **Always `pull-process` before editing** and reference only canonical, server-assigned IDs — IDs you invented in a previous push were reassigned by the server and no longer exist. New nodes added now get placeholder IDs that the server will likewise reassign on push. Existing nodes' IDs are preserved. See [Node ID Lifecycle](${CLAUDE_PLUGIN_ROOT}/docs/process/process-development-guide.md#node-id-lifecycle-server-assignment--stability-on-push).
 - Use descriptive node `title` values (e.g., "Call Payment Process", not "RPC")
 - Place new nodes below existing ones, incrementing `y` by 200–250px
 - Position error nodes to the right of their parent (`x + 300`)

--- a/plugins/corezoid/skills/corezoid-edit/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-edit/SKILL.md
@@ -44,7 +44,7 @@ Apply changes to `PROCESS_PATH`.
 ### Core rules
 
 - Connect nodes only through the `go` field
-- Every node that can fail must have `err_node_id` pointing to a dedicated error node
+- Every node that can fail must have `err_node_id` — point it **directly at a Final Error node** (`obj_type: 2`) unless the error path needs logic (reply to caller, retry routing). Never create an Escalation node (`obj_type: 3`) that only contains a bare `go` — that is a passthrough anti-pattern flagged by `lint-process`
 - Node IDs must be unique 24-character hex strings: `^[0-9a-f]{24}$`. **Always `pull-process` before editing** and reference only canonical, server-assigned IDs — IDs you invented in a previous push were reassigned by the server and no longer exist. New nodes added now get placeholder IDs that the server will likewise reassign on push. Existing nodes' IDs are preserved. See [Node ID Lifecycle](${CLAUDE_PLUGIN_ROOT}/docs/process/process-development-guide.md#node-id-lifecycle-server-assignment--stability-on-push).
 - Use descriptive node `title` values (e.g., "Call Payment Process", not "RPC")
 - Place new nodes below existing ones, incrementing `y` by 200–250px

--- a/plugins/corezoid/skills/corezoid-edit/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-edit/SKILL.md
@@ -109,7 +109,7 @@ Use the `Read` tool to load these files when specific node or validation details
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/api-call-node.md` | HTTP API call configuration |
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/end-node.md` | End node success/error configuration |
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/condition-node.md` | Condition node (branching logic) |
-| `${CLAUDE_PLUGIN_ROOT}/docs/nodes/delay-node.md` | Delay node (timers and waiting) |
+| `${CLAUDE_PLUGIN_ROOT}/docs/nodes/delay-node.md` | Delay node (timers and waiting); 30s limit is static-literal only — dynamic absolute-timestamp `value` for scheduled or sub-30s delays |
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/copy-task-node.md` | Copy Task node (task duplication) |
 | `${CLAUDE_PLUGIN_ROOT}/docs/process/process-json-validation.md` | Validation rules and common errors |
 | `${CLAUDE_PLUGIN_ROOT}/docs/process/error-handling.md` | Error handling patterns (hardware vs software errors) |

--- a/plugins/corezoid/skills/corezoid-edit/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-edit/SKILL.md
@@ -102,7 +102,10 @@ Use the `Read` tool to load these files when specific node or validation details
 
 | Path | When to read |
 |---|---|
-| `${CLAUDE_PLUGIN_ROOT}/docs/node-structures.md` | JSON schemas for all node types (canonical reference) |
+| `${CLAUDE_PLUGIN_ROOT}/docs/node-structures.md` | JSON schemas for all node types + full Logics fields reference (canonical) |
+| `${CLAUDE_PLUGIN_ROOT}/docs/nodes/set-parameters-built-in-functions.md` | Built-in functions: `$.math`, `$.date`, `$.random`, `$.sha1_hex`, `$.md5_hex`, `$.base64_encode`, `$.unixtime`, `$.map`, `$.filter` |
+| `${CLAUDE_PLUGIN_ROOT}/docs/nodes/set-parameters-dynamic-values.md` | Dynamic values: `{{var}}`, `{{node[id].count}}`, `{{node[id].SumID}}`, `{{conv[@alias].ref[...]}}`, `{{env_var[@name].key[1]}}` |
+| `${CLAUDE_PLUGIN_ROOT}/docs/tasks/task-metadata.md` | Global `root.*` fields: `root.task_id`, `root.ref`, `root.conv_id`, `root.node_id`, `root.prev_node_id`, `root.user_id`, `root.change_time`, `root.create_time` |
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/code-node.md` | Code node details and available JS libraries |
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/call-process-node.md` | Call a Process node, semaphores, cross-folder calls |
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/reply-to-process-node.md` | Reply formats, object stringification |

--- a/plugins/corezoid/skills/corezoid-stage-scan/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-stage-scan/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: corezoid-stage-scan
+description: >
+  Pre-merge / pre-deploy static validator for exported Corezoid stages. Use when
+  the user has one or more exported stage files (.zip) or extracted stage folders
+  and wants to find, BEFORE merging or deploying, what will break: processes that
+  are not active, empty/battered processes, broken intra-process node links
+  (to_node_id / err_node_id pointing at a missing node), and broken or inactive
+  cross-process conv_id references (api_rpc / api_copy / api_get_task). Activate
+  when the user says "scan stage", "check stage before merge", "validate export",
+  "why does the merge fail", "find broken links", "find non-active processes",
+  "Can't create more start nodes", "Only active process can be used",
+  "referenced node ... does not exist", "Access user to conveyor is denied",
+  "проверь стейдж", "почему не мерджится", "битые ссылки", "найди неактивные процессы",
+  or attaches two stage ZIPs and asks what is wrong with the merge.
+---
+
+# Scan a Corezoid Stage (pre-merge / pre-deploy validation)
+
+You statically validate **exported** Corezoid stages — `.zip` exports or extracted
+folders — without touching the live environment. This is the fast first answer to
+"why does my merge / deploy fail" and the safe pre-flight check before any
+cross-stage merge.
+
+The check is grep/AST-level over every `*.conv.json` in the export. It is fully
+offline and deterministic, so it works on attachments (e.g. files pulled from a
+Jira ticket) even with no Corezoid credentials.
+
+## What it detects
+
+These map 1:1 to the errors the platform shows in the merge **Errors list** dialog:
+
+| Finding | Platform error it explains |
+|---|---|
+| `[1]` process `status != active` | `Only active process can be used` |
+| `[1b]` empty (no-nodes) process | battered / half-recreated shell; deploy of an empty conv |
+| `[2a]` broken **node** link (`to_node_id` / `err_node_id` / `go_to` → missing node in same process) | `Key 'to_node_id'. 'referenced node X does not exist'` |
+| `[2b]` broken / inactive **conv_id** ref (`api_rpc` / `api_copy` / `api_get_task` → process missing from stage or not active) | `Only active process can be used` · `Key 'conv_id'. 'Access user to conveyor is denied in logic'` |
+| `[2c]` `api_get_task.node_id` missing in the **target** process | invalid get-task node reference |
+
+`{{...}}` and `@alias` conv_id references are reported as *unresolvable* (counted,
+never flagged as broken) — they resolve at deploy time against the live stage.
+
+> Note: `api_get_task.node_id` points at a node in the **target** `conv_id` process,
+> not the current one — the scanner checks it cross-process, so it does not produce
+> false "missing node" positives for get-task logics.
+
+## How to run
+
+The skill ships a self-contained Python 3 scanner (stdlib only — `zipfile`, `json`,
+`re`; no install). Run it directly on the export(s):
+
+```bash
+python3 "${CLAUDE_PLUGIN_ROOT}/skills/corezoid-stage-scan/scripts/scan_stage.py" \
+  <stage.zip | stage_dir> [more ...] [--json report.json] [--quiet]
+```
+
+- One input → scans that stage.
+- Two inputs → scans both (e.g. **source** and **target** of a merge) and prints a
+  report per stage so you can compare.
+- `--json` writes a machine-readable report (array if multiple inputs).
+- Exit code `1` if any blocker is found, `0` if clean → drop it into CI before merge.
+
+Every finding carries both `path` (full file path inside the export) and `folder` (the
+human-readable folder location in the tree, e.g. `4570_CRM / 4526_Push: Pin block`), so you
+can always tell the user **where** to find the object. When reporting back, include the folder
+for each `conv_id` — "what's broken" without "where it is" is not actionable. Exported folder
+names keep their `id_` prefix (and may show mojibake for non-ASCII); the folder id always locates
+the object even if the display name is garbled.
+
+Pass the stage exports as positional args. If the user attached ZIPs to a ticket,
+download them first, then point the scanner at the local files.
+
+## Workflow
+
+1. **Gather inputs.** Identify the exported stage file(s). For a merge problem ask
+   for / locate **both** the source (откуда) and target (куда) exports — most
+   merge failures are explained by comparing the two.
+2. **Run the scanner** on each (or both at once).
+3. **Map findings to the user's symptom.** If they quoted a specific error, point at
+   the exact `conv_id` / node from the matching section above.
+4. **Recommend the fix** per finding:
+   - `status != active` → set the process `active`, or delete it if unused. Do this on
+     **both** stages so the merge sees a consistent state.
+   - empty / battered process → deploy real content or delete the shell.
+   - broken node link → re-point or remove the dangling `to_node_id` / `err_node_id`.
+     If the export is internally consistent but the **live** stage still errors, the
+     live process is in a half-merged state — re-deploy or roll back that one process
+     on the environment (a stale merge that was never rolled back).
+   - broken / inactive conv_id ref → fix the target (create / activate it, or point to
+     the correct existing process / alias). If the error is
+     `Access user to conveyor is denied`, the referenced object is owned by a removed
+     user — reassign ownership to a live account.
+5. **Re-export and re-scan** after fixes; merge only when the scan is clean on both.
+
+## Prevent recurrence (advise the user)
+
+- Always **roll back** a failed or aborted merge — never leave processes in merge state.
+- Avoid **cross-version** merges (newer-version structures into an older `capi` validate
+  differently). Align versions first.
+- Run this scan in CI / before every merge as a gate (`--quiet`, non-zero exit).
+
+## Notes
+
+- Read-only and offline; it never calls the API or mutates anything.
+- Folder/file names in exports may show garbled non-ASCII (UTF-8 shown as latin-1) —
+  cosmetic only; matching is by `conv_id` / `uuid`, not by name.
+- The export schema this relies on: top-level `status`, `obj_id`, `uuid`, `conv_type`,
+  and `scheme.nodes[].condition.logics[]` with `type`, `to_node_id`, `err_node_id`,
+  `conv_id`, `node_id`.

--- a/plugins/corezoid/skills/corezoid-stage-scan/scripts/scan_stage.py
+++ b/plugins/corezoid/skills/corezoid-stage-scan/scripts/scan_stage.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""
+scan_stage.py — pre-merge / pre-deploy static validator for exported Corezoid stages.
+
+Detects the defect classes that block a stage merge or deploy on the Corezoid
+platform, without touching the live environment:
+
+  [1]  status != active           processes/diagrams  -> "Only active process can be used"
+  [1b] empty (no-nodes) processes (battered / recreated shells)
+  [2a] broken intra-process node links (to_node_id / err_node_id / go_to pointing at a
+       node id absent from the SAME process)  -> "Key 'to_node_id'. 'referenced node X does not exist'"
+  [2b] broken / inactive cross-process conv_id references (api_rpc / api_copy / api_get_task
+       conv_id pointing at a process missing from the stage, or one that is not active)
+       -> "Only active process can be used" / "Access user to conveyor is denied in logic"
+  [2c] api_get_task.node_id absent in the TARGET conv_id process
+
+Input may be a .zip export, an extracted directory, or several of them (compare two stages).
+Aliases ({{...}} / @alias conv_id) are reported as "unresolvable", never as broken,
+because they resolve at deploy time against the live stage.
+
+Usage:
+  scan_stage.py PATH [PATH ...] [--label NAME] [--json OUT.json] [--quiet]
+
+Examples:
+  scan_stage.py stage_1305.zip
+  scan_stage.py ./extracted_stage_dir --json report.json
+  scan_stage.py source_735.zip target_1305.zip      # scan both, one report each
+
+Exit code: 0 if no blockers found across all inputs, 1 otherwise (CI-friendly).
+"""
+import argparse, json, os, re, sys, glob, zipfile, tempfile, collections
+
+HEX24 = re.compile(r'^[0-9a-f]{24}$')
+DYN = re.compile(r'\{\{|^@')
+NODE_LINK_FIELDS = ('to_node_id', 'err_node_id', 'go_to', 'goto')
+CONV_REF_LOGICS = ('api_rpc', 'api_copy', 'api_get_task')
+
+
+def is_static_node(v):
+    return isinstance(v, str) and bool(HEX24.match(v))
+
+
+def is_dynamic(v):
+    return isinstance(v, str) and bool(DYN.search(v))
+
+
+def folder_of(rel_path):
+    """Human-readable folder location (where to find the object in the tree).
+
+    Drops the filename and the ".folder" suffix from each path segment, so
+    "4570_CRM.folder/4526_Push.folder/9009_x.conv.json" -> "4570_CRM / 4526_Push".
+    Exported names may carry mojibake (UTF-8 shown as latin-1); the id_ prefix
+    is kept so the object is always locatable by folder id.
+    """
+    parts = rel_path.split('/')[:-1]
+    # drop the export wrapper segments ("<name>.zip", "<id>_<name>.stage")
+    parts = [p for p in parts if not (p.endswith('.zip') or p.endswith('.stage'))]
+    return ' / '.join(p[:-len('.folder')] if p.endswith('.folder') else p
+                      for p in parts) or '(stage root)'
+
+
+def collect_conv_files(path):
+    """Return (root_dir, [conv.json paths]). Extracts zips to a temp dir."""
+    tmp = None
+    if path.lower().endswith('.zip'):
+        tmp = tempfile.mkdtemp(prefix='czscan_')
+        with zipfile.ZipFile(path) as z:
+            z.extractall(tmp)
+        root = tmp
+    elif os.path.isdir(path):
+        root = path
+    else:
+        raise SystemExit(f"error: {path} is neither a .zip nor a directory")
+    files = sorted(glob.glob(os.path.join(root, '**', '*.conv.json'), recursive=True))
+    return root, files, tmp
+
+
+def scan(path, label=None):
+    label = label or os.path.basename(path.rstrip('/')).replace('.zip', '')
+    root, files, tmp = collect_conv_files(path)
+
+    procs = {}            # obj_id -> meta
+    parse_errors = []
+    for f in files:
+        try:
+            d = json.load(open(f, encoding='utf-8'))
+        except Exception as e:
+            parse_errors.append((os.path.relpath(f, root), str(e)))
+            continue
+        if not isinstance(d, dict):
+            continue
+        nodes = (d.get('scheme') or {}).get('nodes') or []
+        procs[d.get('obj_id')] = {
+            'obj_id': d.get('obj_id'),
+            'status': d.get('status'),
+            'conv_type': d.get('conv_type'),
+            'title': d.get('title'),
+            'uuid': d.get('uuid'),
+            'path': os.path.relpath(f, root),
+            'node_ids': {n.get('id') for n in nodes if isinstance(n, dict)},
+            'nodes': nodes,
+        }
+
+    active_ids = {i for i, m in procs.items() if m['status'] == 'active'}
+    inactive = [m for m in procs.values() if m['status'] != 'active']
+    empty = [m for m in procs.values()
+             if m['conv_type'] in ('process', 'state') and not m['node_ids']]
+
+    broken_node_links, broken_conv_refs, broken_gettask, dynamic_refs = [], [], [], []
+
+    for m in procs.values():
+        valid = m['node_ids']
+        for n in m['nodes']:
+            if not isinstance(n, dict):
+                continue
+            nid = n.get('id')
+            for lg in ((n.get('condition') or {}).get('logics') or []):
+                if not isinstance(lg, dict):
+                    continue
+                t = lg.get('type')
+                # [2a] intra-process node links
+                for fld in NODE_LINK_FIELDS:
+                    tgt = lg.get(fld)
+                    if is_static_node(tgt) and tgt not in valid:
+                        broken_node_links.append(
+                            {'conv_id': m['obj_id'], 'node': nid, 'type': t,
+                             'field': fld, 'target': tgt, 'path': m['path']})
+                # [2b]/[2c] cross-process conv_id references
+                if t in CONV_REF_LOGICS:
+                    cv = lg.get('conv_id')
+                    if cv is None:
+                        continue
+                    if is_dynamic(cv):
+                        dynamic_refs.append(
+                            {'conv_id': m['obj_id'], 'node': nid, 'type': t,
+                             'ref': cv, 'path': m['path']})
+                        continue
+                    try:
+                        cvi = int(cv)
+                    except (TypeError, ValueError):
+                        dynamic_refs.append(
+                            {'conv_id': m['obj_id'], 'node': nid, 'type': t,
+                             'ref': cv, 'path': m['path']})
+                        continue
+                    if cvi not in procs:
+                        broken_conv_refs.append(
+                            {'conv_id': m['obj_id'], 'node': nid, 'type': t,
+                             'target_conv': cvi, 'reason': 'missing (not in stage)',
+                             'path': m['path']})
+                    else:
+                        if procs[cvi]['status'] != 'active':
+                            broken_conv_refs.append(
+                                {'conv_id': m['obj_id'], 'node': nid, 'type': t,
+                                 'target_conv': cvi,
+                                 'reason': f"target status={procs[cvi]['status']}",
+                                 'path': m['path']})
+                        if t == 'api_get_task':
+                            tn = lg.get('node_id')
+                            if is_static_node(tn) and tn not in procs[cvi]['node_ids']:
+                                broken_gettask.append(
+                                    {'conv_id': m['obj_id'], 'node': nid,
+                                     'target_conv': cvi, 'target_node': tn,
+                                     'path': m['path']})
+
+    report = {
+        'stage': label,
+        'totals': {'parsed': len(procs), 'active': len(active_ids),
+                   'parse_errors': len(parse_errors)},
+        'inactive': [{**{k: m[k] for k in ('obj_id', 'status', 'conv_type', 'title', 'path')},
+                      'folder': folder_of(m['path'])}
+                     for m in sorted(inactive, key=lambda x: (str(x['status']), x['obj_id'] or 0))],
+        'empty': [{**{k: m[k] for k in ('obj_id', 'status', 'title', 'path')},
+                   'folder': folder_of(m['path'])}
+                  for m in sorted(empty, key=lambda x: x['obj_id'] or 0)],
+        'broken_node_links': broken_node_links,
+        'broken_conv_refs': broken_conv_refs,
+        'broken_gettask': broken_gettask,
+        'dynamic_refs_count': len(dynamic_refs),
+        'parse_errors': [{'path': p, 'error': e} for p, e in parse_errors],
+    }
+    # annotate every finding with its folder location ("where to find it")
+    for key in ('broken_node_links', 'broken_conv_refs', 'broken_gettask'):
+        for x in report[key]:
+            x['folder'] = folder_of(x['path'])
+    return report
+
+
+def distinct(rows, key='conv_id'):
+    return sorted({r[key] for r in rows})
+
+
+def print_report(r, quiet=False):
+    print(f"\n{'='*78}\nSTAGE: {r['stage']}\n{'='*78}")
+    t = r['totals']
+    print(f"parsed={t['parsed']}  active={t['active']}  parse_errors={t['parse_errors']}")
+
+    print(f"\n[1] status != active : {len(r['inactive'])} "
+          f"-> {distinct(r['inactive'], 'obj_id')}")
+    if not quiet:
+        for m in r['inactive']:
+            print(f"    id={m['obj_id']:<7} {str(m['status']):<8} {m['conv_type']:<8} "
+                  f"{m['title']!r}\n        folder: {m['folder']}\n        file:   {m['path']}")
+
+    print(f"\n[1b] empty (no nodes): {len(r['empty'])} "
+          f"-> {distinct(r['empty'], 'obj_id')}")
+    if not quiet:
+        for m in r['empty']:
+            print(f"    id={m['obj_id']:<7} {str(m['status']):<8} {m['title']!r}"
+                  f"\n        folder: {m['folder']}")
+
+    bnl = r['broken_node_links']
+    print(f"\n[2a] broken node links: {len(bnl)} link(s) in "
+          f"{len(distinct(bnl))} process(es) -> {distinct(bnl)}")
+    if not quiet:
+        for x in bnl:
+            print(f"    conv={x['conv_id']:<7} node={x['node']} "
+                  f"{x['type']}.{x['field']} -> {x['target']}  MISSING"
+                  f"\n        folder: {x['folder']}")
+
+    bcr = r['broken_conv_refs']
+    print(f"\n[2b] broken/inactive conv refs: {len(bcr)} in "
+          f"{len(distinct(bcr))} process(es) -> {distinct(bcr)}")
+    if not quiet:
+        for x in bcr:
+            print(f"    conv={x['conv_id']:<7} node={x['node']} {x['type']} -> "
+                  f"conv_id={x['target_conv']}  [{x['reason']}]\n        folder: {x['folder']}")
+
+    bgt = r['broken_gettask']
+    print(f"\n[2c] api_get_task node missing in target: {len(bgt)}")
+    if not quiet:
+        for x in bgt:
+            print(f"    conv={x['conv_id']:<7} -> conv {x['target_conv']} "
+                  f"node {x['target_node']} MISSING\n        folder: {x['folder']}")
+
+    print(f"\n(unresolvable dynamic/@alias conv refs, not checked: {r['dynamic_refs_count']})")
+
+
+def has_blockers(r):
+    return bool(r['inactive'] or r['empty'] or r['broken_node_links']
+                or r['broken_conv_refs'] or r['broken_gettask'] or r['totals']['parse_errors'])
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('paths', nargs='+', help='stage .zip file(s) or extracted dir(s)')
+    ap.add_argument('--label', help='label for a single input (default: filename)')
+    ap.add_argument('--json', dest='json_out', help='write combined JSON report to this file')
+    ap.add_argument('--quiet', action='store_true', help='summary counts only')
+    args = ap.parse_args()
+
+    reports = []
+    for i, p in enumerate(args.paths):
+        lbl = args.label if (args.label and len(args.paths) == 1) else None
+        r = scan(p, lbl)
+        print_report(r, quiet=args.quiet)
+        reports.append(r)
+
+    if args.json_out:
+        json.dump(reports if len(reports) > 1 else reports[0],
+                  open(args.json_out, 'w'), indent=2, ensure_ascii=False)
+        print(f"\n[written {args.json_out}]")
+
+    blockers = any(has_blockers(r) for r in reports)
+    print(f"\n{'BLOCKERS FOUND' if blockers else 'No blockers found'}.")
+    sys.exit(1 if blockers else 0)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/corezoid/skills/corezoid/SKILL.md
+++ b/plugins/corezoid/skills/corezoid/SKILL.md
@@ -124,6 +124,7 @@ For domain-specific workflows use the specialized skills:
 - `/corezoid-state-diagram-edit` — modifying an existing state diagram
 - `/corezoid-review` — auditing and analyzing a single process
 - `/corezoid-project-review` — auditing an entire project or folder (cross-process analysis)
+- `/corezoid-stage-scan` — pre-merge/pre-deploy static check of exported stage `.zip`s: non-active processes, empty/battered processes, broken node links, broken/inactive `conv_id` references (explains "Only active process can be used", "referenced node X does not exist", "Access user to conveyor is denied")
 - `/corezoid-dashboard-manager` — creating dashboards and charts for process metrics
 - `/corezoid-process-tech-writer` — documenting a process (Markdown + enriched JSON)
 - `/corezoid-alias-manager` — creating, listing, modifying, deleting, and using aliases

--- a/plugins/corezoid/skills/corezoid/SKILL.md
+++ b/plugins/corezoid/skills/corezoid/SKILL.md
@@ -137,7 +137,10 @@ Use the `Read` tool to load these files when you need deeper detail:
 
 | Path | When to read |
 |---|---|
-| `${CLAUDE_PLUGIN_ROOT}/docs/node-structures.md` | JSON schemas for all node types (canonical reference) |
+| `${CLAUDE_PLUGIN_ROOT}/docs/node-structures.md` | JSON schemas for all node types + full Logics fields reference (canonical) |
+| `${CLAUDE_PLUGIN_ROOT}/docs/nodes/set-parameters-built-in-functions.md` | Built-in functions: `$.math`, `$.date`, `$.random`, `$.sha1_hex`, `$.md5_hex`, `$.base64_encode`, `$.unixtime`, `$.map`, `$.filter` |
+| `${CLAUDE_PLUGIN_ROOT}/docs/nodes/set-parameters-dynamic-values.md` | Dynamic values: `{{var}}`, `{{node[id].count}}`, `{{node[id].SumID}}`, `{{conv[@alias].ref[...]}}`, `{{env_var[@name].key[1]}}` |
+| `${CLAUDE_PLUGIN_ROOT}/docs/tasks/task-metadata.md` | Global `root.*` fields: `root.task_id`, `root.ref`, `root.conv_id`, `root.node_id`, `root.prev_node_id`, `root.user_id`, `root.change_time`, `root.create_time` |
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/code-node.md` | Code node details and available JS libraries |
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/call-process-node.md` | Call a Process node, semaphores, cross-folder calls |
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/api-call-node.md` | HTTP API call configuration |

--- a/public/.well-known/skills/index.json
+++ b/public/.well-known/skills/index.json
@@ -8,6 +8,27 @@
       ]
     },
     {
+      "name": "corezoid-access",
+      "description": "Corezoid access-control specialist. Use when the user wants to share a process, folder, stage or project with another user / group / API key, create or delete a user group, create or rotate an API key, invite an external user, or audit who currently has access to a Corezoid object. Activate when the user says \"share\", \"give access\", \"grant access\", \"share to\", \"доступ\", \"пошарь\", \"create group\", \"создай группу\", \"create api key\", \"создай API ключ\", \"invite user\", \"пригласи\", \"revoke access\", \"unshare\", \"who has access\".",
+      "files": [
+        "https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-access/SKILL.md"
+      ]
+    },
+    {
+      "name": "corezoid-alias-manager",
+      "description": "Manages Corezoid aliases — create, list, modify, delete, link/unlink, and use aliases in process JSON. Activate when the user mentions \"alias\", \"short_name\", \"short name\", \"create alias\", \"list aliases\", \"delete alias\", \"modify alias\", \"rename alias\", \"unlink alias\", \"link alias\", \"get callback hash\", \"conv[@\", or asks how to reference a process by name instead of numeric ID. Also activate when reviewing a process that uses numeric conv_id values and the user wants to replace them with aliases.",
+      "files": [
+        "https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-alias-manager/SKILL.md"
+      ]
+    },
+    {
+      "name": "corezoid-api-connector",
+      "description": "Corezoid API connector specialist. Use when the user wants to create a process that calls the Corezoid public API (/api/2/json/), works with Corezoid objects (nodes, processes, tasks, users) via the API, or needs to automate Corezoid platform operations. Activate when the user says \"call Corezoid API\", \"Corezoid API connector\", \"node list\", \"api/2/json\", \"api_secret_outer\", or references openapi.corezoid.com operations.",
+      "files": [
+        "https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-api-connector/SKILL.md"
+      ]
+    },
+    {
       "name": "corezoid-create",
       "description": "Corezoid process creation specialist. Use when the user wants to create a new Corezoid process from scratch, build a new automation flow, design a new BPM process, or implement a new API connector. Activate when the user says \"create a process\", \"build a new flow\", \"new process\", \"design from scratch\", \"implement a connector\", \"create an automation\", or \"add a new process\".",
       "files": [
@@ -36,6 +57,13 @@
       ]
     },
     {
+      "name": "corezoid-process-optimizer",
+      "description": "Optimizes a Corezoid process JSON — reduces tact consumption by merging nodes, cleans data flow, fills missing node titles, and adds resilience patterns. Activate when the user says \"optimize\", \"improve\", \"reduce tacts\", \"merge nodes\", \"clean up process\", \"what can be improved\", \"show optimizations\", or any phrase implying they want to make a process faster, cheaper, or more readable. Two modes: plan-only (analysis + report, no changes) and auto (plan + execute immediately).",
+      "files": [
+        "https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-process-optimizer/SKILL.md"
+      ]
+    },
+    {
       "name": "corezoid-process-tech-writer",
       "description": "Documents a Corezoid process — produces a human-readable Markdown file AND enriches the process JSON with descriptions on every node and parameter. Output is designed for team wikis, internal portals, and future product integration. Activate whenever a user asks to document a process, write docs for a connector, add descriptions to a process, create documentation for a logic, describe what a process does, or any similar phrasing. Also activate when the user shares a process JSON and asks to explain it or make it self-documenting. Always produce BOTH outputs (Markdown file + enriched JSON) — never just one.",
       "files": [
@@ -54,6 +82,34 @@
       "description": "Corezoid process review and audit specialist. Use when the user wants to analyze, review, audit, or improve an existing Corezoid process. Activate when the user says \"review a process\", \"analyze\", \"check\", \"audit\", \"find issues\", \"explain this process\", \"what's wrong with\", \"optimize\", or \"check for hardcoded values\".",
       "files": [
         "https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-review/SKILL.md"
+      ]
+    },
+    {
+      "name": "corezoid-stage-scan",
+      "description": "Pre-merge / pre-deploy static validator for exported Corezoid stages. Use when the user has one or more exported stage files (.zip) or extracted stage folders and wants to find, BEFORE merging or deploying, what will break: processes that are not active, empty/battered processes, broken intra-process node links (to_node_id / err_node_id pointing at a missing node), and broken or inactive cross-process conv_id references (api_rpc / api_copy / api_get_task). Activate when the user says \"scan stage\", \"check stage before merge\", \"validate export\", \"why does the merge fail\", \"find broken links\", \"find non-active processes\", \"Can't create more start nodes\", \"Only active process can be used\", \"referenced node ... does not exist\", \"Access user to conveyor is denied\", \"проверь стейдж\", \"почему не мерджится\", \"битые ссылки\", \"найди неактивные процессы\", or attaches two stage ZIPs and asks what is wrong with the merge.",
+      "files": [
+        "https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-stage-scan/SKILL.md"
+      ]
+    },
+    {
+      "name": "corezoid-state-diagram-create",
+      "description": "Corezoid state diagram creation specialist. Use when the user wants to create a new Corezoid state diagram, build a state machine, design a status / lifecycle store, or set up a \"state\" object with conv_type \"state\". Activate when the user says \"create a state diagram\", \"build a state machine\", \"new state diagram\", \"design states\", \"track status\", \"user lifecycle\", \"состояния\", \"стейт диаграмма\", \"создать state diagram\", or mentions storing state-by-ref between processes.",
+      "files": [
+        "https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-state-diagram-create/SKILL.md"
+      ]
+    },
+    {
+      "name": "corezoid-state-diagram-edit",
+      "description": "Corezoid state diagram editing specialist. Use when the user wants to modify, update, or fix an existing Corezoid state diagram — add or remove a state, change a transition, add a side effect on transition, fix the wiring of an api_callback state node, or rework transitions. Activate when the user says \"edit a state diagram\", \"add a state\", \"remove a state\", \"change transitions\", \"fix state diagram\", \"update state machine\", \"поправить state diagram\", \"изменить состояния\", or refers to modifying a .conv.json with conv_type \"state\".",
+      "files": [
+        "https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-state-diagram-edit/SKILL.md"
+      ]
+    },
+    {
+      "name": "corezoid-variable-manager",
+      "description": "Manages Corezoid environment variables (env_var) — create, list, modify, delete, and use variables in process JSON. Activate when the user mentions \"variable\", \"env var\", \"environment variable\", \"secret\", \"create variable\", \"list variables\", \"delete variable\", \"modify variable\", \"env_var\", \"{{env_var\", or asks how to store a URL, token, API key, or any constant that should not be hardcoded in a process. Also activate when a process references {{env_var[@name]}} and the variable does not exist yet.",
+      "files": [
+        "https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-variable-manager/SKILL.md"
       ]
     },
     {

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -5,13 +5,21 @@
 ## Skills
 
 - [corezoid](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid/SKILL.md): Universal Corezoid assistant
+- [corezoid-access](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-access/SKILL.md): Corezoid access-control specialist
+- [corezoid-alias-manager](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-alias-manager/SKILL.md): Manages Corezoid aliases — create, list, modify, delete, link/unlink, and use aliases in process JSON
+- [corezoid-api-connector](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-api-connector/SKILL.md): Corezoid API connector specialist
 - [corezoid-create](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-create/SKILL.md): Corezoid process creation specialist
 - [corezoid-dashboard-manager](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-dashboard-manager/SKILL.md): Creates and manages Corezoid dashboards — adds charts (column, pie, funnel, table), binds metrics to process nodes, configures real-time mode, and sets up drill-down linking between dashboards
 - [corezoid-edit](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-edit/SKILL.md): Corezoid process editing specialist
 - [corezoid-init](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-init/SKILL.md): Corezoid environment setup specialist
+- [corezoid-process-optimizer](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-process-optimizer/SKILL.md): Optimizes a Corezoid process JSON — reduces tact consumption by merging nodes, cleans data flow, fills missing node titles, and adds resilience patterns
 - [corezoid-process-tech-writer](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-process-tech-writer/SKILL.md): Documents a Corezoid process — produces a human-readable Markdown file AND enriches the process JSON with descriptions on every node and parameter
 - [corezoid-project-review](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-project-review/SKILL.md): Corezoid project review and audit specialist
 - [corezoid-review](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-review/SKILL.md): Corezoid process review and audit specialist
+- [corezoid-stage-scan](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-stage-scan/SKILL.md): Pre-merge / pre-deploy static validator for exported Corezoid stages
+- [corezoid-state-diagram-create](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-state-diagram-create/SKILL.md): Corezoid state diagram creation specialist
+- [corezoid-state-diagram-edit](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-state-diagram-edit/SKILL.md): Corezoid state diagram editing specialist
+- [corezoid-variable-manager](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/corezoid-variable-manager/SKILL.md): Manages Corezoid environment variables (env_var) — create, list, modify, delete, and use variables in process JSON
 - [marketplace-publish-validation](https://raw.githubusercontent.com/corezoid/corezoid-ai-plugin/main/plugins/corezoid/skills/marketplace-publish-validation/SKILL.md): Corezoid  marketplace pre-publication validator
 
 ## MCP Tools


### PR DESCRIPTION
## Problem

`push-process` does not update the `title` field of an existing Corezoid process. When a user renames a process in the local `.conv.json` file and runs `push-process`, the new title is silently ignored — the Corezoid server keeps the old name. A subsequent `pull-process` confirms this by returning the original title.

## Root Cause

In `executor_process.go`, `ProcessJSON()` reads `title` from `.conv.json` but only forwards it to `CreateEmptyProcess()` when `ProcessID == 0` (new process). For existing processes there is no API call that sends the updated title to Corezoid.

## Fix

Added a `RenameProcess` call inside `ProcessJSON()` for the existing-process branch. It issues a `type: "modify"`, `obj: "conv"` API operation that includes the `title` field, mirroring the pattern already used by `SetParams` (`obj: "conv_params"`).

## How to Test

1. Create a process and pull it locally with `pull-process`.
2. Edit the `title` field in the `.conv.json` file.
3. Run `push-process` on the file.
4. Run `pull-process` again — the returned title should match the new value.

## Reported By

User renamed 12 process titles in `.conv.json` (removed `/v1/` prefix), ran `push-process` on all 12 — deployed successfully. `pull-process` then returned old title from Corezoid, confirming title was not updated.

tool: push-process | version: 2.3.5 | contact: ilya.donchenko@corezoid.com