### PR TITLE
feat: support git_call nodes in push-process

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The plugin bundles a Go MCP server that exposes Corezoid operations as MCP tools
 | `corezoid-stage-scan`          | "scan stage", "check stage before merge", "why does the merge fail" | Offline pre-merge validation of exported stage `.zip`s: non-active/empty processes, broken node links, broken/inactive `conv_id` refs |
 | `corezoid-dashboard-manager`   | "create dashboard", "add chart", "visualize metrics" | Dashboards, charts, node metrics, real-time monitoring |
 | `corezoid-process-tech-writer` | "document", "write docs", "describe process" | Markdown docs + enriched JSON with node descriptions |
+| `corezoid-gitcall`             | "git call", "gitcall", "run my code", "custom code node", "python/go/php in a process" | Custom code (Python/Go/Java/PHP/JS/…) as a git_call step — parsing, libraries, crypto, attachments; handles the container build on push |
 
 ## Design philosophy
 

--- a/plugins/corezoid/mcp-server/executor.go
+++ b/plugins/corezoid/mcp-server/executor.go
@@ -25,6 +25,10 @@ type Executor struct {
 	Debug         bool
 	Version       int
 	NewProc       bool
+	// gitCallBuildLog accumulates a human-readable build log per git_call node
+	// built during a push, so the push handler can show the user what the
+	// container build service reported (progress + result) — not just on failure.
+	gitCallBuildLog []string
 }
 
 // checkCancel returns v.Ctx.Err() if the executor's context has been

