### PR TITLE
feat(mcp): add push-folder — bulk push for a local folder of processes

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "corezoid",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "license": "MIT",
       "source": {
         "source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "corezoid",
       "source": "./plugins/corezoid",
       "description": "Corezoid BPM platform skills, MCP server, docs, and samples for Claude Code.",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "author": {
         "name": "Corezoid",
         "email": "support@corezoid.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [2.8.0]
+
+- Feat: `push-folder` MCP tool — bulk counterpart to `push-process`. Recursively walks a local directory for `*.conv.json` files and deploys each one, so a folder previously produced by `pull-folder` can be synced back to Corezoid in one call. Continues past per-file failures and reports which files succeeded or failed instead of aborting the whole batch.
+- Refactor: extracted the single-file push logic from `handlePushProcess` into a shared `pushProcessFile` helper reused by `push-folder`; `push-process` behavior is unchanged.
+- Docs: `README.md`, main `corezoid` skill, and `public/llms.txt` updated to reference `push-folder` alongside the existing `pull-folder`/`push-process` tools.
+
 ## [2.7.0]
 
 - Feat: AWS Kiro support — the same plugin payload now installs on Kiro alongside Claude Code and Codex via a symmetric overlay (`plugins/corezoid/.kiro-plugin/plugin.json`, `plugins/corezoid/.mcp.kiro.json`, `plugins/corezoid/steering/corezoid.md`, and a root-level `POWER.md` distribution manifest for kiro.dev/powers).

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ validation errors, and summarize what each process does.
 | `pull-folder`       | Export an entire folder/stage to local files       |
 | `pull-process`      | Export a single process to a `.conv.json` file     |
 | `push-process`      | Validate and deploy a `.conv.json` to Corezoid     |
+| `push-folder`       | Validate and deploy every process under a local folder |
 | `lint-process`      | Validate process structure locally (no API call)   |
 | `run-task`          | Send a task to a deployed process                  |
 | `list-node-tasks`   | List tasks currently sitting in a node             |
@@ -266,7 +267,7 @@ Claude Code / Codex
         ├── Auth          login, logout
         ├── Workspace     list-workspaces, list-stages, list-projects,
         │                 create-project, modify-project, delete-project, show-project
-        ├── Processes     pull-process, pull-folder, push-process, lint-process
+        ├── Processes     pull-process, pull-folder, push-process, push-folder, lint-process
         │                 create-process, create-folder, create-alias, create-variable
         │                 show-folder, list-folders, modify-folder, delete-folder, delete-process
         ├── Tasks         run-task, list-node-tasks, list-task-history

--- a/plugins/corezoid/.claude-plugin/plugin.json
+++ b/plugins/corezoid/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "corezoid",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Corezoid AI Documentation and Templates — skills and MCP server for working with Corezoid BPM processes.",
   "author": {
     "name": "Corezoid",

--- a/plugins/corezoid/.codex-plugin/plugin.json
+++ b/plugins/corezoid/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "corezoid",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Corezoid BPM platform assistant. Exposes Corezoid operations as an MCP server and provides skills for creating, editing, reviewing, and deploying business processes.",
   "author": {
     "name": "Corezoid",

--- a/plugins/corezoid/.kiro-plugin/plugin.json
+++ b/plugins/corezoid/.kiro-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "corezoid",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Corezoid AI Documentation and Templates — skills and MCP server for working with Corezoid BPM processes.",
   "author": {
     "name": "Corezoid",

--- a/plugins/corezoid/mcp-server/mcp_handlers.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers.go
@@ -27,6 +27,7 @@ var toolHandlers = map[string]toolHandler{
 	"pull-folder":          handlePullFolder,
 	"create-variable":      handleCreateVariable,
 	"push-process":         handlePushProcess,
+	"push-folder":          handlePushFolder,
 	"lint-process":         handleLintProcess,
 	"run-task":             handleRunTask,
 	"create-process":       handleCreateProcess,

--- a/plugins/corezoid/mcp-server/mcp_handlers_process.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_process.go
@@ -141,16 +141,28 @@ func handlePushProcess(ctx context.Context, args map[string]interface{}) (string
 		return "Error: " + err.Error(), true
 	}
 
+	procID, err := pushProcessFile(ctx, filePath)
+	if err != nil {
+		return err.Error(), true
+	}
+
+	return fmt.Sprintf("Process deployed successfully, ProcessID: %d", procID), false
+}
+
+// pushProcessFile validates a single local .conv.json file and deploys it to
+// Corezoid. It's the shared core behind both push-process (one file) and
+// push-folder (every .conv.json file under a directory tree).
+func pushProcessFile(ctx context.Context, filePath string) (int, error) {
 	procID, errMsg := extractProcessIDFromPath(filePath)
 	if errMsg != "" {
-		return errMsg, true
+		return 0, fmt.Errorf("%s", errMsg)
 	}
 
 	v := NewValidator(ctx, procID)
 
 	jsonContent, err := LoadBinFromFile(filePath)
 	if err != nil {
-		return fmt.Sprintf("Error loading JSON file: %v", err), true
+		return 0, fmt.Errorf("error loading JSON file: %v", err)
 	}
 
 	jsonContent1, messages := fixStruct(jsonContent, procID)
@@ -162,23 +174,115 @@ func handlePushProcess(ctx context.Context, args map[string]interface{}) (string
 	if jsonContent1 != jsonContent {
 		jsonContent = jsonContent1
 		if err := os.WriteFile(filePath, []byte(jsonContent), 0644); err != nil {
-			return fmt.Sprintf("Error writing fixed JSON: %v", err), true
+			return 0, fmt.Errorf("error writing fixed JSON: %v", err)
 		}
 	}
 
 	if err := ValidateJSONSchema(filePath, debug); err != nil {
-		return fmt.Sprintf("JSON schema validation failed: %v", err), true
+		return 0, fmt.Errorf("JSON schema validation failed: %v", err)
 	}
 
 	if err := v.BeforeValidation(jsonContent, nil); err != nil {
-		return fmt.Sprintf("Validation failed: %v", err), true
+		return 0, fmt.Errorf("validation failed: %v", err)
 	}
 
 	if _, err := v.ProcessJSON(filePath, jsonContent); err != nil {
-		return fmt.Sprintf("Error deploying process: %v", err), true
+		return 0, fmt.Errorf("error deploying process: %v", err)
 	}
 
-	return fmt.Sprintf("Process deployed successfully, ProcessID: %d", procID), false
+	return procID, nil
+}
+
+// handlePushFolder recursively pushes every process file (*.conv.json) found
+// under folder_path back to Corezoid. It's the bulk counterpart to
+// push-process: where push-process deploys one file, push-folder walks a
+// directory tree (typically one previously produced by pull-folder) and
+// deploys every process it finds, so a locally-edited folder can be synced
+// back in one call.
+//
+// Failures are collected per-file rather than aborting the batch — a single
+// broken process shouldn't block deploying the rest of the folder. The
+// result lists both successes and failures; isError is true if any file
+// failed, so callers can tell a partial push from a clean one.
+func handlePushFolder(ctx context.Context, args map[string]interface{}) (string, bool) {
+	dirPath := resolveDirPath(args, "folder_path")
+
+	files, err := collectConvFiles(dirPath)
+	if err != nil {
+		return fmt.Sprintf("Error scanning folder '%s': %v", dirPath, err), true
+	}
+	if len(files) == 0 {
+		return fmt.Sprintf("No .conv.json files found under %s", dirPath), true
+	}
+
+	type pushOutcome struct {
+		path string
+		id   int
+		err  error
+	}
+	outcomes := make([]pushOutcome, 0, len(files))
+	for _, f := range files {
+		if err := ctx.Err(); err != nil {
+			return fmt.Sprintf("Push cancelled after %d/%d file(s): %v", len(outcomes), len(files), err), true
+		}
+		id, err := pushProcessFile(ctx, f)
+		outcomes = append(outcomes, pushOutcome{path: f, id: id, err: err})
+	}
+
+	succeeded := 0
+	var failures []pushOutcome
+	for _, o := range outcomes {
+		if o.err == nil {
+			succeeded++
+		} else {
+			failures = append(failures, o)
+		}
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("Pushed %d/%d process(es) from %s", succeeded, len(outcomes), dirPath))
+	for _, o := range outcomes {
+		if o.err == nil {
+			sb.WriteString(fmt.Sprintf("\n  OK   %s (ProcessID: %d)", o.path, o.id))
+		}
+	}
+	for _, o := range failures {
+		sb.WriteString(fmt.Sprintf("\n  FAIL %s: %v", o.path, o.err))
+	}
+	return sb.String(), len(failures) > 0
+}
+
+// collectConvFiles walks dir recursively and returns the paths of every file
+// ending in ".conv.json", in deterministic (directory-entry-sorted) order.
+// Hidden directories (leading ".") are skipped so trees like .git or
+// .processes don't get scanned. An unreadable subdirectory is skipped with a
+// warning rather than aborting the whole walk — a permission error on one
+// folder shouldn't block pushing the rest.
+func collectConvFiles(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, e := range entries {
+		p := filepath.Join(dir, e.Name())
+		if e.IsDir() {
+			if strings.HasPrefix(e.Name(), ".") {
+				continue
+			}
+			sub, err := collectConvFiles(p)
+			if err != nil {
+				logger.Warn("push-folder: skipping unreadable directory %s: %v", p, err)
+				continue
+			}
+			out = append(out, sub...)
+			continue
+		}
+		if strings.HasSuffix(e.Name(), ".conv.json") {
+			out = append(out, p)
+		}
+	}
+	return out, nil
 }
 
 // handleLintProcess validates a local .conv.json without touching the server.

--- a/plugins/corezoid/mcp-server/mcp_handlers_test.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -98,6 +99,48 @@ func TestHandleToolCall_PushProcess_BadFilename(t *testing.T) {
 		t.Error("expected isError=true for filename without ID prefix")
 	}
 	_ = result
+}
+
+// ---- push-folder ------------------------------------------------------------
+
+func TestHandleToolCall_PushFolder_NoConvJSON(t *testing.T) {
+	resetGlobals(t)
+	dir := t.TempDir()
+	// Auth check fires before the directory scan when credentials are missing,
+	// same as push-process — see comment on TestHandleToolCall_PushProcess_BadFilename.
+	result, isErr := handleToolCall(context.Background(), "push-folder", map[string]interface{}{
+		"folder_path": dir,
+	})
+	if !isErr {
+		t.Error("expected isError=true when no .conv.json files are present")
+	}
+	_ = result
+}
+
+func TestCollectConvFiles_FindsNestedProcessesSkipsHidden(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "123_sub")
+	hidden := filepath.Join(dir, ".git")
+	os.MkdirAll(sub, 0755)    //nolint:errcheck
+	os.MkdirAll(hidden, 0755) //nolint:errcheck
+
+	os.WriteFile(filepath.Join(dir, "1_top.conv.json"), []byte(`{}`), 0644)       //nolint:errcheck
+	os.WriteFile(filepath.Join(sub, "2_nested.conv.json"), []byte(`{}`), 0644)    //nolint:errcheck
+	os.WriteFile(filepath.Join(dir, "123_sub.folder.json"), []byte(`{}`), 0644)   //nolint:errcheck
+	os.WriteFile(filepath.Join(hidden, "3_ignored.conv.json"), []byte(`{}`), 0644) //nolint:errcheck
+
+	files, err := collectConvFiles(dir)
+	if err != nil {
+		t.Fatalf("collectConvFiles: %v", err)
+	}
+	if len(files) != 2 {
+		t.Fatalf("expected 2 .conv.json files, got %d: %v", len(files), files)
+	}
+	for _, f := range files {
+		if strings.Contains(f, ".git") {
+			t.Errorf("hidden directory should have been skipped, found %s", f)
+		}
+	}
 }
 
 // ---- pull-process ----------------------------------------------------------

--- a/plugins/corezoid/mcp-server/tools_registry.go
+++ b/plugins/corezoid/mcp-server/tools_registry.go
@@ -73,6 +73,19 @@ var toolRegistry = []mcpTool{
 		},
 	},
 	{
+		Name:        "push-folder",
+		Description: "Recursively validate and deploy every process file (*.conv.json) found under a local directory back to Corezoid. Bulk counterpart to push-process — use it to sync a folder previously produced by pull-folder. Continues past per-file failures and reports which files succeeded or failed.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"folder_path": map[string]interface{}{
+					"type":        "string",
+					"description": "Relative path to the local directory to push. Defaults to the current directory.",
+				},
+			},
+		},
+	},
+	{
 		Name:        "lint-process",
 		Description: "Validate process structure. Reports orphaned nodes, noop conditions, and unused set_params.",
 		InputSchema: map[string]interface{}{

--- a/plugins/corezoid/skills/corezoid/SKILL.md
+++ b/plugins/corezoid/skills/corezoid/SKILL.md
@@ -24,6 +24,7 @@ You have access to the Corezoid API via the `corezoid` MCP server.
 | `pull-folder` | Export entire stage/folder to local directory |
 | `pull-process` | Export a single process to a file |
 | `push-process` | Validate and deploy a `.conv.json` file |
+| `push-folder` | Validate and deploy every process under a local folder (bulk push, mirrors `pull-folder`) |
 | `lint-process` | Validate process structure locally (no API needed) |
 | `run-task` | Run a task on an already-deployed process |
 | `create-process` | Create a new empty process (`conv_type: "process"`) in a folder |
@@ -162,6 +163,7 @@ Use the `Read` tool to load these files when you need deeper detail:
 - Node IDs are 24-char hex — generate with `crypto.randomBytes(12).toString('hex')`
 - Variables are workspace-scoped — check `_ENV_VARS_.json` before creating new ones
 - `push-process` is mandatory after any edit — changes exist only in memory until pushed
+- Editing several processes in the same folder? `push-folder` deploys every `.conv.json` under a directory in one call instead of pushing each file individually
 
 ## Proactive improvement/bug reporting
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -31,6 +31,7 @@ The plugin bundles a Go MCP server (`convctl`) with these tools:
 - **pull-process**: Export a single process definition to a local .conv.json file
 - **pull-folder**: Recursively export all processes from a Corezoid folder
 - **push-process**: Validate and deploy a local process file to Corezoid
+- **push-folder**: Recursively validate and deploy every process under a local folder
 - **lint-process**: Validate process structure — orphaned nodes, noop conditions, unused params
 - **run-task**: Execute a task on a deployed Corezoid process
 - **create-process**: Create a new empty process inside a Corezoid folder

--- a/scripts/generate-discovery.py
+++ b/scripts/generate-discovery.py
@@ -121,6 +121,7 @@ MCP_TOOLS = [
     ("pull-process",     "Export a single process definition to a local .conv.json file"),
     ("pull-folder",      "Recursively export all processes from a Corezoid folder"),
     ("push-process",     "Validate and deploy a local process file to Corezoid"),
+    ("push-folder",      "Recursively validate and deploy every process under a local folder"),
     ("lint-process",     "Validate process structure — orphaned nodes, noop conditions, unused params"),
     ("run-task",         "Execute a task on a deployed Corezoid process"),
     ("create-process",   "Create a new empty process inside a Corezoid folder"),


### PR DESCRIPTION
## Summary
- Adds a `push-folder` MCP tool: the bulk counterpart to the existing `pull-folder`. It recursively walks a local directory for `*.conv.json` files and deploys each one to Corezoid, so a folder previously produced by `pull-folder` can be synced back in one call.
- Extracted the single-file push logic out of `handlePushProcess` into a shared `pushProcessFile` helper, reused by both `push-process` and the new `push-folder`. `push-process` behavior and its existing tests are unchanged.
- `push-folder` continues past per-file failures instead of aborting the whole batch, and reports which files succeeded/failed.
- Docs updated: README.md MCP tools table + architecture diagram, the main `corezoid` skill, and `public/llms.txt`.
- Version bumped to 2.8.0 across plugin manifests, with a CHANGELOG entry.

## Why
The plugin already supported per-process pull/push (`pull-process`/`push-process`) and bulk pull for a whole folder (`pull-folder`), but there was no bulk push — editing several processes in a pulled folder meant pushing each file back individually. `push-folder` closes that gap while staying fully backward compatible with the existing per-process commands.

## Test plan
- [x] `go build ./...` succeeds in `plugins/corezoid/mcp-server`
- [x] `go test ./...` — new tests for `push-folder` dispatch and `collectConvFiles` (nested discovery + hidden-dir skipping) pass; pre-existing unrelated test failures on this Windows dev environment are unchanged from `main` (verified via `git stash`)
- [x] `TestToolRegistryMatchesREADME` passes with the new tool documented
- [x] Manual `push-folder` run against a live Corezoid workspace: created two throwaway test processes in a dedicated test folder, gave one valid nodes and broke the other (removed the required `status` field), then ran `push-folder` against that folder. Result: `Pushed 1/2 process(es)` — the valid process deployed successfully (server assigned canonical node IDs back into the local file), the broken one failed local JSON-schema validation *before* any API call and left the live process untouched. Test folder and both throwaway processes were then moved to Trash (reversible) to leave the workspace clean.

## Note for reviewers
While testing, noticed `create-process` names its output file `<id>_<name>.json` while `pull-folder`/`push-folder` only recognize `*.conv.json`. Not a regression from this PR (pre-existing convention gap), but worth a follow-up if useful — happy to open a separate issue/PR for it.