### PR TITLE
feat(mcp): pull workspace root Folders when no project is selected

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "corezoid",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "license": "MIT",
       "source": {
         "source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "corezoid",
       "source": "./plugins/corezoid",
       "description": "Corezoid BPM platform skills, MCP server, docs, and samples for Claude Code.",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "author": {
         "name": "Corezoid",
         "email": "support@corezoid.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## [2.7.0]
+## [2.8.0]
+
+- Feat: `corezoid-init` can pull everything under a workspace's root "Folders" — the folders/processes/state diagrams/aliases that live directly under the company, outside any Project. Declining the project picker now offers a "Pull Corezoid Folders contents?" confirmation; accepting pulls it all in one call, without needing a stage or project.
+- Feat: `pull-folder`/`list-folders`/`show-folder`/`pull-process` no longer require `COREZOID_STAGE_ID` — they take an explicit `folder_id`/`process_id`, so they now work before a stage/project has been chosen. `folder_id=0` is a special case for the workspace's virtual root.
+- Fix: `list-folders` read the wrong field for each entry's kind (a nonexistent per-item `obj` key instead of `obj_type`), so "folder" vs "conv" always showed blank in its output.
+- Fix: pulling a plain folder (as opposed to a stage) failed with "stage directory not found" — the export archive wraps content in a `*.folder` directory, not `*.stage`, which the unpacking step didn't recognize.
+- Fix: `updateEnvFile` could silently drop a write when more than one MCP server process is alive at once and both update `.env` around the same time; it now verifies the write landed and retries with a short backoff.
+- Fix: auth state (workspace, stage, token) is now refreshed from `.env` on every tool call instead of only on `login`, so a tool call handled by a different long-lived server process than the one that ran `login` no longer serves a stale, unset workspace.
+- Docs: `corezoid-init` documents the root-Folders pull path for both the native-elicitation and chat-driven setup flows, including persisting the chosen workspace immediately so a later "Folders" choice doesn't run against an unset workspace.
 
 - Feat: AWS Kiro support — the same plugin payload now installs on Kiro alongside Claude Code and Codex via a symmetric overlay (`plugins/corezoid/.kiro-plugin/plugin.json`, `plugins/corezoid/.mcp.kiro.json`, `plugins/corezoid/steering/corezoid.md`, and a root-level `POWER.md` distribution manifest for kiro.dev/powers).
 - Feat: `plugins/corezoid/scripts/install-kiro.sh` sets up an existing Kiro workspace from a cloned repo. Copies the MCP entry, symlinks steering files, and hard-copies each skill into `.kiro/skills/<name>/` while sed-substituting every `$CLAUDE_PLUGIN_ROOT` (and braced `${CLAUDE_PLUGIN_ROOT}`) token with the absolute plugin path so reference-doc paths resolve under Kiro. Idempotent.

--- a/plugins/corezoid/.claude-plugin/plugin.json
+++ b/plugins/corezoid/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "corezoid",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Corezoid AI Documentation and Templates — skills and MCP server for working with Corezoid BPM processes.",
   "author": {
     "name": "Corezoid",

--- a/plugins/corezoid/.codex-plugin/plugin.json
+++ b/plugins/corezoid/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "corezoid",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Corezoid BPM platform assistant. Exposes Corezoid operations as an MCP server and provides skills for creating, editing, reviewing, and deploying business processes.",
   "author": {
     "name": "Corezoid",

--- a/plugins/corezoid/mcp-server/credentials.go
+++ b/plugins/corezoid/mcp-server/credentials.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,8 +41,35 @@ func credentialsFilePath() (string, error) {
 }
 
 // updateEnvFile writes or updates key=value in the given .env file.
-// If the key already exists, its value is replaced; otherwise the line is appended.
+// If the key already exists, its value is replaced; otherwise the line is
+// appended. The host can keep more than one server process alive at once
+// (observed directly: up to 5 concurrently), and this read-modify-write has
+// no cross-process lock, so two processes updating different keys around
+// the same time can race — whichever writes last silently drops the other's
+// change. Retrying with a read-back-and-verify closes that window for the
+// common case without needing a real file lock.
 func updateEnvFile(path, key, value string) error {
+	const maxAttempts = 5
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if attempt > 0 {
+			// Small jittered backoff so a colliding writer's own attempt has
+			// time to finish before we retry, instead of both processes
+			// immediately re-racing each other.
+			time.Sleep(time.Duration(20+rand.Intn(60)) * time.Millisecond)
+		}
+		if err := writeEnvKey(path, key, value); err != nil {
+			return err
+		}
+		if envFileHasKeyValue(path, key, value) {
+			return nil
+		}
+		lastErr = fmt.Errorf("value did not stick — a concurrent writer likely overwrote it")
+	}
+	return fmt.Errorf("updateEnvFile: failed to persist %s after %d attempts: %w", key, maxAttempts, lastErr)
+}
+
+func writeEnvKey(path, key, value string) error {
 	var lines []string
 	if data, err := os.ReadFile(path); err == nil {
 		lines = strings.Split(string(data), "\n")
@@ -65,6 +93,21 @@ func updateEnvFile(path, key, value string) error {
 	}
 
 	return os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0600)
+}
+
+// envFileHasKeyValue reports whether path currently has key=value on disk.
+func envFileHasKeyValue(path, key, value string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	prefix := key + "="
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, prefix) {
+			return line == prefix+value
+		}
+	}
+	return false
 }
 
 // removeEnvKey removes a key from the .env file.

--- a/plugins/corezoid/mcp-server/executor_folders.go
+++ b/plugins/corezoid/mcp-server/executor_folders.go
@@ -68,17 +68,18 @@ func (v *Executor) ShowFolder(folderID int) (*FolderInfo, error) {
 // share the same response slice, distinguished by Obj ("folder" | "conv") and
 // — for convs — ConvType ("process" | "state").
 type FolderChild struct {
-	Obj      string // "folder" | "conv"
+	Obj      string // "folder" | "conv" — read from the item's obj_type string
 	ObjID    int
 	Title    string
-	ObjType  int    // for folders: 0 normal, 2 project, 3 stage
 	ConvType string // for convs only
 	Status   string
 }
 
 // ListFolder returns the immediate children of folderID (subfolders + convs).
-// The Corezoid list-folder endpoint returns a flat slice with each entry
-// tagged by "obj"; this method preserves that shape so callers can filter.
+// Each item in the response's "list" carries its own kind in a per-item
+// string field named "obj_type" ("folder" | "conv") — there is no per-item
+// "obj" key; "obj" only appears once, on the request-echoing wrapper object,
+// and always says "folder" regardless of what's inside.
 func (v *Executor) ListFolder(folderID int) ([]FolderChild, error) {
 	ops := []map[string]any{
 		{
@@ -104,7 +105,7 @@ func (v *Executor) ListFolder(folderID int) ([]FolderChild, error) {
 			continue
 		}
 		child := FolderChild{}
-		if s, ok := m["obj"].(string); ok {
+		if s, ok := m["obj_type"].(string); ok {
 			child.Obj = s
 		}
 		if f, ok := m["obj_id"].(float64); ok {
@@ -112,9 +113,6 @@ func (v *Executor) ListFolder(folderID int) ([]FolderChild, error) {
 		}
 		if s, ok := m["title"].(string); ok {
 			child.Title = s
-		}
-		if f, ok := m["obj_type"].(float64); ok {
-			child.ObjType = int(f)
 		}
 		if s, ok := m["conv_type"].(string); ok {
 			child.ConvType = s
@@ -398,16 +396,27 @@ func (v *Executor) CreateAlias(shortName string, procID, stageID int) (int, erro
 	return 0, fmt.Errorf("create alias: unexpected response format")
 }
 
-// listAliasesByStage returns a map of short_name -> obj_id for all aliases in the given stage.
-func (v *Executor) listAliasesByStage(stage int) (map[string]int, error) {
-	projectID := v.GetProjectIDByStageID(stage)
+// AliasInfo describes one alias record as returned by the "list aliases" API.
+type AliasInfo struct {
+	ShortName string
+	ObjID     int
+	ObjToID   int
+	ObjToType string
+}
+
+// ListAliases returns every alias in the workspace. stage_id/project_id in
+// the request don't actually scope the result — the API returns every alias
+// in the company regardless of what's passed — so this always fetches the
+// full company-wide list; callers that only want aliases relevant to a
+// specific pull (e.g. root Folders) must filter by ObjToID themselves.
+func (v *Executor) ListAliases() ([]AliasInfo, error) {
 	ops := []map[string]any{
 		{
 			"type":       "list",
 			"obj":        "aliases",
 			"company_id": v.WorkspaceID,
-			"stage_id":   stage,
-			"project_id": projectID,
+			"stage_id":   0,
+			"project_id": 0,
 		},
 	}
 	response, err := v.req("json", ops)
@@ -422,20 +431,44 @@ func (v *Executor) listAliasesByStage(stage int) (map[string]int, error) {
 	if !ok || op["proc"] != "ok" {
 		return nil, fmt.Errorf("alias list failed")
 	}
-	result := make(map[string]int)
 	list, _ := op["list"].([]any)
+	out := make([]AliasInfo, 0, len(list))
 	for _, item := range list {
-		itemMap, ok := item.(map[string]any)
+		m, ok := item.(map[string]any)
 		if !ok {
 			continue
 		}
-		sn, _ := itemMap["short_name"].(string)
-		if sn == "" {
+		a := AliasInfo{}
+		if s, ok := m["short_name"].(string); ok {
+			a.ShortName = s
+		}
+		if s := a.ShortName; s == "" {
 			continue
 		}
-		if objID, ok := itemMap["obj_id"].(float64); ok {
-			result[sn] = int(objID)
+		if f, ok := m["obj_id"].(float64); ok {
+			a.ObjID = int(f)
 		}
+		if f, ok := m["obj_to_id"].(float64); ok {
+			a.ObjToID = int(f)
+		}
+		if s, ok := m["obj_to_type"].(string); ok {
+			a.ObjToType = s
+		}
+		out = append(out, a)
+	}
+	return out, nil
+}
+
+// listAliasesByStage returns a map of short_name -> obj_id for all aliases in
+// the workspace (see ListAliases — the API doesn't actually scope by stage).
+func (v *Executor) listAliasesByStage(stage int) (map[string]int, error) {
+	aliases, err := v.ListAliases()
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]int, len(aliases))
+	for _, a := range aliases {
+		result[a.ShortName] = a.ObjID
 	}
 	return result, nil
 }

--- a/plugins/corezoid/mcp-server/executor_mock_test.go
+++ b/plugins/corezoid/mcp-server/executor_mock_test.go
@@ -264,19 +264,7 @@ func TestCreateAlias_OK(t *testing.T) {
 }
 
 func TestListAliasesByStage_Error(t *testing.T) {
-	// GetProjectIDByStageID calls ShowFolder first; must succeed or it panics (nil-deref bug).
-	// We satisfy the ShowFolder call, then fail the alias list call.
-	call := 0
 	_, e := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
-		call++
-		if call == 1 {
-			return map[string]interface{}{
-				"request_proc": "ok",
-				"ops": []interface{}{map[string]interface{}{
-					"proc": "ok", "obj_id": float64(1), "parent_obj_id": float64(0),
-				}},
-			}
-		}
 		return map[string]interface{}{"request_proc": "fail"}
 	})
 

--- a/plugins/corezoid/mcp-server/main.go
+++ b/plugins/corezoid/mcp-server/main.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"testing"
 
 	"github.com/santhosh-tekuri/jsonschema/v6"
 )
@@ -64,6 +65,47 @@ func withAuthLock(fn func()) {
 	authStateMu.Lock()
 	defer authStateMu.Unlock()
 	fn()
+}
+
+// refreshAuthStateFromEnv re-reads .env and re-syncs the in-memory auth
+// globals from whatever it finds. Only handleLogin used to do this, which is
+// a problem: if more than one server process is alive at once (e.g. the host
+// reconnects/respawns the MCP server without killing the old one), a tool
+// call landing on a process OTHER than the one that just ran login() would
+// otherwise keep serving that process's stale startup-time snapshot forever
+// — WORKSPACE_ID looking "unset" even though .env on disk is correct. Called
+// at the top of every tool call so every process reflects the latest saved
+// config, not just the one that happened to run login most recently.
+func refreshAuthStateFromEnv() {
+	if testing.Testing() {
+		// Tests set up auth state directly (resetGlobals/setProjectAuth) and
+		// run from inside this repo, which has its own real .env a few
+		// directories up — walking up and loading it would clobber whatever
+		// mock state the test just configured.
+		return
+	}
+	findAndLoadDotEnv()
+	withAuthLock(func() {
+		if v := os.Getenv("ACCOUNT_URL"); v != "" {
+			accountURL = v
+		}
+		if v := os.Getenv("COREZOID_API_URL"); v != "" {
+			apiURL = v
+		}
+		if v := os.Getenv("WORKSPACE_ID"); v != "" {
+			workspaceID = v
+		}
+		if v := os.Getenv("COREZOID_STAGE_ID"); v != "" {
+			if id, err := strconv.Atoi(v); err == nil && id != 0 {
+				stageID = id
+			}
+		}
+		if apiToken == "" {
+			if v := os.Getenv("ACCESS_TOKEN"); v != "" {
+				apiToken = v
+			}
+		}
+	})
 }
 
 func loadDotEnv(filename string) {

--- a/plugins/corezoid/mcp-server/mcp_handlers.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers.go
@@ -105,6 +105,14 @@ var tokenOnlyTools = map[string]struct{}{
 	"modify-project":  {},
 	"delete-project":  {},
 	"show-project":    {},
+	// These take an explicit folder_id/process_id argument, so they don't need
+	// a configured COREZOID_STAGE_ID — this is what lets a user pull everything
+	// under the workspace's root "Folders" (folder_id=0) without ever picking a
+	// project/stage.
+	"list-folders": {},
+	"show-folder":  {},
+	"pull-folder":  {},
+	"pull-process": {},
 }
 
 // handleToolCall dispatches an MCP tool invocation. ctx must be non-nil — it
@@ -119,6 +127,8 @@ func handleToolCall(ctx context.Context, name string, args map[string]interface{
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	refreshAuthStateFromEnv()
 
 	switch {
 	case isInSet(name, noAuthTools):

--- a/plugins/corezoid/mcp-server/mcp_handlers_auth.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_auth.go
@@ -26,6 +26,9 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 	// write lock to keep concurrent readers consistent.
 	findAndLoadDotEnv()
 	var stageIDAtStart int
+	var rootFoldersPulled bool
+	var rootFoldersCount int
+	var rootAliasWarning string
 	withAuthLock(func() {
 		if apiToken == "" {
 			apiToken = os.Getenv("ACCESS_TOKEN")
@@ -356,34 +359,30 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 				}
 			}
 
-			// Fallback: if stage still not set, ask for stage ID directly.
+			// No project/stage picked. Offer to pull everything under the
+			// workspace's root "Folders" (folder_id=0) instead — these are
+			// the plain folders/processes/state diagrams/dashboards/aliases
+			// that live directly under the company, outside any Project.
 			if snapStageID == 0 {
-				content, action, err := elicitValues(
-					"Enter your Stage ID (root folder ID for this project):",
+				_, action, err := elicitValues(
+					"Pull Corezoid Folders contents? This exports everything under \"Folders\" at the workspace root (folders, processes, state diagrams, dashboards, aliases) — excluding Projects.",
 					map[string]interface{}{
-						"type": "object",
-						"properties": map[string]interface{}{
-							"stage_id": map[string]interface{}{
-								"type":        "string",
-								"title":       "Stage ID",
-								"description": "Root folder ID for this project (numeric)",
-							},
-						},
-						"required": []string{"stage_id"},
+						"type":       "object",
+						"properties": map[string]interface{}{},
 					},
 				)
 				if err == nil && action == "accept" {
-					if v, _ := content["stage_id"].(string); v != "" {
-						if id, err := strconv.Atoi(v); err == nil && id != 0 {
-							snapStageID = id
-							withAuthLock(func() { stageID = id })
-							os.Setenv("COREZOID_STAGE_ID", v)
-							if err := updateEnvFile(envPath, "COREZOID_STAGE_ID", v); err != nil {
-								logger.Warn("login: could not save COREZOID_STAGE_ID: %v", err)
-							}
-						}
+					count, aliasWarning, pullErr := downloadRootFoldersRecursively(ctx, ".")
+					if pullErr != nil {
+						return fmt.Sprintf("Failed to pull root Folders contents: %v", pullErr), true
 					}
+					rootFoldersPulled = true
+					rootFoldersCount = count
+					rootAliasWarning = aliasWarning
 				}
+				// Decline (or elicitation error) — do nothing further. No stage
+				// is set; the user can still work with explicit folder_id/
+				// process_id values, or re-run login later to pick a project.
 			}
 		} else {
 			// No elicitation — list projects so LLM can collect stage from user.
@@ -408,6 +407,7 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 				}
 				sb.WriteString(fmt.Sprintf("\nPlease ask the user which project to use. Call list-stages(project_id=<id>, company_id=%s) to see available stages, then ask the user to pick one and call login(workspace_id=%s, stage_id=<stage_id>).", snapWorkspaceID, snapWorkspaceID))
 			}
+			sb.WriteString("\n\nIf the user doesn't want to work inside a specific project, ask them whether to pull everything under the workspace's root \"Folders\" instead (folders, processes, state diagrams, dashboards, aliases that live directly under the company, excluding Projects). If they agree, call pull-folder(folder_id=0) and skip project/stage selection entirely — no COREZOID_STAGE_ID is needed for that.")
 			return sb.String(), false
 		}
 	}
@@ -421,6 +421,16 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 	}
 
 	msg := fmt.Sprintf("Setup complete! Configuration saved to %s.", envPath)
+	if rootFoldersPulled {
+		if rootFoldersCount == 0 {
+			msg += " No project was selected, and the workspace's root Folders came back empty. If you expected content there, this usually means WORKSPACE_ID isn't set correctly — check with list-workspaces and re-run login(workspace_id=<id>)."
+		} else {
+			msg += fmt.Sprintf(" No project was selected — pulled everything under the workspace's root Folders instead (%d item(s), excluding Projects).", rootFoldersCount)
+			if rootAliasWarning != "" {
+				msg += " " + rootAliasWarning
+			}
+		}
+	}
 	if !tokenExpiry.IsZero() {
 		msg += fmt.Sprintf(" Token expires: %s.", tokenExpiry.Format("2006-01-02 15:04"))
 	}

--- a/plugins/corezoid/mcp-server/mcp_handlers_process.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_process.go
@@ -94,11 +94,26 @@ func handlePullProcess(ctx context.Context, args map[string]interface{}) (string
 }
 
 // handlePullFolder recursively downloads a folder (stage) and all its
-// processes/subfolders into the current working directory.
+// processes/subfolders into the current working directory. folder_id 0 is
+// special-cased to mean the workspace's virtual root "Folders" (everything
+// outside any Project) — it isn't a real folder object the export endpoint
+// can address directly, so it's handled by listing + per-child export instead.
 func handlePullFolder(ctx context.Context, args map[string]interface{}) (string, bool) {
 	folderID, err := intArg(args, "folder_id")
 	if err != nil {
 		return "Error: " + err.Error(), true
+	}
+
+	if folderID == 0 {
+		count, aliasWarning, err := downloadRootFoldersRecursively(ctx, ".")
+		if err != nil {
+			return fmt.Sprintf("Error fetching root Folders: %v", err), true
+		}
+		if count == 0 {
+			return "Root Folders came back empty (0 items). If you expected content there, WORKSPACE_ID is probably not set correctly — check with list-workspaces and re-run login(workspace_id=<id>).", false
+		}
+		msg := fmt.Sprintf("Root Folders (excluding Projects) saved to current directory (%d item(s)). %s", count, aliasWarning)
+		return msg, false
 	}
 
 	v := NewValidator(ctx, 0)

--- a/plugins/corezoid/mcp-server/pull-project.go
+++ b/plugins/corezoid/mcp-server/pull-project.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"archive/zip"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -79,11 +80,15 @@ func unzipFile(src, destDir string) error {
 	return nil
 }
 
-// findStageDir looks for a directory named *.stage up to maxDepth levels deep inside root.
+// findStageDir looks for the exported object's own directory up to maxDepth
+// levels deep inside root: *.stage when exporting a stage root, *.folder when
+// exporting a plain folder — the export zip wraps either one in an outer
+// directory named after the server's own temp file (no recognizable suffix),
+// so both suffixes have to be tried.
 func findStageDir(root string, maxDepth int) (string, error) {
 	var found string
 	err := walkDepth(root, 0, maxDepth, func(path string, d os.DirEntry) bool {
-		if d.IsDir() && strings.HasSuffix(d.Name(), ".stage") {
+		if d.IsDir() && (strings.HasSuffix(d.Name(), ".stage") || strings.HasSuffix(d.Name(), ".folder")) {
 			found = path
 			return true // stop
 		}
@@ -246,6 +251,137 @@ func downloadStageRecursively(e *Executor, folderID int, filePath string) error 
 	//	}
 	//	fmt.Println("Process saved to", filePath+"/"+title+".json")
 	//}
+}
+
+// downloadRootFoldersRecursively exports everything the workspace's virtual
+// root (obj_id 0) lists as a direct child, into filePath. obj_id 0 isn't a
+// real folder/stage object — the export endpoint rejects it outright ("Object
+// stage with id 0 does not exist") — so unlike downloadStageRecursively this
+// can't fetch the whole subtree in one export call. Instead it lists the
+// direct children and handles each by kind: real folders recurse through the
+// normal per-folder export; conv items sitting loose at the root (not
+// wrapped in any folder) are exported individually, same as pull-process.
+//
+// Returns the number of direct children found, so callers can tell "root is
+// genuinely empty" apart from "something's wrong" (e.g. WORKSPACE_ID isn't
+// set, so the request silently landed in the wrong company scope) — 0 is a
+// legitimate result but a surprising one, and callers should say so instead
+// of reporting a blanket success. aliasStatus always describes what
+// happened with the aliases — found-and-written, genuinely none, or the
+// fetch failed — so the caller can say so explicitly instead of leaving
+// alias handling silent (which reads as "forgot to check" either way).
+func downloadRootFoldersRecursively(ctx context.Context, filePath string) (count int, aliasStatus string, err error) {
+	e := NewValidator(ctx, 0)
+	children, err := e.ListFolder(0)
+	if err != nil {
+		return 0, "", fmt.Errorf("failed to list root folders: %w", err)
+	}
+	for _, c := range children {
+		if err := e.checkCancel(); err != nil {
+			return 0, "", err
+		}
+		switch c.Obj {
+		case "folder":
+			// Give each root-level folder its own named subdirectory so
+			// siblings (e.g. two folders that each contain a process) don't
+			// get merged together — downloadStageRecursively otherwise
+			// unwraps folderID's own name and drops its contents straight
+			// into filePath, which is only safe for a single, standalone pull.
+			childDir := filepath.Join(filePath, fmt.Sprintf("%d_%s", c.ObjID, sanitizePathSegment(c.Title)))
+			if err := os.MkdirAll(childDir, 0755); err != nil {
+				return 0, "", fmt.Errorf("failed to create directory for folder %q (#%d): %w", c.Title, c.ObjID, err)
+			}
+			if err := downloadStageRecursively(e, c.ObjID, childDir); err != nil {
+				return 0, "", fmt.Errorf("failed to pull folder %q (#%d): %w", c.Title, c.ObjID, err)
+			}
+		case "conv":
+			if err := downloadRootConv(ctx, c.ObjID, filePath); err != nil {
+				return 0, "", fmt.Errorf("failed to pull %q (#%d): %w", c.Title, c.ObjID, err)
+			}
+		}
+	}
+
+	if len(children) > 0 {
+		aliasCount, aerr := downloadRootAliases(ctx, filePath)
+		if aerr != nil {
+			aliasStatus = fmt.Sprintf("aliases.json was not written — fetching aliases failed: %v. Re-run pull-folder(folder_id=0) to retry just the aliases.", aerr)
+			logger.Warn("downloadRootFoldersRecursively: %s", aliasStatus)
+		} else if aliasCount == 0 {
+			aliasStatus = "no aliases exist in this workspace (aliases.json not written)."
+		} else {
+			aliasStatus = fmt.Sprintf("aliases.json written with %d alias(es).", aliasCount)
+		}
+	}
+
+	return len(children), aliasStatus, nil
+}
+
+// downloadRootAliases writes aliases.json into destDir with every alias in
+// the workspace, and returns how many it found. The "Aliases" entry the
+// Corezoid UI shows alongside Folders is exactly this — the full
+// company-wide list, not scoped to Folders — and the list-aliases API
+// confirms that: stage_id/project_id in the request don't actually filter
+// anything, every alias in the company comes back regardless. So this
+// mirrors the UI 1:1 rather than trying to guess which aliases are
+// "relevant" to what else got pulled.
+func downloadRootAliases(ctx context.Context, destDir string) (int, error) {
+	e := NewValidator(ctx, 0)
+	aliases, err := e.ListAliases()
+	if err != nil {
+		return 0, fmt.Errorf("failed to list aliases: %w", err)
+	}
+	if len(aliases) == 0 {
+		return 0, nil
+	}
+
+	data, err := json.MarshalIndent(aliases, "", "  ")
+	if err != nil {
+		return 0, fmt.Errorf("failed to marshal aliases: %w", err)
+	}
+	if err := os.WriteFile(filepath.Join(destDir, "aliases.json"), data, 0644); err != nil {
+		return 0, err
+	}
+	return len(aliases), nil
+}
+
+// downloadRootConv exports a single conv (process or state diagram) that
+// lives directly under the workspace root — not inside any folder — and
+// writes it as JSON into destDir.
+func downloadRootConv(ctx context.Context, processID int, destDir string) error {
+	v := NewValidator(ctx, processID)
+	procInfo1, err := v.ExportProcess()
+	if err != nil {
+		return err
+	}
+	var procInfo interface{}
+	if arr, ok := procInfo1.([]interface{}); ok && len(arr) > 0 {
+		procInfo = arr[0]
+	} else {
+		procInfo = procInfo1
+	}
+	data, err := json.MarshalIndent(procInfo, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	fileName := fmt.Sprintf("%d.conv.json", processID)
+	if m, ok := procInfo.(map[string]interface{}); ok {
+		if title, _ := m["title"].(string); title != "" {
+			fileName = fmt.Sprintf("%d_%s.conv.json", processID, sanitizePathSegment(title))
+		}
+	}
+	return os.WriteFile(filepath.Join(destDir, fileName), data, 0644)
+}
+
+// sanitizePathSegment turns a Corezoid title into a single safe path segment:
+// spaces become underscores and any path separator embedded in the title
+// (some folders are legitimately named e.g. "Simulator / Smart Forms /
+// Filament") is replaced too, so it can't split into nested directories.
+func sanitizePathSegment(title string) string {
+	safe := strings.ReplaceAll(title, " ", "_")
+	safe = strings.ReplaceAll(safe, "/", "_")
+	safe = strings.ReplaceAll(safe, "\\", "_")
+	return safe
 }
 
 func renameFiles2Folders(filePath string) error {

--- a/plugins/corezoid/skills/corezoid-init/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-init/SKILL.md
@@ -29,6 +29,17 @@ The `login` tool handles everything automatically in sequence:
 
 When `login` returns "Setup complete", proceed to **Step 2**.
 
+### If the user declines the project picker
+
+Corezoid workspaces have two separate top-level containers, visible side-by-side in the UI sidebar: **Projects** (each with its own stages) and plain **Folders** (folders/processes/state diagrams that live directly under the workspace, outside any Project). If the user clicks **Decline** on the "Select your Corezoid project" form, `login` does not fall through to Projects/Stages — it shows one more confirmation:
+
+> "Pull Corezoid Folders contents?" — Accept / Decline
+
+- **Accept** → `login` immediately pulls everything under the workspace's root Folders (folder_id `0`) — folders, processes, state diagrams, dashboards, and aliases, excluding Projects — and finishes with "Setup complete", reporting how much it found (including whether any aliases exist). No `COREZOID_STAGE_ID` is set or needed for this mode; `pull-folder`, `pull-process`, `list-folders`, and `show-folder` all work with an explicit `folder_id`/`process_id` regardless of whether a stage is configured.
+- **Decline** → nothing happens. `login` finishes with "Setup complete" and no stage is set. Don't offer a manual Stage-ID prompt unless the user asks for one directly.
+
+Once no project/stage is selected, treat the workspace as stage-less for the rest of the session: pull further content directly with `pull-folder(folder_id=<id>)` (root Folders is `folder_id=0`), and note that stage-scoped write operations (e.g. `create-alias`) will still require a real stage/project if the user later needs them.
+
 ---
 
 ## Mode B — Elicitation not supported (chat-based collection)
@@ -49,15 +60,19 @@ The tool opens a browser for OAuth2 authentication and saves the token to `~/.co
 
 → Show the full workspace list to the user. **Ask the user to choose** — do not select automatically.
 
-→ Wait for the user's answer before proceeding.
+→ Wait for the user's answer.
+
+→ **Immediately call `login(workspace_id=<chosen_id>)`** — do this before moving on to B3, even though a full "Setup complete" isn't expected yet (no stage is set). `list-projects` and `pull-folder` don't take a workspace/company argument of their own; they read `WORKSPACE_ID` from the saved config. Skipping this step is the single most common cause of "root Folders came back empty" — `pull-folder(folder_id=0)` in B3 would run against an unset workspace.
 
 ### B3 — Select Project
 
 → Call **`list-projects(company_id=<workspace_id>)`** using the workspace the user chose.
 
-→ Show the full project list to the user. **Ask the user to choose** — do not select automatically.
+→ Show the full project list to the user, and also ask whether they'd rather skip Projects entirely and pull everything under the workspace's root **Folders** instead (folders/processes/state diagrams/dashboards/aliases that live directly under the workspace, outside any Project). **Ask the user to choose** — do not select automatically.
 
-→ Wait for the user's answer before proceeding.
+→ If the user picks "Folders" / declines to pick a project: call `pull-folder(folder_id=0)` directly — this needs only the OAuth token and `WORKSPACE_ID` (already saved in B2), no `COREZOID_STAGE_ID`. Skip B4/B5 and Step 2 entirely; the pull already happened. Note for later in the session: this workspace has no stage/project — further pulls use `pull-folder(folder_id=<id>)` / `pull-process(process_id=<id>)` directly, and stage-scoped write operations (e.g. `create-alias`) will need a real stage if the user picks one later.
+
+→ Otherwise, wait for the user's project choice before proceeding.
 
 ### B4 — Select Stage
 


### PR DESCRIPTION
Adds a root-Folders pull path to corezoid-init: declining the project picker now offers to pull everything under the workspace's root Folders (folders, processes, state diagrams, aliases) in one call, without needing a stage or project. pull-folder/list-folders/ show-folder/pull-process work before a stage is configured.

Also fixes list-folders reading the wrong field for entry kind, pulling a plain folder failing with "stage directory not found", and .env writes getting silently dropped when more than one MCP server process is alive at once.