--- a/plugins/corezoid/mcp-server/executor_gitcall.go
+++ b/plugins/corezoid/mcp-server/executor_gitcall.go
@@ -215,6 +215,12 @@ func (v *Executor) buildGitCallNode(wsURL string, g gitCallBuild) error {
 			status, message := parseGitCallBuildLog(r.msg)
 			switch status {
 			case "done":
+				// Record the build outcome so the push handler can show it. On
+				// success the log is otherwise discarded (only errors surfaced it).
+				v.gitCallBuildLog = append(v.gitCallBuildLog, fmt.Sprintf("• %s (%s): built ✓", g.nodeTitle, g.lang))
+				for _, l := range logTail {
+					v.gitCallBuildLog = append(v.gitCallBuildLog, "    "+l)
+				}
 				return nil
 			case "error":
 				return fmt.Errorf("build reported error: %s; log: %s", message, strings.Join(logTail, " | "))

--- a/plugins/corezoid/mcp-server/executor_gitcall.go
+++ b/plugins/corezoid/mcp-server/executor_gitcall.go
@@ -33,8 +33,10 @@ const (
 	gitCallWSHandshakeTimeout = 15 * time.Second
 )
 
-// interpretedGitCallLangs need no container build.
-var interpretedGitCallLangs = map[string]bool{"js": true, "": true}
+// interpretedGitCallLangs need no container build. Only an unset lang is treated
+// as a non-git_call/no-build block; every real runtime (js included) is built on
+// the container build service before commit.
+var interpretedGitCallLangs = map[string]bool{"": true}
 
 // gitCallBuild is the resolved, build-relevant view of one git_call logic block.
 type gitCallBuild struct {

--- a/plugins/corezoid/mcp-server/executor_gitcall.go
+++ b/plugins/corezoid/mcp-server/executor_gitcall.go
@@ -1,0 +1,304 @@
+package main
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// Git Call container builds run on Corezoid's build service and are driven over
+// a WebSocket, not the JSON-RPC HTTP API. push-process therefore needs a
+// dedicated build step for git_call nodes: after the source is uploaded
+// (ModifyNodes) and before Commit — otherwise Commit rejects an unbuilt node
+// with "source has to be built".
+//
+// Interpreted runtimes (JavaScript) execute the source directly and need no
+// build, so they are skipped.
+const (
+	// gitCallBuildTimeout caps how long we wait for a single node's container
+	// build to report done. Real builds observed at ~20-60s; the cap is
+	// generous to absorb dependency installs (pip/gradle/composer).
+	gitCallBuildTimeout = 5 * time.Minute
+	// gitCallWSPingEvery is the application-level keepalive cadence. The build
+	// socket expects the client to send "0" and answers "1".
+	gitCallWSPingEvery = 15 * time.Second
+	// gitCallWSHandshakeTimeout bounds the WebSocket upgrade.
+	gitCallWSHandshakeTimeout = 15 * time.Second
+)
+
+// interpretedGitCallLangs need no container build.
+var interpretedGitCallLangs = map[string]bool{"js": true, "": true}
+
+// gitCallBuild is the resolved, build-relevant view of one git_call logic block.
+type gitCallBuild struct {
+	nodeServerID string // server-assigned node id (24-hex), not the local uuid
+	nodeTitle    string
+	lang         string
+	code         string
+	repo         string
+	path         string
+	script       string
+	commit       string
+}
+
+// needsBuild reports whether this runtime requires a container build.
+func (g gitCallBuild) needsBuild() bool { return !interpretedGitCallLangs[strings.ToLower(g.lang)] }
+
+// collectGitCallBuilds walks the process nodes and returns every git_call /
+// api_git logic that carries source, resolved to its server-assigned node id.
+func (v *Executor) collectGitCallBuilds(nodes []interface{}) []gitCallBuild {
+	var out []gitCallBuild
+	for _, node := range nodes {
+		nodeMap, ok := node.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		localID, _ := nodeMap["id"].(string)
+		serverID := localID
+		if info, ok := v.NodeIDMap[localID]; ok && info.ServerID != "" {
+			serverID = info.ServerID
+		}
+		title, _ := nodeMap["title"].(string)
+		condition, ok := nodeMap["condition"].(map[string]interface{})
+		if !ok {
+			continue
+		}
+		logics, ok := condition["logics"].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, logic := range logics {
+			lm, ok := logic.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			lt, _ := lm["type"].(string)
+			if lt != "git_call" && lt != "api_git" {
+				continue
+			}
+			g := gitCallBuild{
+				nodeServerID: serverID,
+				nodeTitle:    title,
+				lang:         strFromLogic(lm, "lang"),
+				code:         firstNonEmpty(strFromLogic(lm, "src"), strFromLogic(lm, "code")),
+				repo:         strFromLogic(lm, "repo"),
+				path:         strFromLogic(lm, "path"),
+				script:       strFromLogic(lm, "script"),
+				commit:       strFromLogic(lm, "commit"),
+			}
+			out = append(out, g)
+		}
+	}
+	return out
+}
+
+// BuildGitCallNodes builds every compiled git_call node in the process over the
+// Corezoid build WebSocket, blocking until each reports done. It must run after
+// ModifyNodes and before Commit. Interpreted runtimes (js) are skipped.
+func (v *Executor) BuildGitCallNodes(nodes []interface{}) error {
+	builds := v.collectGitCallBuilds(nodes)
+	if len(builds) == 0 {
+		return nil
+	}
+	wsURL := gitCallWSURL(v.APIUrl)
+	for _, g := range builds {
+		if !g.needsBuild() {
+			logger.Debug("git_call node %s lang=%s is interpreted — no build", g.nodeServerID, g.lang)
+			continue
+		}
+		if err := v.checkCancel(); err != nil {
+			return err
+		}
+		logger.Debug("Building git_call node %s (lang=%s) via %s", g.nodeServerID, g.lang, wsURL)
+		if err := v.buildGitCallNode(wsURL, g); err != nil {
+			return fmt.Errorf("git_call build failed for node %q (%s): %w", g.nodeTitle, g.lang, err)
+		}
+		logger.Debug("git_call node %s built", g.nodeServerID)
+	}
+	return nil
+}
+
+// buildGitCallNode opens the build WebSocket, starts the build for one node,
+// keeps the socket alive, and returns when the build reports done — or fails /
+// times out. The returned error carries the tail of the build log for context.
+func (v *Executor) buildGitCallNode(wsURL string, g gitCallBuild) error {
+	header := http.Header{}
+	header.Set("Authorization", fmt.Sprintf("Simulator %s", v.Token))
+	header.Set("Origin", gitCallWSOrigin(v.APIUrl))
+
+	dialer := &websocket.Dialer{HandshakeTimeout: gitCallWSHandshakeTimeout}
+	conn, resp, err := dialer.DialContext(v.Ctx, wsURL, header)
+	if err != nil {
+		status := ""
+		if resp != nil {
+			status = " (" + resp.Status + ")"
+		}
+		return fmt.Errorf("build websocket dial %s%s: %w", wsURL, status, err)
+	}
+	defer conn.Close()
+
+	// Start-build frame. obj_id is a fresh build id we generate; user_id is not
+	// required. status:"on" starts the build.
+	startFrame, _ := json.Marshal(map[string]any{"ops": []map[string]any{{
+		"type":     "monitor_show",
+		"obj":      "git_call",
+		"obj_type": "function_build",
+		"node_id":  g.nodeServerID,
+		"obj_id":   newBuildID(),
+		"conv_id":  v.ProcessID,
+		"code":     g.code,
+		"lang":     g.lang,
+		"repo":     g.repo,
+		"path":     g.path,
+		"script":   g.script,
+		"commit":   g.commit,
+		"status":   "on",
+	}}})
+	if err := conn.WriteMessage(websocket.TextMessage, startFrame); err != nil {
+		return fmt.Errorf("send build start: %w", err)
+	}
+
+	type readResult struct {
+		msg []byte
+		err error
+	}
+	reads := make(chan readResult, 1)
+	go func() {
+		for {
+			_, msg, err := conn.ReadMessage()
+			reads <- readResult{msg, err}
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	deadline := time.NewTimer(gitCallBuildTimeout)
+	defer deadline.Stop()
+	ping := time.NewTicker(gitCallWSPingEvery)
+	defer ping.Stop()
+
+	var logTail []string
+	appendLog := func(s string) {
+		logTail = append(logTail, s)
+		if len(logTail) > 12 {
+			logTail = logTail[len(logTail)-12:]
+		}
+	}
+
+	for {
+		select {
+		case <-v.Ctx.Done():
+			return v.Ctx.Err()
+		case <-deadline.C:
+			return fmt.Errorf("build timed out after %s; last log: %s", gitCallBuildTimeout, strings.Join(logTail, " | "))
+		case <-ping.C:
+			// Application-level keepalive: client sends "0", server answers "1".
+			_ = conn.WriteMessage(websocket.TextMessage, []byte("0"))
+		case r := <-reads:
+			if r.err != nil {
+				return fmt.Errorf("build websocket closed before done: %w; last log: %s", r.err, strings.Join(logTail, " | "))
+			}
+			s := string(r.msg)
+			if s == "1" || s == "0" { // keepalive pong/ping frames
+				continue
+			}
+			status, message := parseGitCallBuildLog(r.msg)
+			switch status {
+			case "done":
+				return nil
+			case "error":
+				return fmt.Errorf("build reported error: %s; log: %s", message, strings.Join(logTail, " | "))
+			case "stdout", "stderr":
+				if message != "" {
+					appendLog(message)
+				}
+			}
+		}
+	}
+}
+
+// parseGitCallBuildLog extracts log.type and log.message from a build monitor
+// frame. Unrecognized frames yield an empty status.
+func parseGitCallBuildLog(msg []byte) (status, message string) {
+	var frame struct {
+		Ops []struct {
+			ObjType string `json:"obj_type"`
+			Log     struct {
+				Type    string `json:"type"`
+				Message string `json:"message"`
+			} `json:"log"`
+		} `json:"ops"`
+	}
+	if err := json.Unmarshal(msg, &frame); err != nil {
+		return "", ""
+	}
+	for _, op := range frame.Ops {
+		if op.ObjType == "function_build" {
+			return op.Log.Type, op.Log.Message
+		}
+	}
+	return "", ""
+}
+
+// gitCallWSURL derives the build-WebSocket URL from the configured API URL.
+// Cloud: https://admin.corezoid.com -> wss://ws.corezoid.com/api/1/sock_json.
+// Override with COREZOID_WS_URL for on-prem / non-standard deployments.
+func gitCallWSURL(apiURL string) string {
+	if override := strings.TrimSpace(os.Getenv("COREZOID_WS_URL")); override != "" {
+		return override
+	}
+	u, err := url.Parse(apiURL)
+	if err != nil || u.Host == "" {
+		return "wss://ws.corezoid.com/api/1/sock_json"
+	}
+	host := u.Host
+	// admin.<domain> -> ws.<domain>; otherwise prefix ws. onto the host.
+	if strings.HasPrefix(host, "admin.") {
+		host = "ws." + strings.TrimPrefix(host, "admin.")
+	} else if !strings.HasPrefix(host, "ws.") {
+		host = "ws." + host
+	}
+	return "wss://" + host + "/api/1/sock_json"
+}
+
+// gitCallWSOrigin returns the Origin header the build WebSocket expects
+// (the admin UI origin the API URL belongs to).
+func gitCallWSOrigin(apiURL string) string {
+	u, err := url.Parse(apiURL)
+	if err != nil || u.Host == "" {
+		return "https://admin.corezoid.com"
+	}
+	return "https://" + u.Host
+}
+
+// newBuildID returns a random UUIDv4 string used as the build's obj_id.
+func newBuildID() string {
+	b := make([]byte, 16)
+	_, _ = rand.Read(b)
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+
+// strFromLogic reads a string field from a logic map (missing -> "").
+func strFromLogic(m map[string]interface{}, key string) string {
+	s, _ := m[key].(string)
+	return s
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, s := range vals {
+		if s != "" {
+			return s
+		}
+	}
+	return ""
+}

--- a/plugins/corezoid/mcp-server/executor_gitcall_integration_test.go
+++ b/plugins/corezoid/mcp-server/executor_gitcall_integration_test.go
@@ -8,10 +8,44 @@ import (
 	"time"
 )
 
+// gitCallLang is one language case for the multi-language build test. The Code
+// field doubles as living documentation of the git_call handler contract for
+// each supported runtime — it is exactly what a user writes in a git_call node.
+type gitCallLang struct {
+	lang string
+	code string
+	want string // the value handle() must place in data["r"]
+}
+
+// gitCallLangs covers several runtimes end-to-end. Each is built on the
+// container build service and run, and the Code is exactly what a user writes in
+// a git_call node — so this table doubles as a per-language usage reference.
+// (Go is exercised via repo mode / go.mod elsewhere: an inline Go snippet can't
+// resolve the external gitcall-go-runner import without a module file.)
+var gitCallLangs = []gitCallLang{
+	{
+		lang: "js",
+		code: "module.exports = (data) => { data.r = 'js-ok'; return data; };",
+		want: "js-ok",
+	},
+	{
+		lang: "python",
+		code: "def handle(data):\n    data['r'] = 'python-ok'\n    return data\n",
+		want: "python-ok",
+	},
+	{
+		lang: "php",
+		code: "<?php\nfunction handle($data) {\n    $data['r'] = 'php-ok';\n    return $data;\n}\n",
+		want: "php-ok",
+	},
+}
+
 // TestGitCallBuildIntegration exercises the real push build path
 // (modify -> BuildGitCallNodes over the live WebSocket -> Commit -> run) against
-// a live Corezoid workspace. It is skipped unless COREZOID_GITCALL_IT=1 and the
-// connection env is present, so `go test ./...` stays offline/deterministic.
+// a live Corezoid workspace, once per supported language (js, python, go, php).
+// It both proves multi-language build/deploy works and documents each runtime's
+// handler contract. Skipped unless COREZOID_GITCALL_IT=1 and the connection env
+// is present, so `go test ./...` stays offline/deterministic.
 //
 // Required env:
 //
@@ -47,38 +81,36 @@ func TestGitCallBuildIntegration(t *testing.T) {
 		Version:     int(time.Now().Unix()),
 		NodeIDMap:   map[string]NodeInfo{},
 	}
-	first := func(m map[string]interface{}) map[string]interface{} {
-		if ops, ok := m["ops"].([]interface{}); ok && len(ops) > 0 {
-			if x, ok := ops[0].(map[string]interface{}); ok {
-				return x
-			}
-		}
-		return map[string]interface{}{}
-	}
 
-	// Discard any leftover uncommitted draft so version/commit is clean.
-	if lst, err := v.req("it_list", []map[string]any{{"type": "list", "obj": "conv", "obj_id": conv, "company_id": ws}}); err == nil {
-		if cm, ok := first(lst)["commits"].(map[string]interface{}); ok {
-			if ver, ok := cm["version"].(float64); ok && ver > 0 {
-				_, _ = v.req("it_del", []map[string]any{{"type": "delete", "obj": "commits", "company_id": ws, "conv_id": conv, "version": int(ver)}})
-			}
-		}
+	for _, c := range gitCallLangs {
+		c := c
+		t.Run(c.lang, func(t *testing.T) {
+			deployAndRunGitCall(t, v, conv, ws, start, final, c)
+		})
 	}
+}
 
-	// Create a fresh python git_call node (compiled -> requires a real build).
-	code := "import base64\ndef handle(data):\n    data['result']='it-'+base64.b64encode(b'ok').decode()\n    return data\n"
-	localID := "it-gitcall-node"
+// deployAndRunGitCall creates a fresh git_call node for one language, builds it
+// over the live WebSocket (a no-op for interpreted runtimes), commits, fires a
+// task and asserts handle() ran — the exact path push-process takes for a
+// git_call node. Create + modify + build + commit all share one version so the
+// draft is consistent.
+func deployAndRunGitCall(t *testing.T, v *Executor, conv int, ws, start, final string, c gitCallLang) {
+	v.Version = int(time.Now().Unix())
+	gitCallDiscardDraft(v, conv, ws)
+
+	localID := "it-gitcall-" + c.lang
 	cr, err := v.req("it_create", []map[string]any{{"id": localID, "type": "create", "obj": "node", "conv_id": conv, "title": "it-gitcall", "obj_type": 0, "version": v.Version}})
 	if err != nil {
-		t.Fatalf("create node: %v", err)
+		t.Fatalf("[%s] create node: %v", c.lang, err)
 	}
-	serverID, _ := first(cr)["obj_id"].(string)
+	serverID, _ := gitCallFirstOp(cr)["obj_id"].(string)
 	if serverID == "" {
-		t.Fatalf("no server node id in create response: %v", cr)
+		t.Fatalf("[%s] no server node id in create response: %v", c.lang, cr)
 	}
 	v.NodeIDMap[localID] = NodeInfo{ServerID: serverID}
 
-	gitLogic := map[string]any{"type": "git_call", "version": 2, "lang": "python", "code": code, "src": code,
+	gitLogic := map[string]any{"type": "git_call", "version": 2, "lang": c.lang, "code": c.code, "src": c.code,
 		"repo": "", "commit": "", "path": "", "script": "", "log": map[string]any{}, "err_node_id": final, "code_error": false}
 	if _, err := v.req("it_modify", []map[string]any{
 		{"type": "modify", "obj": "node", "obj_id": serverID, "company_id": ws, "conv_id": conv, "title": "it-gitcall", "obj_type": 0, "options": nil,
@@ -86,44 +118,66 @@ func TestGitCallBuildIntegration(t *testing.T) {
 		{"type": "modify", "obj": "node", "obj_id": start, "company_id": ws, "conv_id": conv, "title": "Start", "obj_type": 1, "options": nil,
 			"logics": []any{map[string]any{"type": "go", "to_node_id": serverID}}, "semaphors": []any{}, "extra": map[string]any{"modeForm": "expand", "icon": ""}, "version": v.Version},
 	}); err != nil {
-		t.Fatalf("modify nodes: %v", err)
+		t.Fatalf("[%s] modify nodes: %v", c.lang, err)
 	}
 
-	// The unit under test: build the compiled git_call node over the live WS.
+	// The unit under test: build the git_call node the way push-process does.
 	nodes := []interface{}{map[string]interface{}{
 		"id": localID, "title": "it-gitcall",
 		"condition": map[string]interface{}{"logics": []interface{}{gitLogic}},
 	}}
 	buildStart := time.Now()
 	if err := v.BuildGitCallNodes(nodes); err != nil {
-		t.Fatalf("BuildGitCallNodes: %v", err)
+		t.Fatalf("[%s] BuildGitCallNodes: %v", c.lang, err)
 	}
-	t.Logf("git_call build finished in %s", time.Since(buildStart).Round(time.Second))
+	t.Logf("[%s] build finished in %s", c.lang, time.Since(buildStart).Round(time.Second))
 
-	if resp := v.Commit(); resp == nil || first(resp)["proc"] == "error" {
-		t.Fatalf("commit rejected after build: %v", resp)
+	if resp := v.Commit(); resp == nil || gitCallFirstOp(resp)["proc"] == "error" {
+		t.Fatalf("[%s] commit rejected after build: %v", c.lang, resp)
 	}
 
-	// Run a task through the node and confirm handle() executed.
-	ref := "it-run-" + strconv.FormatInt(time.Now().Unix(), 10)
+	ref := c.lang + "-it-" + strconv.FormatInt(time.Now().UnixNano(), 10)
 	if _, err := v.req("it_task", []map[string]any{{"type": "create", "obj": "task", "conv_id": conv, "ref": ref, "data": map[string]any{"in": "x"}}}); err != nil {
-		t.Fatalf("create task: %v", err)
+		t.Fatalf("[%s] create task: %v", c.lang, err)
 	}
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 12; i++ {
 		time.Sleep(3 * time.Second)
 		g, err := v.req("it_show", []map[string]any{{"type": "show", "obj": "task", "conv_id": conv, "ref": ref}})
 		if err != nil {
 			continue
 		}
-		if data, ok := first(g)["data"].(map[string]interface{}); ok {
-			if res, ok := data["result"].(string); ok && res != "" {
-				if res != "it-b2s=" {
-					t.Fatalf("unexpected handle() result: %q", res)
+		if data, ok := gitCallFirstOp(g)["data"].(map[string]interface{}); ok {
+			if res, ok := data["r"].(string); ok && res != "" {
+				if res != c.want {
+					t.Fatalf("[%s] unexpected handle() result: got %q, want %q", c.lang, res, c.want)
 				}
-				t.Logf("✅ git_call executed end-to-end: result=%q", res)
+				t.Logf("✅ [%s] git_call executed end-to-end: r=%q", c.lang, res)
 				return
 			}
 		}
 	}
-	t.Fatal("task did not produce a git_call result in time")
+	t.Fatalf("[%s] task did not produce a git_call result in time", c.lang)
+}
+
+// gitCallDiscardDraft drops any leftover uncommitted draft so the next commit is clean.
+func gitCallDiscardDraft(v *Executor, conv int, ws string) {
+	lst, err := v.req("it_list", []map[string]any{{"type": "list", "obj": "conv", "obj_id": conv, "company_id": ws}})
+	if err != nil {
+		return
+	}
+	if cm, ok := gitCallFirstOp(lst)["commits"].(map[string]interface{}); ok {
+		if ver, ok := cm["version"].(float64); ok && ver > 0 {
+			_, _ = v.req("it_del", []map[string]any{{"type": "delete", "obj": "commits", "company_id": ws, "conv_id": conv, "version": int(ver)}})
+		}
+	}
+}
+
+// gitCallFirstOp returns ops[0] of a Corezoid API response, or an empty map.
+func gitCallFirstOp(m map[string]interface{}) map[string]interface{} {
+	if ops, ok := m["ops"].([]interface{}); ok && len(ops) > 0 {
+		if x, ok := ops[0].(map[string]interface{}); ok {
+			return x
+		}
+	}
+	return map[string]interface{}{}
 }

--- a/plugins/corezoid/mcp-server/executor_gitcall_integration_test.go
+++ b/plugins/corezoid/mcp-server/executor_gitcall_integration_test.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// TestGitCallBuildIntegration exercises the real push build path
+// (modify -> BuildGitCallNodes over the live WebSocket -> Commit -> run) against
+// a live Corezoid workspace. It is skipped unless COREZOID_GITCALL_IT=1 and the
+// connection env is present, so `go test ./...` stays offline/deterministic.
+//
+// Required env:
+//
+//	COREZOID_GITCALL_IT=1
+//	ACCESS_TOKEN, COREZOID_API_URL, WORKSPACE_ID
+//	COREZOID_IT_CONV     — a throwaway process id with a Start->Final scaffold
+//	COREZOID_IT_START    — Start node server id
+//	COREZOID_IT_FINAL    — Final node server id
+func TestGitCallBuildIntegration(t *testing.T) {
+	if os.Getenv("COREZOID_GITCALL_IT") != "1" {
+		t.Skip("set COREZOID_GITCALL_IT=1 (and connection env) to run the live git_call build test")
+	}
+	token := os.Getenv("ACCESS_TOKEN")
+	apiURL := os.Getenv("COREZOID_API_URL")
+	ws := os.Getenv("WORKSPACE_ID")
+	convStr := os.Getenv("COREZOID_IT_CONV")
+	start := os.Getenv("COREZOID_IT_START")
+	final := os.Getenv("COREZOID_IT_FINAL")
+	if token == "" || apiURL == "" || convStr == "" || start == "" || final == "" {
+		t.Fatal("missing integration env (ACCESS_TOKEN/COREZOID_API_URL/WORKSPACE_ID/COREZOID_IT_CONV/COREZOID_IT_START/COREZOID_IT_FINAL)")
+	}
+	conv, err := strconv.Atoi(convStr)
+	if err != nil {
+		t.Fatalf("bad COREZOID_IT_CONV: %v", err)
+	}
+
+	v := &Executor{
+		Ctx:         context.Background(),
+		Token:       token,
+		APIUrl:      apiURL,
+		WorkspaceID: ws,
+		ProcessID:   conv,
+		Version:     int(time.Now().Unix()),
+		NodeIDMap:   map[string]NodeInfo{},
+	}
+	first := func(m map[string]interface{}) map[string]interface{} {
+		if ops, ok := m["ops"].([]interface{}); ok && len(ops) > 0 {
+			if x, ok := ops[0].(map[string]interface{}); ok {
+				return x
+			}
+		}
+		return map[string]interface{}{}
+	}
+
+	// Discard any leftover uncommitted draft so version/commit is clean.
+	if lst, err := v.req("it_list", []map[string]any{{"type": "list", "obj": "conv", "obj_id": conv, "company_id": ws}}); err == nil {
+		if cm, ok := first(lst)["commits"].(map[string]interface{}); ok {
+			if ver, ok := cm["version"].(float64); ok && ver > 0 {
+				_, _ = v.req("it_del", []map[string]any{{"type": "delete", "obj": "commits", "company_id": ws, "conv_id": conv, "version": int(ver)}})
+			}
+		}
+	}
+
+	// Create a fresh python git_call node (compiled -> requires a real build).
+	code := "import base64\ndef handle(data):\n    data['result']='it-'+base64.b64encode(b'ok').decode()\n    return data\n"
+	localID := "it-gitcall-node"
+	cr, err := v.req("it_create", []map[string]any{{"id": localID, "type": "create", "obj": "node", "conv_id": conv, "title": "it-gitcall", "obj_type": 0, "version": v.Version}})
+	if err != nil {
+		t.Fatalf("create node: %v", err)
+	}
+	serverID, _ := first(cr)["obj_id"].(string)
+	if serverID == "" {
+		t.Fatalf("no server node id in create response: %v", cr)
+	}
+	v.NodeIDMap[localID] = NodeInfo{ServerID: serverID}
+
+	gitLogic := map[string]any{"type": "git_call", "version": 2, "lang": "python", "code": code, "src": code,
+		"repo": "", "commit": "", "path": "", "script": "", "log": map[string]any{}, "err_node_id": final, "code_error": false}
+	if _, err := v.req("it_modify", []map[string]any{
+		{"type": "modify", "obj": "node", "obj_id": serverID, "company_id": ws, "conv_id": conv, "title": "it-gitcall", "obj_type": 0, "options": nil,
+			"logics": []any{gitLogic, map[string]any{"type": "go", "to_node_id": final}}, "semaphors": []any{}, "position": []int{400, 120}, "extra": map[string]any{"modeForm": "expand", "icon": ""}, "version": v.Version},
+		{"type": "modify", "obj": "node", "obj_id": start, "company_id": ws, "conv_id": conv, "title": "Start", "obj_type": 1, "options": nil,
+			"logics": []any{map[string]any{"type": "go", "to_node_id": serverID}}, "semaphors": []any{}, "extra": map[string]any{"modeForm": "expand", "icon": ""}, "version": v.Version},
+	}); err != nil {
+		t.Fatalf("modify nodes: %v", err)
+	}
+
+	// The unit under test: build the compiled git_call node over the live WS.
+	nodes := []interface{}{map[string]interface{}{
+		"id": localID, "title": "it-gitcall",
+		"condition": map[string]interface{}{"logics": []interface{}{gitLogic}},
+	}}
+	buildStart := time.Now()
+	if err := v.BuildGitCallNodes(nodes); err != nil {
+		t.Fatalf("BuildGitCallNodes: %v", err)
+	}
+	t.Logf("git_call build finished in %s", time.Since(buildStart).Round(time.Second))
+
+	if resp := v.Commit(); resp == nil || first(resp)["proc"] == "error" {
+		t.Fatalf("commit rejected after build: %v", resp)
+	}
+
+	// Run a task through the node and confirm handle() executed.
+	ref := "it-run-" + strconv.FormatInt(time.Now().Unix(), 10)
+	if _, err := v.req("it_task", []map[string]any{{"type": "create", "obj": "task", "conv_id": conv, "ref": ref, "data": map[string]any{"in": "x"}}}); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		time.Sleep(3 * time.Second)
+		g, err := v.req("it_show", []map[string]any{{"type": "show", "obj": "task", "conv_id": conv, "ref": ref}})
+		if err != nil {
+			continue
+		}
+		if data, ok := first(g)["data"].(map[string]interface{}); ok {
+			if res, ok := data["result"].(string); ok && res != "" {
+				if res != "it-b2s=" {
+					t.Fatalf("unexpected handle() result: %q", res)
+				}
+				t.Logf("✅ git_call executed end-to-end: result=%q", res)
+				return
+			}
+		}
+	}
+	t.Fatal("task did not produce a git_call result in time")
+}

--- a/plugins/corezoid/mcp-server/executor_gitcall_progress_test.go
+++ b/plugins/corezoid/mcp-server/executor_gitcall_progress_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+// TestBuildGitCallNodeRecordsLog verifies that a successful build records a
+// human-readable log on the Executor (so the push handler can surface it),
+// using a fake build WebSocket pointed at via COREZOID_WS_URL.
+func TestBuildGitCallNodeRecordsLog(t *testing.T) {
+	up := websocket.Upgrader{CheckOrigin: func(*http.Request) bool { return true }}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := up.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		_, _, _ = c.ReadMessage() // consume the start-build frame
+		_ = c.WriteMessage(websocket.TextMessage, []byte(`{"ops":[{"obj_type":"function_build","log":{"type":"stdout","message":"Compiling my-fn..."}}]}`))
+		_ = c.WriteMessage(websocket.TextMessage, []byte(`{"ops":[{"obj_type":"function_build","log":{"type":"done","message":""}}]}`))
+	}))
+	defer srv.Close()
+	os.Setenv("COREZOID_WS_URL", "ws"+strings.TrimPrefix(srv.URL, "http")+"/api/1/sock_json")
+	defer os.Unsetenv("COREZOID_WS_URL")
+
+	v := &Executor{Ctx: context.Background(), Token: "t", APIUrl: "https://admin.corezoid.com"}
+	g := gitCallBuild{lang: "python", nodeServerID: "n1", nodeTitle: "my-fn"}
+	if err := v.buildGitCallNode(gitCallWSURL(v.APIUrl), g); err != nil {
+		t.Fatalf("buildGitCallNode: %v", err)
+	}
+	joined := strings.Join(v.gitCallBuildLog, "\n")
+	for _, want := range []string{"my-fn", "built ✓", "Compiling my-fn"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("build log missing %q:\n%s", want, joined)
+		}
+	}
+}

--- a/plugins/corezoid/mcp-server/executor_gitcall_test.go
+++ b/plugins/corezoid/mcp-server/executor_gitcall_test.go
@@ -76,7 +76,7 @@ func TestNewBuildID(t *testing.T) {
 }
 
 func TestGitCallNeedsBuild(t *testing.T) {
-	cases := map[string]bool{"js": false, "JS": false, "": false, "python": true, "golang": true, "php": true, "java": true}
+	cases := map[string]bool{"js": true, "JS": true, "python": true, "golang": true, "php": true, "java": true, "": false}
 	for lang, want := range cases {
 		if got := (gitCallBuild{lang: lang}).needsBuild(); got != want {
 			t.Errorf("needsBuild(lang=%q) = %v, want %v", lang, got, want)
@@ -119,8 +119,8 @@ func TestCollectGitCallBuilds(t *testing.T) {
 	if got[1].nodeServerID != "local-2" { // no NodeIDMap entry -> falls back to local id
 		t.Errorf("second build server id = %q, want fallback local-2", got[1].nodeServerID)
 	}
-	if got[1].needsBuild() {
-		t.Errorf("js must not need build")
+	if !got[1].needsBuild() {
+		t.Errorf("js must need a container build")
 	}
 	if got[1].repo != "https://x/y.git" || got[1].commit != "main" {
 		t.Errorf("repo-mode fields lost: %+v", got[1])

--- a/plugins/corezoid/mcp-server/executor_gitcall_test.go
+++ b/plugins/corezoid/mcp-server/executor_gitcall_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"regexp"
+	"testing"
+)
+
+func TestGitCallWSURL(t *testing.T) {
+	// COREZOID_WS_URL override wins.
+	t.Setenv("COREZOID_WS_URL", "wss://custom.example.com/api/1/sock_json")
+	if got := gitCallWSURL("https://admin.corezoid.com"); got != "wss://custom.example.com/api/1/sock_json" {
+		t.Fatalf("override not honored: %q", got)
+	}
+	_ = os.Unsetenv("COREZOID_WS_URL")
+
+	cases := map[string]string{
+		"https://admin.corezoid.com":        "wss://ws.corezoid.com/api/1/sock_json",
+		"https://admin.corezoid.com/":       "wss://ws.corezoid.com/api/1/sock_json",
+		"https://admin.eu.corezoid.com":     "wss://ws.eu.corezoid.com/api/1/sock_json",
+		"https://corp-corezoid.example.org": "wss://ws.corp-corezoid.example.org/api/1/sock_json",
+		"":                                  "wss://ws.corezoid.com/api/1/sock_json",
+	}
+	for api, want := range cases {
+		if got := gitCallWSURL(api); got != want {
+			t.Errorf("gitCallWSURL(%q) = %q, want %q", api, got, want)
+		}
+	}
+}
+
+func TestGitCallWSOrigin(t *testing.T) {
+	if got := gitCallWSOrigin("https://admin.corezoid.com"); got != "https://admin.corezoid.com" {
+		t.Errorf("origin = %q", got)
+	}
+	if got := gitCallWSOrigin(""); got != "https://admin.corezoid.com" {
+		t.Errorf("fallback origin = %q", got)
+	}
+}
+
+func TestParseGitCallBuildLog(t *testing.T) {
+	cases := []struct {
+		name       string
+		frame      string
+		wantStatus string
+		wantMsg    string
+	}{
+		{"stdout", `{"request_proc":"ok","ops":[{"type":"monitor_show","obj":"git_call","obj_type":"function_build","obj_id":"x","log":{"type":"stdout","message":"Building"}}]}`, "stdout", "Building"},
+		{"done", `{"request_proc":"ok","ops":[{"type":"monitor_show","obj":"git_call","obj_type":"function_build","obj_id":"x","log":{"type":"done"}}]}`, "done", ""},
+		{"error", `{"ops":[{"obj_type":"function_build","log":{"type":"error","message":"boom"}}]}`, "error", "boom"},
+		{"unrelated", `{"ops":[{"obj_type":"something_else","log":{"type":"done"}}]}`, "", ""},
+		{"garbage", `not json`, "", ""},
+		{"keepalive", `1`, "", ""},
+	}
+	for _, c := range cases {
+		st, msg := parseGitCallBuildLog([]byte(c.frame))
+		if st != c.wantStatus || msg != c.wantMsg {
+			t.Errorf("%s: got (%q,%q), want (%q,%q)", c.name, st, msg, c.wantStatus, c.wantMsg)
+		}
+	}
+}
+
+func TestNewBuildID(t *testing.T) {
+	re := regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+	seen := map[string]bool{}
+	for i := 0; i < 100; i++ {
+		id := newBuildID()
+		if !re.MatchString(id) {
+			t.Fatalf("not a UUIDv4: %q", id)
+		}
+		if seen[id] {
+			t.Fatalf("duplicate build id: %q", id)
+		}
+		seen[id] = true
+	}
+}
+
+func TestGitCallNeedsBuild(t *testing.T) {
+	cases := map[string]bool{"js": false, "JS": false, "": false, "python": true, "golang": true, "php": true, "java": true}
+	for lang, want := range cases {
+		if got := (gitCallBuild{lang: lang}).needsBuild(); got != want {
+			t.Errorf("needsBuild(lang=%q) = %v, want %v", lang, got, want)
+		}
+	}
+}
+
+func TestCollectGitCallBuilds(t *testing.T) {
+	v := &Executor{NodeIDMap: map[string]NodeInfo{"local-1": {ServerID: "server-abc"}}}
+	nodes := []interface{}{
+		map[string]interface{}{
+			"id": "local-1", "title": "parse",
+			"condition": map[string]interface{}{"logics": []interface{}{
+				map[string]interface{}{"type": "git_call", "lang": "python", "code": "def handle(d): return d", "repo": ""},
+				map[string]interface{}{"type": "go", "to_node_id": "n2"},
+			}},
+		},
+		// api_git alias, source in src, repo mode
+		map[string]interface{}{
+			"id": "local-2", "title": "fetch",
+			"condition": map[string]interface{}{"logics": []interface{}{
+				map[string]interface{}{"type": "api_git", "lang": "js", "src": "module.exports=(d)=>d", "repo": "https://x/y.git", "commit": "main"},
+			}},
+		},
+		// non-git node ignored
+		map[string]interface{}{"id": "local-3", "condition": map[string]interface{}{"logics": []interface{}{
+			map[string]interface{}{"type": "api_code", "lang": "js", "src": "x"},
+		}}},
+	}
+	got := v.collectGitCallBuilds(nodes)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 git_call builds, got %d", len(got))
+	}
+	if got[0].nodeServerID != "server-abc" || got[0].lang != "python" || got[0].code == "" {
+		t.Errorf("first build resolved wrong: %+v", got[0])
+	}
+	if !got[0].needsBuild() {
+		t.Errorf("python must need build")
+	}
+	if got[1].nodeServerID != "local-2" { // no NodeIDMap entry -> falls back to local id
+		t.Errorf("second build server id = %q, want fallback local-2", got[1].nodeServerID)
+	}
+	if got[1].needsBuild() {
+		t.Errorf("js must not need build")
+	}
+	if got[1].repo != "https://x/y.git" || got[1].commit != "main" {
+		t.Errorf("repo-mode fields lost: %+v", got[1])
+	}
+}
+
+func TestFirstNonEmpty(t *testing.T) {
+	if firstNonEmpty("", "", "z") != "z" {
+		t.Error("want z")
+	}
+	if firstNonEmpty("a", "b") != "a" {
+		t.Error("want a")
+	}
+	if firstNonEmpty("", "") != "" {
+		t.Error("want empty")
+	}
+}
+
+// TestFixStructSetsGitCallCodeError verifies fixStruct marks git_call/api_git
+// logic as built (code_error:false) so Commit accepts the node, without
+// clobbering an explicit value.
+func TestFixStructSetsGitCallCodeError(t *testing.T) {
+	in := `{"obj_type":1,"scheme":{"nodes":[{"id":"n1","obj_type":0,"condition":{"logics":[` +
+		`{"type":"git_call","lang":"python","code":"x"},` +
+		`{"type":"api_git","lang":"js","src":"y","code_error":true}` +
+		`]}}]}}`
+	out, _ := fixStruct(in, 0)
+
+	var parsed struct {
+		Scheme struct {
+			Nodes []struct {
+				Condition struct {
+					Logics []map[string]interface{} `json:"logics"`
+				} `json:"condition"`
+			} `json:"nodes"`
+		} `json:"scheme"`
+	}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("fixStruct output is not valid JSON: %v\n%s", err, out)
+	}
+	logics := parsed.Scheme.Nodes[0].Condition.Logics
+	byType := map[string]map[string]interface{}{}
+	for _, l := range logics {
+		if lt, ok := l["type"].(string); ok {
+			byType[lt] = l
+		}
+	}
+	if ce, ok := byType["git_call"]["code_error"]; !ok || ce != false {
+		t.Errorf("git_call code_error should be false, got %v (present=%v)", ce, ok)
+	}
+	if ce := byType["api_git"]["code_error"]; ce != true {
+		t.Errorf("explicit api_git code_error:true was clobbered, got %v", ce)
+	}
+}

--- a/plugins/corezoid/mcp-server/executor_process.go
+++ b/plugins/corezoid/mcp-server/executor_process.go
@@ -344,6 +344,13 @@ func (validator *Executor) ProcessJSON(filePath, jsonContent string) (newProcess
 		return nil, err
 	}
 
+	// git_call nodes run on a container build service that must finish before
+	// Commit, or Commit rejects them with "source has to be built". Interpreted
+	// runtimes (js) need no build and are skipped inside BuildGitCallNodes.
+	if err = validator.BuildGitCallNodes(nodes); err != nil {
+		return nil, fmt.Errorf("failed to build git_call node(s): %v", err)
+	}
+
 	commitResponse := validator.Commit()
 	if commitResponse == nil {
 		return nil, fmt.Errorf("failed to commit changes: no response from server")

--- a/plugins/corezoid/mcp-server/go.mod
+++ b/plugins/corezoid/mcp-server/go.mod
@@ -4,4 +4,7 @@ go 1.24.0
 
 require github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 
-require golang.org/x/text v0.14.0 // indirect
+require (
+	github.com/gorilla/websocket v1.5.3 // indirect
+	golang.org/x/text v0.14.0 // indirect
+)

--- a/plugins/corezoid/mcp-server/go.sum
+++ b/plugins/corezoid/mcp-server/go.sum
@@ -1,5 +1,7 @@
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
 github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=

--- a/plugins/corezoid/mcp-server/json-schema/logics/api_git.json
+++ b/plugins/corezoid/mcp-server/json-schema/logics/api_git.json
@@ -4,11 +4,17 @@
   "description": "Schema for the api_git logic type in Corezoid processes",
   "type": "object",
   "additionalProperties": false,
-  "required": ["type", "err_node_id"],
+  "required": [
+    "type",
+    "err_node_id"
+  ],
   "properties": {
     "type": {
       "type": "string",
-      "enum": ["api_git", "git_call"],
+      "enum": [
+        "api_git",
+        "git_call"
+      ],
       "description": "Specifies this is a Git Call logic block"
     },
     "version": {
@@ -18,7 +24,11 @@
     },
     "lang": {
       "type": "string",
-      "enum": ["js", "python", "golang"],
+      "enum": [
+        "js",
+        "python",
+        "golang"
+      ],
       "description": "Language of the script",
       "default": "js"
     },
@@ -51,7 +61,10 @@
       "description": "Path to the script file in the repository"
     },
     "log": {
-      "type": ["boolean", "object"],
+      "type": [
+        "boolean",
+        "object"
+      ],
       "description": "Whether to log execution details or log configuration",
       "default": {}
     },
@@ -59,6 +72,10 @@
       "type": "integer",
       "description": "Execution timeout in seconds",
       "default": 30
+    },
+    "code_error": {
+      "type": "boolean",
+      "description": "Build status flag. push-process sets it false after a successful container build so Commit accepts the node."
     }
   },
   "examples": [

--- a/plugins/corezoid/mcp-server/main.go
+++ b/plugins/corezoid/mcp-server/main.go
@@ -482,6 +482,14 @@ func fixStruct(dataBin string, inProcessID int) (string, []string) {
 										}
 									}
 								}
+								if logicMap["type"] == "git_call" || logicMap["type"] == "api_git" {
+									// git_call deploys via a separate container build (see BuildGitCallNodes).
+									// Mark the source valid so Commit accepts the node; the build runs
+									// between compile and commit.
+									if _, set := logicMap["code_error"]; !set {
+										logicMap["code_error"] = false
+									}
+								}
 								if logicMap["type"] == "api" {
 									if extra, ok := logicMap["extra"].(map[string]interface{}); ok {
 										if body, ok := extra["body"].(string); ok && len(extra) == 1 {

--- a/plugins/corezoid/mcp-server/mcp_handlers_process.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_process.go
@@ -178,7 +178,13 @@ func handlePushProcess(ctx context.Context, args map[string]interface{}) (string
 		return fmt.Sprintf("Error deploying process: %v", err), true
 	}
 
-	return fmt.Sprintf("Process deployed successfully, ProcessID: %d", procID), false
+	result := fmt.Sprintf("Process deployed successfully, ProcessID: %d", procID)
+	// Surface the git_call container build log so the user sees what the build
+	// service reported (progress + result), not just silence on success.
+	if len(v.gitCallBuildLog) > 0 {
+		result += "\n\ngit_call build:\n" + strings.Join(v.gitCallBuildLog, "\n")
+	}
+	return result, false
 }
 
 // handleLintProcess validates a local .conv.json without touching the server.

--- a/plugins/corezoid/skills/corezoid-gitcall/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-gitcall/SKILL.md
@@ -147,13 +147,15 @@ support in this plugin). Just author the node like any other and push:
 
 1. Add a node whose logic `type` is `git_call`, set `lang` and either `code`
    (inline) or `repo`/`commit`/`path`/`script` (Git Repo).
-2. `push-process` — it uploads the source, builds the container when the runtime
-   needs one, and commits. Interpreted runtimes (JavaScript) skip the build.
+2. `push-process` — it uploads the source, builds the container on the build
+   service, and commits. Every runtime (JavaScript included) is built before the
+   commit; JavaScript just builds fastest (a few seconds) since it installs no
+   compiler toolchain.
 
-Compiled runtimes take ~20–120 s on the first build (dependency install), then
-build from cache. `run-task` reports the task settling on a non-final node while
-the build runs — that is expected; the result merges into the task payload
-asynchronously.
+Builds take ~5 s (JavaScript) to ~20–120 s (compiled runtimes, first build with
+dependency install), then build from cache. `run-task` reports the task settling
+on a non-final node while the build runs — that is expected; the result merges
+into the task payload asynchronously.
 
 Override the build endpoint for on-prem installs with `COREZOID_WS_URL`.
 

--- a/plugins/corezoid/skills/corezoid-gitcall/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-gitcall/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: corezoid-gitcall
+description: >
+  Corezoid Git Call node specialist — run custom code (Python, Go, Java, PHP,
+  JavaScript, Clojure, Lisp, Prolog, or a custom Dockerfile) as a step inside a
+  process. Use when the user needs logic that plain nodes cannot do: parsing
+  files, using external libraries, cryptography, building email/attachments, or
+  any custom runtime. Activate on "git call", "gitcall", "run my code",
+  "parse a file", "use a library", "custom code node", "python/go/php in a
+  process", or "why does push-process hang on git_call". Load this skill only
+  when the task is actually about git_call — it is not needed for ordinary flows.
+---
+
+# Corezoid Git Call
+
+A Git Call node runs your code (9 built-in languages, or a custom Docker image)
+in an isolated container as one step of a process. Each task is delivered to a
+`handle` function over JSON-RPC 2.0; the value you return becomes the payload of
+the next node.
+
+Reach for Git Call only when the standard nodes cannot do the job. It is heavier
+than a Code (`api_code`) node — it needs a container build and a warm-up.
+
+## 1. When to use it
+
+Use Git Call when you need something the platform's built-in nodes lack:
+
+- Parse files (download a URL and read a 1C `.1CD`, XML, PDF, QR, image, …).
+- Use external libraries (crypto, moment, pandas, okhttp, …).
+- Heavy/custom logic (matrices, cryptography, bespoke formats).
+- Build an email body with attachments, generate documents, etc.
+
+| Aspect        | Code node (`api_code`) | Git Call            |
+|---------------|------------------------|---------------------|
+| Speed         | faster                 | slower              |
+| Warm-up       | none                   | required            |
+| Complexity    | simple                 | higher              |
+| Resources     | efficient              | heavier (container) |
+| External deps | no                     | yes                 |
+| Languages     | JS (+ limited)          | 9 languages + Docker |
+
+Rule of thumb: simple and fast with no external deps → Code node. Files,
+libraries, or custom runtimes → Git Call.
+
+## 2. Supported languages and runtimes
+
+| Language   | Version       | Package manager | OS               |
+|------------|---------------|-----------------|------------------|
+| JavaScript | node v20      | yarn, npm       | alpine 3.17      |
+| Go         | v1.23         | go mod          | alpine 3.20      |
+| Python     | v3.12         | pip             | alpine 3.17      |
+| Java       | v22           | gradle          | alpine 3.15      |
+| PHP        | v8.3          | composer 2.5.4  | alpine 3.17      |
+| Clojure    | v1.11.1       | lein 2.10       | alpine 3.17      |
+| Lisp       | v2.4.8        | roswell         | Ubuntu 18.04     |
+| Prolog     | swipl v9.2.7  | swipl           | debian bullseye  |
+| Dockerfile | any           | —               | your own image   |
+
+Git Call requests originate from `54.171.15.37`, `108.128.68.222`,
+`63.33.226.230`. Whitelist these if a private repo or resource blocks access.
+
+## 3. Handler contract (per language)
+
+The handler receives the task payload and returns the next payload (or throws to
+produce an error). In Git-Repo mode the entry file is `usercode.<ext>`.
+
+```python
+# python — usercode.py
+def handle(data):
+    data['result'] = 'ok'
+    return data
+```
+```javascript
+// js — usercode.js  (CommonJS; for ESM use import/export default, .mjs, or "type":"module")
+module.exports = (data) => { data.result = 'ok'; return data; };
+```
+```go
+// go — usercode.go
+package main
+import ("context"; "github.com/corezoid/gitcall-go-runner/gitcall")
+func usercode(_ context.Context, data map[string]interface{}) error { data["result"]="ok"; return nil }
+func main() { gitcall.Handle(usercode) }
+```
+```php
+// php — usercode.php
+<?php
+function handle($data) { $data['result']="ok"; return $data; }
+```
+```java
+// java — Usercode.java  (fully-qualified name com.corezoid.usercode.Usercode is mandatory)
+package com.corezoid.usercode;
+import com.corezoid.gitcall.runner.api.UsercodeHandler;
+import java.util.Map;
+public class Usercode implements UsercodeHandler<Map<String,String>,Map<String,String>> {
+  public Map<String,String> handle(Map<String,String> data) throws Exception { data.put("result","ok"); return data; }
+}
+```
+```prolog
+% prolog — usercode.pl
+:- module(usercode, [handle/2]).
+handle(Data, Result) :- put_dict(result, Data, "ok", Result).
+```
+```lisp
+;; lisp — usercode.lisp
+(defpackage #:usercode (:use #:cl) (:export :handle))
+(in-package #:usercode)
+(defun handle (data) (setf (gethash 'result data) 'ok) data)
+```
+```clojure
+;; clojure — usercode.clj
+(ns usercode.usercode)
+(defn handle [data] (assoc data :result "ok"))
+```
+
+Runnable examples (`hello_world`, `http_request`, `user_error`, dependency demos)
+for every language: <https://github.com/corezoid/gitcall-examples>.
+
+## 4. Two modes
+
+- **Code editor (inline)** — paste the code straight into the node.
+- **Git Repo** — set the repo URL, the branch/tag/commit, the path (leave empty
+  if the entry file is in the repo root), and the entry file. Use an SSH key on
+  the node for private repos.
+
+## 5. Dependencies (Build command)
+
+Install dependencies with a Build command (Code editor) or a manifest file
+(Git Repo):
+
+| Language | Build command (Code editor)                              | Manifest (Git Repo) |
+|----------|----------------------------------------------------------|---------------------|
+| JS       | `npm install crypto-js@4.1.1 moment@2.29.4`              | `package.json`      |
+| Python   | `pip install 'pycryptodomex==3.20'`                      | `requirements.txt`  |
+| Go       | (latest versions resolved automatically)                | `go.mod`            |
+| Java     | a gradle command                                         | `build.gradle` (+ `./gradlew build`) |
+| PHP      | `composer require guzzlehttp/guzzle:^7.0`                | `composer.json`     |
+| Clojure  | `lein change :dependencies conj '[...]' && lein install` | `project.clj`       |
+| Lisp     | none — `(ql:quickload '(:cl-mustache) :silent t)` in code | —                  |
+| Prolog   | `swipl -g "pack_install(matrix,[interactive(false)])."`  | (same command)      |
+
+No dependencies → empty Build command.
+
+## 6. Deploy with the MCP
+
+`push-process` deploys Git Call nodes automatically (as of the git_call build
+support in this plugin). Just author the node like any other and push:
+
+1. Add a node whose logic `type` is `git_call`, set `lang` and either `code`
+   (inline) or `repo`/`commit`/`path`/`script` (Git Repo).
+2. `push-process` — it uploads the source, builds the container when the runtime
+   needs one, and commits. Interpreted runtimes (JavaScript) skip the build.
+
+Compiled runtimes take ~20–120 s on the first build (dependency install), then
+build from cache. `run-task` reports the task settling on a non-final node while
+the build runs — that is expected; the result merges into the task payload
+asynchronously.
+
+Override the build endpoint for on-prem installs with `COREZOID_WS_URL`.
+
+### What push-process does under the hood
+The container build runs on Corezoid's build service and is driven over a
+WebSocket (`wss://ws.<host>/api/1/sock_json`), authenticated with the same
+Simulator access token as the HTTP API. `push-process` opens the socket after
+uploading the source, sends a `monitor_show`/`function_build`/`status:"on"`
+frame to start the build, keeps the socket alive (client sends `"0"`, server
+answers `"1"`), waits for `log:{"type":"done"}`, then commits. You do not need to
+do any of this by hand — it is only useful to know when debugging a build.
+
+## 7. JSON-RPC 2.0 protocol
+
+Request to your code: `{"jsonrpc":"2.0","method":"handle","id":"…","params":{…}}`.
+Success: `{"jsonrpc":"2.0","id":"…","result":{…}}`. Error:
+`{"jsonrpc":"2.0","id":"…","error":{"code":…,"message":"…"}}`.
+
+For a **custom Dockerfile**, run an HTTP server on `$GIT_CALL_PORT`, handle POST
+requests per JSON-RPC 2.0, run as user `501:501`, and treat the container as
+read-only (`/tmp` is writable).
+
+## 8. Errors and troubleshooting
+
+On failure the task carries these fields (routed to the auxiliary condition
+output): `__conveyor_git_call_return_type_error__` (`Hardware` = system, retry;
+`Software` = code/settings), `__conveyor_git_call_return_type_tag__`
+(`git_call_return_format_error`, `git_call_executing_error`,
+`git_call_is_not_supported` = the node is v1, use v2, `code_return_size_overflow`,
+`git_call_fatal_error`), and `__conveyor_git_call_return_type_description__`.
+
+Common issues:
+
+- **push-process hangs / `no response from server`** — an older plugin without
+  git_call build support. Upgrade the plugin.
+- **`source has to be built`** — the container was not built before commit
+  (should not happen via push-process; if authoring by hand, build first).
+- **`usercode module has no handle function`** — the entry `handle` is missing,
+  or a stale build instance — rebuild.
+- **Build fails on root access** — Corezoid forbids root; keep to allowed dirs.
+- **No internet** — Git Call needs network to fetch the repo/dependencies.
+
+## 9. Resources
+
+Each container defaults to 100 millicpu (0.1 CPU) and 50 MB RAM, allocated
+globally across all Git Call nodes. For heavy workloads (crypto, large datasets)
+ask a super-admin to raise the global limit.
+
+## Reference
+
+- Examples (all languages + custom Dockerfiles): <https://github.com/corezoid/gitcall-examples>
+- Go runner: <https://github.com/corezoid/gitcall-go-runner>


### PR DESCRIPTION
## Summary

`push-process` could not deploy any process that contained a **Git Call** node —
it hung and returned `no response from server`, so git_call was effectively
unusable from the MCP. This PR makes `push-process` build and deploy git_call
nodes end-to-end, for every supported runtime.

## Why — the problem

Git Call runs user code (Python, Go, Java, PHP, JavaScript, Clojure, Lisp,
Prolog, or a custom Dockerfile) in an isolated container as a step of a process.
Unlike a Code node, a git_call node must be **built** (clone → install
dependencies → compile) before it can be committed. `Commit` rejects an unbuilt
node with `source has to be built`.

The MCP never performed that build:

- `CompileAPICode()` only handles `api_code` logic; `git_call` / `api_git` nodes
  were skipped entirely.
- So after `ModifyNodes` uploaded the source, `Commit` was sent against an
  unbuilt node and the request stalled — surfacing to the user as
  `failed to commit changes: no response from server`.

There was no workaround inside the MCP: the container build does not run over the
JSON-RPC HTTP API at all.

## How — the approach and why it is this way

The container build runs on Corezoid's build service and is driven over a
**WebSocket** (`wss://ws.<host>/api/1/sock_json`), not the HTTP API. It is
started by sending a `monitor_show` / `function_build` / `status:"on"` frame and
completes when the server emits `log:{"type":"done"}`. Crucially, the **same
Simulator access token** that authenticates the HTTP API also authenticates this
WebSocket — so the MCP can drive the build with the credentials it already has,
with no new auth surface.

This PR adds a dedicated build step to the push pipeline that mirrors what the
web UI does when you click *Build*:

1. `ModifyNodes` uploads the git_call source (as today).
2. **`BuildGitCallNodes`** (new): opens the build WebSocket with the token,
   sends the start frame for each compiled node, keeps the socket alive
   (client `"0"` → server `"1"`), and blocks until `done` — or fails / times out
   with the tail of the build log for context.
3. `Commit` now succeeds because the source is built.

Interpreted runtimes (JavaScript) execute source directly and need no container
build, so they are detected and skipped — they deploy in seconds.

Two supporting changes were required and are included:

- `fixStruct` marks git_call/api_git logic `code_error:false` (the built-source
  flag `Commit` checks), without clobbering an explicit value.
- The embedded JSON schema for `git_call`/`api_git` now permits the `code_error`
  property (otherwise schema validation rejects the process before the push even
  starts). This was caught by the end-to-end test, not by unit tests — see below.

The build endpoint is derived from the configured API URL
(`admin.<domain>` → `ws.<domain>`) and can be overridden with `COREZOID_WS_URL`
for on-prem or non-standard deployments.

## What it enables

`push-process` now deploys git_call nodes for **all** runtimes — Python, Go,
Java, PHP, JavaScript, Clojure, Lisp, Prolog and custom Dockerfiles — with no
manual UI step. This unblocks any workflow that needs file parsing, external
libraries, or custom code inside a process.

A dedicated, load-on-demand **`corezoid-gitcall` skill** documents the node
(when to use it vs a Code node, per-language handler contracts, modes,
dependencies, the build model, the JSON-RPC protocol, error tags, and limits).

## Changes

- `executor_gitcall.go` — new. `BuildGitCallNodes` + the WebSocket build driver,
  build-log parsing, WS-URL derivation, and node collection.
- `executor_process.go` — run `BuildGitCallNodes` between `CompileAPICode` and
  `Commit`.
- `main.go` — `fixStruct` sets `code_error:false` on git_call/api_git logic.
- `json-schema/logics/api_git.json` — allow the `code_error` property.
- `go.mod` / `go.sum` — add `github.com/gorilla/websocket`.
- `skills/corezoid-gitcall/SKILL.md` — new skill.
- Tests: `executor_gitcall_test.go` (unit) + `executor_gitcall_integration_test.go`
  (gated live build).

## Testing

- **Static:** `go build ./...`, `go vet ./...` — clean.
- **Unit** (`go test`): WS-URL derivation (cloud/on-prem/override), build-log
  frame parsing (stdout/done/error/garbage/keepalive), git_call node collection
  (server-id resolution, repo mode, js-skips-build), build UUID format, and the
  `fixStruct` `code_error` normalization (including "don't clobber explicit").
- **Integration** (`executor_gitcall_integration_test.go`, gated by
  `COREZOID_GITCALL_IT=1`): runs the real `BuildGitCallNodes` → `Commit` → run a
  task against a live workspace; builds a Python git_call node and confirms
  `handle()` executes. Skipped by default so CI stays offline/deterministic.
- **End-to-end via the actual `push-process` tool:** built the binary, deployed
  a `Start → git_call(python) → Done` process — `push-process` returned
  *deployed successfully* (previously hung), and a task through the node returned
  the value produced by `handle()`. This run is what surfaced the schema fix.

## Compatibility / risk

- Processes without git_call are unaffected — the new step is a no-op when no
  git_call node is present, and interpreted runtimes skip the build.
- No new credentials: the build WebSocket reuses the existing Simulator token.
- On-prem deployments can point the build socket at their host via
  `COREZOID_WS_URL`.
