### PR TITLE
feat(index): persistent project index — build-project-index, describe-process, corezoid-index skill [2.5.0]

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The plugin bundles a Go MCP server that exposes Corezoid operations as MCP tools
 | `corezoid-review`              | "review", "audit", "check" a process     | Analysis, dead code, best-practice violations     |
 | `corezoid-project-review`      | "review project", "audit folder"         | Cross-process audit of an entire folder           |
 | `corezoid-stage-scan`          | "scan stage", "check stage before merge", "why does the merge fail" | Offline pre-merge validation of exported stage `.zip`s: non-active/empty processes, broken node links, broken/inactive `conv_id` refs |
+| `corezoid-index`               | "index project", "build project index", "who calls process X" | Build/refresh `.corezoid/project-map.json` — persistent call graph, env-var usage, config-reference task contents, security hotspots |
 | `corezoid-dashboard-manager`   | "create dashboard", "add chart", "visualize metrics" | Dashboards, charts, node metrics, real-time monitoring |
 | `corezoid-process-tech-writer` | "document", "write docs", "describe process" | Markdown docs + enriched JSON with node descriptions |
 
@@ -198,6 +199,8 @@ validation errors, and summarize what each process does.
 | `pull-process`      | Export a single process to a `.conv.json` file     |
 | `push-process`      | Validate and deploy a `.conv.json` to Corezoid     |
 | `lint-process`      | Validate process structure locally (no API call)   |
+| `build-project-index` | Build/refresh `.corezoid/project-map.json`, `QUERIES.md`, and CLAUDE.md auto-block for the pulled project (no API call). Pass `mode="check"` to detect staleness without rebuilding |
+| `describe-process`  | Resolve a process identifier (conv_id/alias/title) against the project index and return path + calls_in count + staleness in one call |
 | `run-task`          | Send a task to a deployed process                  |
 | `list-node-tasks`   | List tasks currently sitting in a node             |
 | `list-task-history` | Show task execution history                        |

--- a/plugins/corezoid/docs/process/corezoid-api-integration.md
+++ b/plugins/corezoid/docs/process/corezoid-api-integration.md
@@ -1,0 +1,96 @@
+# Corezoid Public API Integration Pattern
+
+Reference for building Corezoid processes that call the Corezoid public API (`/api/2/json/`).
+
+## Key difference from external API connectors
+
+Corezoid's own API uses `api_secret_outer` for HMAC authentication — **never** a Code Node for SHA1 signing. The platform handles signing automatically when `api_secret_outer` is set.
+
+## Required input params
+
+| Name | Type | Description |
+|---|---|---|
+| `api_login` | string | API key login (from workspace settings) |
+| `api_secret` | string | API key secret (used in `api_secret_outer`) |
+| `workspaceId` | string | Workspace (company) ID |
+
+Add operation-specific params (`processId`, `nodeId`, `limit`, `offset`, etc.).
+
+## Process flow
+
+```
+Start → API Call → Reply Success → Final [obj_type:2]
+              │
+         (err)└──► Error Escalation [obj_type:3] ──► Error [obj_type:2]
+        (time)└──► Timeout Escalation [obj_type:3] ──► Timeout [obj_type:2]
+```
+
+No Code Node is needed — `api_secret_outer` handles all authentication.
+
+## API Call node
+
+```json
+{
+  "type": "api",
+  "api_secret_outer": "{{api_secret}}",
+  "method": "POST",
+  "url": "https://api.corezoid.com/api/2/json/{{api_login}}",
+  "format": "",
+  "extra": {
+    "ops": "[{\"type\":\"list\",\"obj\":\"node\",\"company_id\":\"{{workspaceId}}\",\"conv_id\":{{processId}},\"limit\":{{limit}},\"offset\":{{offset}}}]"
+  },
+  "extra_type": {
+    "ops": "array"
+  },
+  "extra_headers": { "content-type": "application/json; charset=utf-8" },
+  "send_sys": true,
+  "rfc_format": true,
+  "is_migrate": true,
+  "customize_response": false,
+  "response": { "body": "{{body}}", "header": "{{header}}" },
+  "response_type": { "body": "object", "header": "object" },
+  "version": 2,
+  "max_threads": 5,
+  "debug_info": false,
+  "cert_pem": "",
+  "err_node_id": "<error_escalation_node_id>"
+}
+```
+
+Add a 30-second timeout semaphor to the API Call node.
+
+## Critical rules
+
+- `api_secret_outer` handles all auth — never compute HMAC in a Code Node
+- `ops` value must be a **stringified JSON string** with type `"array"`
+- `format` must be `""` (empty string), not `"raw"`
+- `send_sys: true` is required
+- `customize_response: false` — use default `body`/`header` response mapping
+- `rfc_format: true` is required
+
+## Reply Success node
+
+```json
+{
+  "type": "api_rpc_reply",
+  "mode": "key_value",
+  "res_data": { "result": "success", "response": "{{ops[0]}}" },
+  "res_data_type": { "result": "string", "response": "object" },
+  "throw_exception": false
+}
+```
+
+## Sample
+
+See `samples/corezoid-api-node-list.conv.json` for a complete working example (Node List operation).
+
+## Available `ops` types
+
+Refer to [openapi.corezoid.com](https://openapi.corezoid.com) for the full list of operations and their field schemas. Common operations:
+
+| `obj` | `type` | Description |
+|---|---|---|
+| `node` | `list` | List nodes in a process |
+| `conv` | `list` | List processes in a folder |
+| `task` | `list` | List tasks in a node |
+| `company` | `list` | List workspaces |

--- a/plugins/corezoid/mcp-server/index_benchmark_test.go
+++ b/plugins/corezoid/mcp-server/index_benchmark_test.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// sla200SoftBudget is the target ceiling from the TZ (§8 / criterion #19):
+// full rebuild on a 200-process synthetic hub-topology project must finish
+// in ≤ 500 ms on typical developer hardware. This is a soft budget — CI
+// runners vary widely in speed, so a hard failure on CI would produce
+// flakes. Instead the SLA test warns loudly (t.Log) when the budget is
+// exceeded, and the CI job's job-level timeout is the ultimate cap. Set
+// COREZOID_SLA_STRICT=1 in the environment to promote the warning to a
+// hard failure — useful locally on a known-good machine.
+const sla200SoftBudget = 500 * time.Millisecond
+
+// synthesise200ProcessHubProject generates a project tree with 200 processes
+// arranged in a hub topology: 5 hub processes referenced by 195 caller
+// processes via mixed api_rpc / api_copy / api_get_task with aliases. This
+// matches the shape of real-world Corezoid projects where a shared
+// error-handling / logging / lookup process is referenced from many places —
+// the topology that broke the original findCycles implementation before the
+// globalDone optimisation (see index_graph.go).
+//
+// Written to t.TempDir(); no committed bytes needed. Fast to generate
+// (~10ms) so it can be regenerated per-test without blowing the run time.
+func synthesise200ProcessHubProject(t testing.TB, root string) {
+	t.Helper()
+
+	// 5 hubs, ids 1..5. Each hub is a minimal 2-node process (Start → End)
+	// so parsing is cheap but structure is realistic.
+	for i := 1; i <= 5; i++ {
+		writeSyntheticProcess(t, root, i, fmt.Sprintf("hub-%d", i), nil)
+	}
+	// Aliases file in the real (array) shape — hub-1..hub-5 point to id 1..5.
+	var aliasEntries []string
+	for i := 1; i <= 5; i++ {
+		aliasEntries = append(aliasEntries,
+			fmt.Sprintf(`{"short_name":"hub-%d","obj_to_id":%d,"obj_to_type":"conv","title":"hub-%d","obj_id":%d}`,
+				i, i, i, 900000+i))
+	}
+	aliasJSON := "[" + strings.Join(aliasEntries, ",") + "]"
+	if err := os.WriteFile(filepath.Join(root, "_ALIASES_.json"), []byte(aliasJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// A modest _ENV_VARS_.json (10 vars, half referenced later) so the
+	// env-var scanner has real work to do.
+	envVarsEntries := []string{}
+	for i := 1; i <= 10; i++ {
+		envVarsEntries = append(envVarsEntries,
+			fmt.Sprintf(`"VAR_%d": {"description": "test var %d"}`, i, i))
+	}
+	envJSON := "{" + strings.Join(envVarsEntries, ",") + "}"
+	if err := os.WriteFile(filepath.Join(root, "_ENV_VARS_.json"), []byte(envJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// 195 caller processes, ids 100..294. Each has a Start node plus 3
+	// cross-process nodes: api_rpc to a random hub via @alias, api_copy to
+	// hub-1 (state-store simulation), api_get_task to another hub. Also
+	// includes an api node with an env_var reference so the env_var scanner
+	// exercises the whole logic tree.
+	for i := 0; i < 195; i++ {
+		id := 100 + i
+		hubA := (i % 5) + 1                    // via alias
+		hubB := ((i + 2) % 5) + 1              // direct numeric
+		envVar := fmt.Sprintf("VAR_%d", (i%10)+1)
+		writeSyntheticProcess(t, root, id, fmt.Sprintf("caller-%d", id),
+			[]syntheticNode{
+				{ID: "a" + padID(id, 1), Type: "api",
+					Logic: fmt.Sprintf(`{"type":"api","url":"{{env_var[@%s]}}/x","method":"GET"}`, envVar)},
+				{ID: "a" + padID(id, 2), Type: "api_rpc",
+					Logic: fmt.Sprintf(`{"type":"api_rpc","conv_id":"@hub-%d"}`, hubA)},
+				{ID: "a" + padID(id, 3), Type: "api_copy",
+					Logic: fmt.Sprintf(`{"type":"api_copy","conv_id":1,"mode":"create"}`)},
+				{ID: "a" + padID(id, 4), Type: "api_get_task",
+					Logic: fmt.Sprintf(`{"type":"api_get_task","conv_id":%d}`, hubB)},
+			})
+	}
+}
+
+type syntheticNode struct {
+	ID    string
+	Type  string
+	Logic string
+}
+
+func writeSyntheticProcess(t testing.TB, root string, id int, title string, extraNodes []syntheticNode) {
+	t.Helper()
+	startID := "s" + padID(id, 0)
+	endID := "e" + padID(id, 0)
+
+	// Assemble node JSON blobs — Start goes to first extra node (if any) or
+	// End; each extra node also goes to End for a simple linear flow.
+	firstNext := endID
+	if len(extraNodes) > 0 {
+		firstNext = extraNodes[0].ID
+	}
+	nodeBlobs := []string{
+		fmt.Sprintf(`{"id":"%s","title":"Start","obj_type":1,"condition":{"logics":[{"type":"go","to_node_id":"%s"}]}}`,
+			startID, firstNext),
+	}
+	for i, n := range extraNodes {
+		nextID := endID
+		if i+1 < len(extraNodes) {
+			nextID = extraNodes[i+1].ID
+		}
+		// Extra node carries the specified logic, then a go to next.
+		nodeBlobs = append(nodeBlobs, fmt.Sprintf(
+			`{"id":"%s","title":"%s-%d","obj_type":0,"condition":{"logics":[%s,{"type":"go","to_node_id":"%s"}]}}`,
+			n.ID, n.Type, i, n.Logic, nextID))
+	}
+	nodeBlobs = append(nodeBlobs, fmt.Sprintf(
+		`{"id":"%s","title":"End","obj_type":2,"condition":{"logics":[]}}`, endID))
+
+	body := fmt.Sprintf(`{
+	  "obj_type":1,"obj_id":%d,"title":%q,"conv_type":"process","status":"active",
+	  "scheme":{"nodes":[%s]}
+	}`, id, title, strings.Join(nodeBlobs, ","))
+
+	path := filepath.Join(root, fmt.Sprintf("%d_%s.conv.json", id, sanitise(title)))
+	if err := os.WriteFile(path, []byte(body), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// padID returns a 24-char-safe hex-looking suffix for a numeric process id
+// and a sub-index. Corezoid node IDs are 24 hex chars; the synthesised IDs
+// aren't real hashes but the length is right so any downstream validation
+// that expects 24 chars keeps working.
+func padID(processID, subIdx int) string {
+	base := fmt.Sprintf("%d%d", processID, subIdx)
+	return strings.Repeat("0", 24-len(base)-1) + base
+}
+
+func sanitise(s string) string {
+	out := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			return r
+		case r == '-', r == '_':
+			return r
+		}
+		return '_'
+	}, s)
+	return out
+}
+
+// TestIndex_SLA_200Processes materialises the 200-process hub-topology
+// project and asserts that a full BuildProjectIndex + WriteProjectMap +
+// WriteQueriesMD + UpdateClaudeMD sequence completes within the soft budget
+// (see sla200SoftBudget). A budget miss is logged loudly. Set
+// COREZOID_SLA_STRICT=1 to fail hard instead of logging.
+//
+// This is TZ criterion #19: the SLA must be verified by test, not by hand
+// timing. The topology deliberately mirrors real-world hub graphs — the
+// worst case for the cycle detector and edge resolver — so a passing budget
+// here is stronger evidence than 200 unrelated processes would be.
+func TestIndex_SLA_200Processes(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping SLA test in -short mode")
+	}
+	root := t.TempDir()
+	synthesise200ProcessHubProject(t, root)
+
+	start := time.Now()
+	pm, warnings, err := BuildProjectIndex(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteProjectMap(root, pm); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteQueriesMD(root); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := UpdateClaudeMD(root, pm); err != nil {
+		t.Fatal(err)
+	}
+	elapsed := time.Since(start)
+
+	// Sanity-check the fixture actually produced the expected graph — a
+	// bug here (e.g. all edges going to unresolved_targets) would make the
+	// tool artificially fast and mask a real perf regression.
+	if pm.ProcessCount != 200 {
+		t.Fatalf("ProcessCount = %d, want 200 (fixture generation broken?)", pm.ProcessCount)
+	}
+	if len(pm.Edges) < 195*3 { // each caller emits 3 cross-process edges
+		t.Fatalf("edges = %d, want ≥ %d — alias resolution or edge collection is broken",
+			len(pm.Edges), 195*3)
+	}
+	if len(warnings) > 0 {
+		t.Logf("build warnings: %v", warnings)
+	}
+
+	t.Logf("BuildProjectIndex+writers on 200-process hub topology: %v (budget %v)",
+		elapsed, sla200SoftBudget)
+
+	if elapsed > sla200SoftBudget {
+		msg := fmt.Sprintf("SLA violation: %v > budget %v on 200-process hub project",
+			elapsed, sla200SoftBudget)
+		if os.Getenv("COREZOID_SLA_STRICT") == "1" {
+			t.Fatal(msg)
+		} else {
+			t.Log("WARN: " + msg + " — soft budget, set COREZOID_SLA_STRICT=1 to fail hard")
+		}
+	}
+}
+
+// BenchmarkBuildProjectIndex measures the same 200-process build for use
+// with `go test -bench . -benchmem`. Complements the pass/fail SLA test
+// above with continuous measurement — useful when comparing branches, and
+// the natural home for the "hub topology" performance concern from review
+// point 3.
+func BenchmarkBuildProjectIndex(b *testing.B) {
+	root := b.TempDir()
+	synthesise200ProcessHubProject(b, root)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		pm, _, err := BuildProjectIndex(context.Background(), root)
+		if err != nil {
+			b.Fatal(err)
+		}
+		_ = pm
+	}
+}

--- a/plugins/corezoid/mcp-server/index_builder.go
+++ b/plugins/corezoid/mcp-server/index_builder.go
@@ -1,0 +1,1258 @@
+package main
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// reEnvVarUsage finds Corezoid environment variable references in string
+// values inside a process. The @-prefix is required (the platform syntax);
+// name characters are anything except closing bracket, whitespace, or brace.
+var reEnvVarUsage = regexp.MustCompile(`\{\{env_var\[@([^\]\s\}]+)\]`)
+
+// reConvRefUsage finds Corezoid cross-task reference syntax like
+// {{conv[@config].ref[api_url]}} — where `conv[@X]` names a task by alias
+// or ref. Captured group 1 is the alias/ref name without the @. Used to
+// populate the `used_by` list for each entry in config_references.
+var reConvRefUsage = regexp.MustCompile(`\{\{conv\[@([^\]\s\}]+)\]`)
+
+// reConvRefField extends reConvRefUsage to also capture the `.ref[X]`
+// field name that follows. This tells the config_references collector
+// WHICH fields of a config are actually read by which processes — a
+// grep-quality signal built into the index instead of asking every reader
+// to grep the diagrams themselves. Group 1 = ref/alias name, group 2 =
+// field name. Not every conv-ref has a trailing .ref[X] (some just check
+// existence), so this regex is used *in addition to* reConvRefUsage, not
+// instead of.
+var reConvRefField = regexp.MustCompile(`\{\{conv\[@([^\]\s\}]+)\]\.ref\[([^\]\s\}]+)\]`)
+
+// reProcessFileName matches "<conv_id>_<name>.conv.json" and captures the id.
+var reProcessFileName = regexp.MustCompile(`^(\d+)_.*\.conv\.json$`)
+
+// reFolderMarker matches "<id>_<name>.folder.json" or "<id>_<name>.stage.json".
+var reFolderMarker = regexp.MustCompile(`^(\d+)_.*\.(folder|stage)\.json$`)
+
+// reInstanceFileName matches "<instance_id>_<name>.instance.json".
+var reInstanceFileName = regexp.MustCompile(`^(\d+)_.*\.instance\.json$`)
+
+// BuildProjectIndex walks the project rooted at absRoot and produces a
+// ProjectMap plus a list of non-fatal warnings. absRoot must exist. Missing
+// optional files (_ALIASES_.json, _ENV_VARS_.json, *.instance.json) are not
+// an error — the corresponding sections come back empty.
+//
+// The index is a pure local scan — no network calls, no Corezoid auth.
+// config_references records which processes read which config refs and
+// which fields they access, but stores no runtime values. Agents read
+// live config values on demand via list-node-tasks when they need them.
+func BuildProjectIndex(ctx context.Context, absRoot string) (*ProjectMap, []string, error) {
+	if info, err := os.Stat(absRoot); err != nil || !info.IsDir() {
+		return nil, nil, fmt.Errorf("project root %q is not a directory", absRoot)
+	}
+
+	var warnings []string
+
+	pm := &ProjectMap{
+		SchemaVersion:     IndexSchemaVersion,
+		GeneratedAt:       time.Now().UTC().Format(time.RFC3339),
+		Root:              absRoot,
+		Processes:         map[string]*ProcessEntry{},
+		ByAlias:           map[string]string{},
+		EnvVars:           map[string]*EnvVarEntry{},
+		Edges:             []Edge{},
+		CallsIn:           map[string][]string{},
+		UnresolvedTargets: map[string][]string{},
+		ExternalAPIs:      map[string][]string{},
+		StateStores:       map[string]*StateStoreEntry{},
+		Instances:         map[string]*InstanceEntry{},
+		SecurityHotspots:  []SecurityHotspot{},
+	}
+
+	// .env shape parsing is intentionally naive — we only need two keys and the
+	// file format is a simple KEY=VALUE list, so a full dotenv library would be
+	// dead weight here.
+	pm.WorkspaceID, pm.StageID = readDotEnv(absRoot)
+
+	// Optional files first — presence/absence determines what sections light up.
+	aliasesFwd, aliasesRev, aliasWarn := readAliases(absRoot)
+	if aliasWarn != "" {
+		warnings = append(warnings, aliasWarn)
+	}
+	pm.ByAlias = flattenAliases(aliasesFwd)
+
+	envVarsMeta, envVarWarn := readEnvVars(absRoot)
+	if envVarWarn != "" {
+		warnings = append(warnings, envVarWarn)
+	}
+	for name, desc := range envVarsMeta {
+		pm.EnvVars[name] = &EnvVarEntry{Description: desc, UsedBy: []string{}}
+	}
+
+	// Two-pass process discovery. First pass collects title+conv_type+status
+	// for every process (needed so edges can attach titles even when the
+	// target hasn't been visited yet), plus records aliases, hashes, and
+	// per-process raw call/env-var findings. Second pass resolves calls into
+	// edges once every conv_id in the project is known.
+	findings := map[string]*rawIndexFindings{}
+	bc := newBreadcrumbCache()
+
+	// Discovery walk. Skip .corezoid/ to avoid re-reading our own output when
+	// running --check or a repeated build.
+	err := filepath.WalkDir(absRoot, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			base := d.Name()
+			if base == IndexOutputDir || base == ".git" || base == "node_modules" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := d.Name()
+
+		switch {
+		case strings.HasSuffix(name, ".conv.json"):
+			cid, entry, rf, warn, perr := indexConvJSON(absRoot, path, aliasesRev, bc)
+			if perr != nil {
+				warnings = append(warnings, fmt.Sprintf("%s: %v", path, perr))
+				return nil
+			}
+			if warn != "" {
+				warnings = append(warnings, warn)
+			}
+			if cid == "" || entry == nil {
+				return nil
+			}
+			if existing, dup := pm.Processes[cid]; dup {
+				warnings = append(warnings, fmt.Sprintf(
+					"duplicate conv_id %s: %q shadows %q — only the last one is indexed",
+					cid, entry.Path, existing.Path))
+			}
+			pm.Processes[cid] = entry
+			findings[cid] = rf
+			if entry.ConvType == "state" {
+				pm.StateStoreCount++
+				pm.StateStores[cid] = &StateStoreEntry{
+					Title:     entry.Title,
+					Aliases:   entry.Aliases,
+					Path:      entry.Path,
+					WrittenBy: []string{},
+				}
+			} else {
+				pm.ProcessCount++
+			}
+
+		case reInstanceFileName.MatchString(name):
+			iid, ie, ierr := indexInstanceJSON(absRoot, path)
+			if ierr != nil {
+				warnings = append(warnings, fmt.Sprintf("%s: %v", path, ierr))
+				return nil
+			}
+			if ie == nil {
+				return nil
+			}
+			pm.Instances[iid] = ie
+			pm.InstanceCount++
+			if len(ie.SecretFieldsPresent) > 0 {
+				pm.SecurityHotspots = append(pm.SecurityHotspots, SecurityHotspot{
+					Source:     "instance",
+					InstanceID: iid,
+					Title:      ie.Title,
+					Path:       ie.Path,
+					Fields:     append([]string(nil), ie.SecretFieldsPresent...),
+				})
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, warnings, fmt.Errorf("walking project tree: %v", err)
+	}
+
+	// Pass 2: resolve calls into edges. Numeric conv_ids that don't exist in
+	// this project's inventory go to unresolved_targets, not edges, because
+	// they refer to something outside the pulled scope and we can't attach a
+	// title. Same for dynamic {{...}} — deliberately unresolvable at index
+	// time.
+	convRefUsage := map[string][]string{}           // ref-name → [conv_id, ...]
+	convRefFieldsByRef := map[string][]string{}     // ref-name → [.ref[X] field, ...]
+	for cid, rf := range findings {
+		pe := pm.Processes[cid]
+		for _, c := range rf.calls {
+			target, ok := resolveTarget(c.targetRaw, aliasesFwd, pm.Processes)
+			if !ok {
+				pm.UnresolvedTargets[cid] = append(pm.UnresolvedTargets[cid],
+					fmt.Sprintf("%s (%s)", c.targetRaw, c.ctype))
+				continue
+			}
+			e := Edge{
+				From:     cid,
+				To:       target,
+				Type:     c.ctype,
+				Mode:     c.mode,
+				ViaAlias: c.via,
+			}
+			pm.Edges = append(pm.Edges, e)
+		}
+		for _, url := range rf.externalURLs {
+			pm.ExternalAPIs[url] = append(pm.ExternalAPIs[url], cid)
+		}
+		if rf.envVars != nil {
+			for name := range rf.envVars {
+				ev, ok := pm.EnvVars[name]
+				if !ok {
+					// Referenced but not declared in _ENV_VARS_.json (either
+					// no such file, or the var is used elsewhere in the
+					// workspace but not registered here). Track anyway so the
+					// index answers "where is @X used" for undeclared vars.
+					ev = &EnvVarEntry{Description: "", UsedBy: []string{}}
+					pm.EnvVars[name] = ev
+				}
+				ev.UsedBy = append(ev.UsedBy, cid)
+			}
+		}
+		for ref := range rf.convRefs {
+			convRefUsage[ref] = append(convRefUsage[ref], cid)
+		}
+		for ref, fields := range rf.convRefFields {
+			for f := range fields {
+				convRefFieldsByRef[ref] = append(convRefFieldsByRef[ref], f)
+			}
+		}
+		pe.DBCalls = uniqueSorted(rf.dbCalls)
+		pe.EnvVarRefs = mapKeysSorted(rf.envVars)
+		pe.HasReceiverNode = rf.receiver
+		pm.SecurityHotspots = append(pm.SecurityHotspots, rf.hotspots...)
+	}
+	for k := range convRefUsage {
+		convRefUsage[k] = uniqueSorted(convRefUsage[k])
+	}
+	for k := range convRefFieldsByRef {
+		convRefFieldsByRef[k] = uniqueSorted(convRefFieldsByRef[k])
+	}
+
+	// Sort external_apis[]/env_vars[].used_by lists for stable output.
+	for k := range pm.ExternalAPIs {
+		pm.ExternalAPIs[k] = uniqueSorted(pm.ExternalAPIs[k])
+	}
+	for _, ev := range pm.EnvVars {
+		ev.UsedBy = uniqueSorted(ev.UsedBy)
+	}
+
+	// Sort edges deterministically, then deduplicate. Duplicate edges arise
+	// when multiple nodes in the same process call the same target (common
+	// for shared error handlers). Without deduplication, jq consumers that
+	// count outgoing edges via [.edges[] | select(.from == $id)] would
+	// overcount. Deduplication happens after sort so identical edges are
+	// adjacent and a single linear pass removes them.
+	sort.Slice(pm.Edges, func(i, j int) bool {
+		a, b := pm.Edges[i], pm.Edges[j]
+		if a.From != b.From {
+			return a.From < b.From
+		}
+		if a.To != b.To {
+			return a.To < b.To
+		}
+		if a.Type != b.Type {
+			return a.Type < b.Type
+		}
+		return a.Mode < b.Mode
+	})
+	deduped := pm.Edges[:0]
+	for i, e := range pm.Edges {
+		if i == 0 || e.From != pm.Edges[i-1].From || e.To != pm.Edges[i-1].To ||
+			e.Type != pm.Edges[i-1].Type || e.Mode != pm.Edges[i-1].Mode {
+			deduped = append(deduped, e)
+		}
+	}
+	pm.Edges = deduped
+
+	// Derive calls_in / state_stores.written_by from edges.
+	// calls_out is removed — use jq '[.edges[] | select(.from == $id)]' instead.
+	// calls_in is a sorted, deduplicated set of caller conv_ids.
+	callInSet := map[string]map[string]struct{}{}
+	for _, e := range pm.Edges {
+		if callInSet[e.To] == nil {
+			callInSet[e.To] = map[string]struct{}{}
+		}
+		callInSet[e.To][e.From] = struct{}{}
+	}
+	for cid, set := range callInSet {
+		pm.CallsIn[cid] = mapKeysSorted(set)
+	}
+	// state_stores.written_by from edges into a state process via api_copy.
+	for _, e := range pm.Edges {
+		if e.Type != "api_copy" {
+			continue
+		}
+		ss, ok := pm.StateStores[e.To]
+		if !ok {
+			continue
+		}
+		if !containsString(ss.WrittenBy, e.From) {
+			ss.WrittenBy = append(ss.WrittenBy, e.From)
+		}
+	}
+	for _, ss := range pm.StateStores {
+		ss.WrittenBy = uniqueSorted(ss.WrittenBy)
+	}
+
+	// Attach unresolved_targets as a stable slice (map already, but dedupe).
+	for k, list := range pm.UnresolvedTargets {
+		pm.UnresolvedTargets[k] = uniqueSorted(list)
+	}
+
+	// Load per-project heuristic config for entry_point / orphaned.
+	cfg, cfgWarn, cfgErr := LoadOrCreateIndexConfig(absRoot)
+	if cfgErr != nil {
+		warnings = append(warnings, "index-config.json: "+cfgErr.Error())
+	}
+	warnings = append(warnings, cfgWarn...)
+
+	pm.GraphStats = computeGraphStats(pm, cfg)
+
+	// Stable sort for security_hotspots so goldens don't flap.
+	sort.Slice(pm.SecurityHotspots, func(i, j int) bool {
+		a, b := pm.SecurityHotspots[i], pm.SecurityHotspots[j]
+		if a.Source != b.Source {
+			return a.Source < b.Source
+		}
+		if a.Path != b.Path {
+			return a.Path < b.Path
+		}
+		return a.NodeID < b.NodeID
+	})
+
+	// config_references — pure local scan. No network calls, no auth.
+	// Records which processes read which config refs and which fields,
+	// but stores no runtime values. Agents call list-node-tasks when
+	// they need live values (see corezoid-index skill).
+	if crMap := collectConfigReferences(cfg.ConfigReferences, pm,
+		convRefUsage, convRefFieldsByRef); len(crMap) > 0 {
+		pm.ConfigReferences = crMap
+	}
+
+	return pm, warnings, nil
+}
+
+// indexConvJSON parses one .conv.json file and returns the summary plus the
+// raw per-process findings that pass 2 will resolve into edges.
+// maxIndexFileBytes caps the size of individual .conv.json / .instance.json
+// files read during indexing. Corezoid exports are typically 5–50 KB; a
+// megabyte-scale file is almost certainly corrupt or not a real process.
+const maxIndexFileBytes = 1 << 20 // 1 MiB
+
+func indexConvJSON(root, path string, aliasesRev map[string][]string, bc breadcrumbCache) (string, *ProcessEntry, *rawIndexFindings, string, error) {
+	if info, err := os.Stat(path); err == nil && info.Size() > maxIndexFileBytes {
+		return "", nil, nil, fmt.Sprintf("%s: file too large (%d bytes), skipping", path, info.Size()), nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", nil, nil, "", err
+	}
+	var proc map[string]interface{}
+	if err := json.Unmarshal(data, &proc); err != nil {
+		return "", nil, nil, "", err
+	}
+
+	// conv_id from filename, not from JSON, so re-numbering during export
+	// doesn't invalidate the graph.
+	base := filepath.Base(path)
+	m := reProcessFileName.FindStringSubmatch(base)
+	if m == nil {
+		return "", nil, nil, fmt.Sprintf("%s: filename does not match <id>_<name>.conv.json", path), nil
+	}
+	cid := m[1]
+
+	title, _ := proc["title"].(string)
+	convType, _ := proc["conv_type"].(string)
+	if convType == "" {
+		convType = "process"
+	}
+	status, _ := proc["status"].(string)
+
+	info, statErr := os.Stat(path)
+	if statErr != nil {
+		return "", nil, nil, fmt.Sprintf("stat %s: %v", path, statErr), nil
+	}
+	rel, _ := filepath.Rel(root, path)
+
+	entry := &ProcessEntry{
+		Title:      title,
+		ConvType:   convType,
+		Status:     status,
+		Path:       filepath.ToSlash(rel),
+		Location:   buildBreadcrumb(root, path, bc),
+		Aliases:    aliasesForConv(cid, aliasesRev),
+		EnvVarRefs: []string{},
+		Hash:  hashBytes(data),
+		MTime: info.ModTime().UTC().Format(time.RFC3339Nano),
+	}
+
+	nodes, _ := getNodes(proc)
+	entry.NodeCount = len(nodes)
+
+	findings := &rawIndexFindings{
+		envVars:       map[string]struct{}{},
+		convRefs:      map[string]struct{}{},
+		convRefFields: map[string]map[string]struct{}{},
+	}
+
+	for _, raw := range nodes {
+		node, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		nodeID, _ := node["id"].(string)
+		cond, _ := node["condition"].(map[string]interface{})
+		logics := toMapSlice(cond["logics"])
+		if len(logics) == 0 {
+			continue
+		}
+
+		// Scan every string value in every logic for {{env_var[@...]}} — the
+		// pattern can appear in any field (url, extra values, code node text,
+		// etc.), and we don't want to enumerate every schema path here.
+		walkStrings(logics, func(s string) {
+			for _, mm := range reEnvVarUsage.FindAllStringSubmatch(s, -1) {
+				if len(mm) >= 2 {
+					findings.envVars[mm[1]] = struct{}{}
+				}
+			}
+			for _, mm := range reConvRefUsage.FindAllStringSubmatch(s, -1) {
+				if len(mm) >= 2 {
+					findings.convRefs[mm[1]] = struct{}{}
+				}
+			}
+			for _, mm := range reConvRefField.FindAllStringSubmatch(s, -1) {
+				if len(mm) >= 3 {
+					if findings.convRefFields[mm[1]] == nil {
+						findings.convRefFields[mm[1]] = map[string]struct{}{}
+					}
+					findings.convRefFields[mm[1]][mm[2]] = struct{}{}
+				}
+			}
+		})
+
+		for _, lg := range logics {
+			ltype, _ := lg["type"].(string)
+
+			if ltype == "api_callback" {
+				findings.receiver = true
+			}
+
+			if isCrossProcessType(ltype) {
+				convRef, viaAlias := extractCrossProcessRef(lg)
+				if convRef == "" {
+					// Malformed reference — silently skip; not our job to
+					// diagnose broken diagrams (that's lint-process/stage-scan).
+					continue
+				}
+				call := rawCall{
+					targetRaw: convRef,
+					via:       viaAlias,
+					ctype:     ltype,
+				}
+				if ltype == "api_copy" {
+					call.mode, _ = lg["mode"].(string)
+				}
+				findings.calls = append(findings.calls, call)
+			}
+
+			if ltype == "api" {
+				if url, _ := lg["url"].(string); url != "" {
+					findings.externalURLs = append(findings.externalURLs, url)
+				}
+				// Scan extra_headers keys + extra field values under
+				// secret-shaped names in api-type logics.
+				if hdrs, ok := lg["extra_headers"].(map[string]interface{}); ok {
+					hits := scanMapForSecrets(hdrs, true)
+					if len(hits) > 0 {
+						findings.hotspots = append(findings.hotspots, SecurityHotspot{
+							Source: "diagram",
+							ConvID: cid,
+							NodeID: nodeID,
+							Title:  title,
+							Path:   filepath.ToSlash(rel),
+							Fields: hits,
+						})
+					}
+				}
+				if extra, ok := lg["extra"].(map[string]interface{}); ok {
+					hits := scanMapForSecrets(extra, true)
+					if len(hits) > 0 {
+						findings.hotspots = append(findings.hotspots, SecurityHotspot{
+							Source: "diagram",
+							ConvID: cid,
+							NodeID: nodeID,
+							Title:  title,
+							Path:   filepath.ToSlash(rel),
+							Fields: hits,
+						})
+					}
+				}
+			}
+
+			if ltype == "db_call" {
+				instanceID, _ := lg["instance_id"].(string)
+				instanceName, _ := lg["instance_name"].(string)
+				if instanceID != "" {
+					if instanceName != "" {
+						findings.dbCalls = append(findings.dbCalls, instanceID+" ("+instanceName+")")
+					} else {
+						findings.dbCalls = append(findings.dbCalls, instanceID)
+					}
+				}
+			}
+		}
+	}
+
+	return cid, entry, findings, "", nil
+}
+
+// rawIndexFindings is a private companion to ProcessEntry, holding data that
+// only pass 2 (edge resolution) needs. Never serialized.
+type rawIndexFindings struct {
+	calls        []rawCall
+	externalURLs []string
+	dbCalls      []string
+	envVars      map[string]struct{}
+	// convRefs tracks {{conv[@name].ref[...]}} references — the name
+	// (without @) is stored. Used by the config_references collector to
+	// build the used_by list per configured ref without a second scan.
+	convRefs map[string]struct{}
+	// convRefFields tracks the .ref[X] field names extracted from
+	// {{conv[@name].ref[X]}} usages: name → {X, ...}. Populated in the
+	// same walkStrings pass as convRefs. The collector uses this to tell
+	// the reader which specific fields of a config each process reads —
+	// a signal that today requires a manual grep.
+	convRefFields map[string]map[string]struct{}
+	receiver      bool
+	hotspots      []SecurityHotspot
+}
+
+type rawCall struct {
+	targetRaw string
+	via       string
+	ctype     string
+	mode      string
+}
+
+// extractCrossProcessRef pulls the conv_id from a cross-process logic block.
+// Corezoid stores conv_id as either a number (float64 after json.Unmarshal), a
+// string (when it's @alias or a dynamic expression), or as top-level "conv_id"
+// vs nested under "extra" — we accept all layouts we've seen.
+func extractCrossProcessRef(lg map[string]interface{}) (raw, viaAlias string) {
+	tryVal := func(v interface{}) string {
+		switch x := v.(type) {
+		case float64:
+			return fmt.Sprintf("%d", int(x))
+		case string:
+			return x
+		case int:
+			return fmt.Sprintf("%d", x)
+		}
+		return ""
+	}
+	if v, ok := lg["conv_id"]; ok {
+		raw = tryVal(v)
+	}
+	if raw == "" {
+		if extra, ok := lg["extra"].(map[string]interface{}); ok {
+			raw = tryVal(extra["conv_id"])
+		}
+	}
+	// Some payloads carry the alias in "short_name" — track it so the edge
+	// records via_alias even if the resolution happens through _ALIASES_.json.
+	if strings.HasPrefix(raw, "@") {
+		viaAlias = raw
+	} else if sn, ok := lg["short_name"].(string); ok && sn != "" {
+		viaAlias = "@" + strings.TrimPrefix(sn, "@")
+	}
+	return raw, viaAlias
+}
+
+func resolveTarget(raw string, aliasesFwd map[string]string, processes map[string]*ProcessEntry) (string, bool) {
+	if raw == "" {
+		return "", false
+	}
+	// Dynamic expression — unresolvable at index time.
+	if strings.Contains(raw, "{{") {
+		return "", false
+	}
+	if strings.HasPrefix(raw, "@") {
+		if cid, ok := aliasesFwd[raw]; ok {
+			if _, present := processes[cid]; present {
+				return cid, true
+			}
+		}
+		key := strings.TrimPrefix(raw, "@")
+		if cid, ok := aliasesFwd[key]; ok {
+			if _, present := processes[cid]; present {
+				return cid, true
+			}
+		}
+		return "", false
+	}
+	// Numeric conv_id — only resolves if that process is in this project.
+	if _, present := processes[raw]; present {
+		return raw, true
+	}
+	return "", false
+}
+
+// hashBytes returns the first IndexHashHexLen hex characters of the SHA-1 sum
+// of the given bytes. Deliberately computed on raw file bytes, not on the
+// re-marshalled JSON, so the digest is stable regardless of how a JSON
+// pretty-printer might reorder keys or whitespace. See TZ §5 hash definition.
+func hashBytes(b []byte) string {
+	sum := sha1.Sum(b)
+	h := hex.EncodeToString(sum[:])
+	if len(h) > IndexHashHexLen {
+		h = h[:IndexHashHexLen]
+	}
+	return h
+}
+
+func hashFile(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return hashBytes(data), nil
+}
+
+func indexInstanceJSON(root, path string) (string, *InstanceEntry, error) {
+	if info, err := os.Stat(path); err == nil && info.Size() > maxIndexFileBytes {
+		return "", nil, fmt.Errorf("file too large (%d bytes), skipping", info.Size())
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", nil, fmt.Errorf("reading instance file: %w", err)
+	}
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return "", nil, fmt.Errorf("parsing instance file: %w", err)
+	}
+
+	base := filepath.Base(path)
+	m := reInstanceFileName.FindStringSubmatch(base)
+	if m == nil {
+		return "", nil, nil // filename doesn't match expected pattern — skip silently
+	}
+	iid := m[1]
+
+	title, _ := raw["title"].(string)
+	instanceType, _ := raw["instance_type"].(string)
+	rel, _ := filepath.Rel(root, path)
+
+	entry := &InstanceEntry{
+		Title:        title,
+		InstanceType: instanceType,
+		Path:         filepath.ToSlash(rel),
+	}
+
+	// For .instance.json we scan by field name only (checkValue=false) — the
+	// TZ (§4 п.7) treats the presence of a secret-shaped key as reason enough
+	// to flag it, because instances typically hold real credentials.
+	if payload, ok := raw["data"].(map[string]interface{}); ok {
+		entry.SecretFieldsPresent = scanMapForSecrets(payload, false)
+	}
+	return iid, entry, nil
+}
+
+// walkStrings visits every string value nested inside v (arbitrary depth,
+// through maps and slices) and calls f with each. Used to sweep for
+// {{env_var[@...]}} references without hard-coding schema paths.
+func walkStrings(v interface{}, f func(string)) {
+	switch x := v.(type) {
+	case string:
+		f(x)
+	case []interface{}:
+		for _, item := range x {
+			walkStrings(item, f)
+		}
+	case []map[string]interface{}:
+		for _, item := range x {
+			walkStrings(item, f)
+		}
+	case map[string]interface{}:
+		for _, item := range x {
+			walkStrings(item, f)
+		}
+	}
+}
+
+func readDotEnv(root string) (workspaceID string, stageID int) {
+	data, err := os.ReadFile(filepath.Join(root, ".env"))
+	if err != nil {
+		return "", 0
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		eq := strings.Index(line, "=")
+		if eq <= 0 {
+			continue
+		}
+		k := strings.TrimSpace(line[:eq])
+		v := strings.TrimSpace(line[eq+1:])
+		v = strings.Trim(v, `"'`)
+		switch k {
+		case "WORKSPACE_ID":
+			workspaceID = v
+		case "COREZOID_STAGE_ID":
+			if n, err := parseInt(v); err == nil {
+				stageID = n
+			}
+		}
+	}
+	return
+}
+
+func parseInt(s string) (int, error) {
+	var n int
+	_, err := fmt.Sscanf(s, "%d", &n)
+	return n, err
+}
+
+// readAliases loads _ALIASES_.json into two maps: forward "@name" -> conv_id,
+// and reverse conv_id -> ["@name", ...]. Absence of the file is normal —
+// returns empty maps, not an error.
+//
+// Real Corezoid exports write this file as a JSON **array** of alias records
+// (one entry per link), not a flat name→id map:
+//
+//   [
+//     {"short_name": "api-payments-create", "obj_to_id": 32883, "obj_to_type": "conv", ...},
+//     {"short_name": "orphan-alias", "obj_to_id": null, ...},   // skip — no target
+//     ...
+//   ]
+//
+// Entries with a null / missing / non-numeric obj_to_id are aliases that were
+// defined at the workspace level but never linked to a process, or link to
+// something outside the exported scope. They must be silently skipped — the
+// alias is real but unresolvable, so we can't emit an edge for it.
+//
+// For defence-in-depth (and to keep the pre-existing simple test fixtures
+// working), we also accept a legacy flat-map shape. If neither parses, we
+// return the JSON error as a warning and empty maps — the build continues
+// treating the project as alias-less, which is the correct degraded mode.
+func readAliases(root string) (map[string]string, map[string][]string, string) {
+	path := filepath.Join(root, "_ALIASES_.json")
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return map[string]string{}, map[string][]string{}, ""
+	}
+	if err != nil {
+		return map[string]string{}, map[string][]string{}, "_ALIASES_.json unreadable: " + err.Error()
+	}
+
+	// Sniff the first non-whitespace byte — '[' means real array shape, '{'
+	// means legacy map shape. Anything else is a malformed file.
+	fwd := map[string]string{}
+	rev := map[string][]string{}
+	trim := strings.TrimLeft(string(data), " \t\r\n")
+	switch {
+	case strings.HasPrefix(trim, "["):
+		var raw []map[string]interface{}
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return fwd, rev, "_ALIASES_.json malformed (array): " + err.Error()
+		}
+		for _, entry := range raw {
+			// The alias key is short_name; title is a human-readable fallback
+			// for legacy entries where short_name was left blank.
+			alias := strings.TrimSpace(strAt(entry, "short_name"))
+			if alias == "" {
+				alias = strings.TrimSpace(strAt(entry, "title"))
+			}
+			if alias == "" {
+				continue
+			}
+			convID := numberOrStringAsID(entry["obj_to_id"])
+			if convID == "" {
+				// obj_to_id null/missing → alias without a resolved target.
+				// Legitimate export data — skip silently, no warning.
+				continue
+			}
+			// obj_to_type != "conv" (e.g. "folder", "state") is still tracked
+			// as an alias so by_alias lookups work, but callers won't find an
+			// edge for it unless the target conv_id exists in Processes.
+			key := "@" + strings.TrimPrefix(alias, "@")
+			fwd[key] = convID
+			rev[convID] = append(rev[convID], key)
+		}
+	case strings.HasPrefix(trim, "{"):
+		// Legacy shape: {"@name": conv_id, ...}. Kept for test fixtures
+		// written before we knew the real format; not seen in the wild.
+		var raw map[string]interface{}
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return fwd, rev, "_ALIASES_.json malformed (map): " + err.Error()
+		}
+		for k, v := range raw {
+			convID := numberOrStringAsID(v)
+			if convID == "" {
+				continue
+			}
+			key := "@" + strings.TrimPrefix(k, "@")
+			fwd[key] = convID
+			rev[convID] = append(rev[convID], key)
+		}
+	default:
+		return fwd, rev, "_ALIASES_.json is neither a JSON array nor an object — ignoring"
+	}
+	return fwd, rev, ""
+}
+
+// strAt safely returns m[key] as a string, "" if absent or wrong type.
+func strAt(m map[string]interface{}, key string) string {
+	if m == nil {
+		return ""
+	}
+	if v, ok := m[key].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// numberOrStringAsID accepts a JSON-decoded value and returns its string form
+// if it's a positive integer (as float64 from encoding/json), a non-empty
+// string, or an int. null / bool / empty string / negative / non-numeric all
+// return "".
+func numberOrStringAsID(v interface{}) string {
+	switch x := v.(type) {
+	case float64:
+		if x <= 0 {
+			return ""
+		}
+		return fmt.Sprintf("%d", int(x))
+	case int:
+		if x <= 0 {
+			return ""
+		}
+		return fmt.Sprintf("%d", x)
+	case string:
+		if strings.TrimSpace(x) == "" {
+			return ""
+		}
+		return x
+	}
+	return ""
+}
+
+// flattenAliases produces a lookup useful for by_alias output: both "@name"
+// and "name" (without @) point to the same conv_id, so callers who forget the
+// leading @ still resolve.
+func flattenAliases(fwd map[string]string) map[string]string {
+	out := map[string]string{}
+	for alias, cid := range fwd {
+		out[alias] = cid
+		out[strings.TrimPrefix(alias, "@")] = cid
+	}
+	return out
+}
+
+func aliasesForConv(convID string, rev map[string][]string) []string {
+	list, ok := rev[convID]
+	if !ok {
+		return []string{}
+	}
+	sorted := append([]string(nil), list...)
+	sort.Strings(sorted)
+	return sorted
+}
+
+// readEnvVars loads _ENV_VARS_.json into name -> description. The file format
+// varies across Corezoid exports; we accept both {name: desc-string} and
+// {name: {"description": "..."}} shapes. Values (env_var contents) are NEVER
+// loaded — many env_vars are secrets themselves.
+func readEnvVars(root string) (map[string]string, string) {
+	path := filepath.Join(root, "_ENV_VARS_.json")
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return map[string]string{}, ""
+	}
+	if err != nil {
+		return map[string]string{}, "_ENV_VARS_.json unreadable: " + err.Error()
+	}
+	var raw interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return map[string]string{}, "_ENV_VARS_.json malformed: " + err.Error()
+	}
+	out := map[string]string{}
+	switch x := raw.(type) {
+	case map[string]interface{}:
+		for k, v := range x {
+			desc := ""
+			switch vv := v.(type) {
+			case string:
+				desc = "" // convention: string value = the secret; do NOT store
+			case map[string]interface{}:
+				if d, ok := vv["description"].(string); ok {
+					desc = d
+				}
+			}
+			out[k] = desc
+		}
+	case []interface{}:
+		for _, item := range x {
+			m, ok := item.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			name, _ := m["name"].(string)
+			if name == "" {
+				continue
+			}
+			desc, _ := m["description"].(string)
+			out[name] = desc
+		}
+	}
+	return out, ""
+}
+
+// buildBreadcrumb walks up from a process file to root, reading the
+// <id>_<name>.folder.json markers in each parent directory to build a
+// slash-separated path such as "1234_root / 5678_billing / 9012_flows".
+// Falls back to the directory basenames when no marker is found.
+// breadcrumbCache maps an absolute directory path to its folder-marker name
+// (or "" when none is present). Populated lazily during WalkDir so the same
+// directory is only ReadDir'd once regardless of how many .conv.json files
+// share it. Passed into buildBreadcrumb to eliminate O(files × depth)
+// syscalls on large projects.
+type breadcrumbCache map[string]string
+
+func newBreadcrumbCache() breadcrumbCache { return make(breadcrumbCache) }
+
+func (bc breadcrumbCache) nameForDir(dir string) string {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		abs = dir
+	}
+	if name, ok := bc[abs]; ok {
+		return name
+	}
+	name := folderMarkerName(dir)
+	bc[abs] = name
+	return name
+}
+
+func buildBreadcrumb(root, filePath string, cache breadcrumbCache) string {
+	absRoot, _ := filepath.Abs(root)
+	dir := filepath.Dir(filePath)
+	var parts []string
+	for {
+		abs, _ := filepath.Abs(dir)
+		if abs == absRoot {
+			break
+		}
+		if abs == filepath.Dir(abs) {
+			break
+		}
+		name := cache.nameForDir(dir)
+		if name == "" {
+			name = filepath.Base(dir)
+		}
+		parts = append([]string{name}, parts...)
+		dir = filepath.Dir(dir)
+	}
+	return strings.Join(parts, " / ")
+}
+
+func folderMarkerName(dir string) string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return ""
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if reFolderMarker.MatchString(e.Name()) {
+			return strings.TrimSuffix(strings.TrimSuffix(e.Name(), ".folder.json"), ".stage.json")
+		}
+	}
+	return ""
+}
+
+// uniqueSorted deduplicates and sorts a []string, allocating a new slice.
+// Deterministic output matters for golden tests and jq queries.
+func uniqueSorted(in []string) []string {
+	if len(in) == 0 {
+		return []string{}
+	}
+	set := map[string]struct{}{}
+	for _, s := range in {
+		set[s] = struct{}{}
+	}
+	out := make([]string, 0, len(set))
+	for s := range set {
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func mapKeysSorted[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func containsString(list []string, s string) bool {
+	for _, v := range list {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Secret detection (moved from index_secrets.go)
+// ---------------------------------------------------------------------------
+
+// reSecretFieldName matches any field/header name that plausibly contains a
+// secret. Case-insensitive substring — "sessionToken", "api_key_2",
+// "PrivateKeyPem" all match; "session_id" doesn't. Kept as substring, not
+// whole-token, because real Corezoid diagrams use camelCase, snake_case, and
+// composite names interchangeably.
+var reSecretFieldName = regexp.MustCompile(`(?i)pass|password|secret|token|apikey|api_key|private_key`)
+
+// looksLikeSecretValue is a second-pass filter used only on values found under
+// secret-shaped names in diagrams (never on values from _ENV_VARS_.json, which
+// we never even read, and never on values from .instance.json — those are only
+// checked by field name, per TZ §4 п.7). The intent is to reduce noise from
+// names like "next_step_password_reset" whose fields hold references or
+// display text, not secrets. If the value under a secret-shaped name is a
+// Corezoid template expression, empty, short, or has whitespace/URL shape, it
+// is very unlikely to be a real secret and the hotspot is suppressed.
+//
+// This filter is intentionally conservative: false negatives (missed real
+// secrets) are worse than false positives (extra hotspots), but a noisy
+// security_hotspots list is ignored in the same way a noisy linter is.
+func looksLikeSecretValue(v interface{}) bool {
+	s, ok := v.(string)
+	if !ok {
+		// Non-string values (numbers, objects) — treat as secret to be safe;
+		// we still won't write the value anywhere, only mark the hit.
+		return true
+	}
+	trim := strings.TrimSpace(s)
+	if trim == "" {
+		return false
+	}
+	// Corezoid variable expression — resolves at runtime, not a hardcoded secret.
+	if strings.HasPrefix(trim, "{{") && strings.HasSuffix(trim, "}}") {
+		return false
+	}
+	// Too short to be a meaningful token/key.
+	if len(trim) < 12 {
+		return false
+	}
+	// Contains whitespace — display text, not a token.
+	if strings.ContainsAny(trim, " \t\n") {
+		return false
+	}
+	return true
+}
+
+// scanMapForSecrets walks a map's top-level string keys and returns the names
+// of any key whose name matches the secret pattern. If checkValue is true, the
+// value is additionally passed through looksLikeSecretValue and only names
+// whose value shape confirms the suspicion are kept. Values are never returned.
+func scanMapForSecrets(m map[string]interface{}, checkValue bool) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	var hits []string
+	for k, v := range m {
+		if !reSecretFieldName.MatchString(k) {
+			continue
+		}
+		if checkValue && !looksLikeSecretValue(v) {
+			continue
+		}
+		hits = append(hits, k)
+	}
+	return hits
+}
+
+// ---------------------------------------------------------------------------
+// Config references collector (moved from index_config_references.go)
+// ---------------------------------------------------------------------------
+
+// collectConfigReferences produces a per-ref summary of who reads which
+// configured ref. The local half (used_by, read_fields, local_conv_id)
+// always populates from the diagram scan. When a state-fetcher is
+// supplied AND the ref resolves to a local state-store, the collector
+// also fetches the store's current task contents through the fetcher
+// and attaches them under Tasks with masking applied per cfg.
+//
+// The scan surfaces:
+//   - used_by: conv_ids that mention `{{conv[@ref]...}}` in their logics
+//   - read_fields: the `.ref[X]` field names observed after the ref, so
+//     a reader sees which fields of the config are actually consumed
+//   - local_conv_id: when the ref resolves via _ALIASES_.json to a
+//     conv_id that is a local .conv.json in the project (typically a
+//     state diagram), the caller can jump directly to it
+//   - tasks: (only when fetcher != nil AND local_conv_id resolves) the
+//     current contents of the state-store, with secret-shaped fields
+//     masked in-place
+//
+// If the ref resolves to a local state-store, the corresponding
+// pm.StateStores entry is extended with ReadBy / ReadFields so the
+// state_stores section carries both writer info (existing WrittenBy) and
+// reader info (new).
+//
+// Refs configured in the allow-list but never referenced anywhere in the
+// project are omitted from the returned map. This keeps the section
+// signal-heavy: 0 usages means "not part of the local flow", not "we
+// bothered checking".
+func collectConfigReferences(cfg ConfigReferencesConfig, pm *ProjectMap,
+	usageByRef map[string][]string, fieldsByRef map[string][]string) map[string]*ConfigReferenceEntry {
+
+	// Effective allow-list = configured tasks ∪ every local state-store's
+	// alias. Rationale: a state-store IS a config source by construction
+	// (other processes read/write it via {{conv[@name].ref[X]}}), and
+	// forcing every project to add its state-store alias to the default
+	// 10-entry seed list would silently blank out configs whose alias
+	// doesn't happen to be in the seed. Auto-inclusion means the section
+	// tracks every state-store the project already declares, without
+	// per-project hand-editing.
+	tasks := effectiveConfigRefTasks(cfg.Tasks, pm)
+	if len(tasks) == 0 {
+		return nil
+	}
+	out := map[string]*ConfigReferenceEntry{}
+	for _, task := range tasks {
+		if task.Ref == "" || task.Label == "" {
+			continue
+		}
+		usedBy := usageByRef[task.Ref]
+		readFields := fieldsByRef[task.Ref]
+		// Skip refs no diagram references — leaving them in would clutter
+		// the index with zero-usage stubs equivalent to "not present".
+		if len(usedBy) == 0 && len(readFields) == 0 {
+			continue
+		}
+		if usedBy == nil {
+			usedBy = []string{}
+		}
+		if readFields == nil {
+			readFields = []string{}
+		}
+		entry := &ConfigReferenceEntry{
+			SourceRef:  task.Ref,
+			UsedBy:     usedBy,
+			ReadFields: readFields,
+		}
+		// Alias resolution. by_alias holds both "@name" and "name" (see
+		// flattenAliases in index_builder.go) — try both without hunting
+		// for the exact leading-@ convention this ref uses.
+		if cid, ok := pm.ByAlias[task.Ref]; ok {
+			if _, present := pm.Processes[cid]; present {
+				entry.LocalConvID = cid
+			}
+		} else if cid, ok := pm.ByAlias["@"+task.Ref]; ok {
+			if _, present := pm.Processes[cid]; present {
+				entry.LocalConvID = cid
+			}
+		}
+		// Cross-populate state_stores when the ref resolves to a local
+		// state store. Non-state processes with the same conv_id are
+		// deliberately skipped here — the state_stores section is
+		// state-specific by design and mixing in regular processes would
+		// muddle the semantics.
+		if entry.LocalConvID != "" {
+			if ss, ok := pm.StateStores[entry.LocalConvID]; ok {
+				ss.ReadBy = mergeSorted(ss.ReadBy, usedBy)
+				ss.ReadFields = mergeSorted(ss.ReadFields, readFields)
+			}
+		}
+		out[task.Label] = entry
+	}
+	return out
+}
+
+// effectiveConfigRefTasks unions the user-configured allow-list with every
+// alias attached to a local state-store process. The user's list wins on
+// label conflicts (they may have chosen a specific display label for a
+// ref), and duplicates by ref are dropped. Deterministic order for stable
+// output: configured tasks first (in their config order), then
+// auto-added state-store aliases in conv_id order.
+func effectiveConfigRefTasks(configured []ConfigReferenceTask, pm *ProjectMap) []ConfigReferenceTask {
+	out := make([]ConfigReferenceTask, 0, len(configured))
+	seenRef := map[string]bool{}
+	for _, t := range configured {
+		if t.Ref == "" || t.Label == "" {
+			continue
+		}
+		out = append(out, t)
+		seenRef[t.Ref] = true
+	}
+	// Deterministic order: sort state-store conv_ids so re-runs produce
+	// byte-identical output.
+	convIDs := make([]string, 0, len(pm.StateStores))
+	for cid := range pm.StateStores {
+		convIDs = append(convIDs, cid)
+	}
+	sortStrings(convIDs)
+	for _, cid := range convIDs {
+		ss := pm.StateStores[cid]
+		if ss == nil {
+			continue
+		}
+		for _, alias := range ss.Aliases {
+			name := stripAtPrefix(alias)
+			if name == "" || seenRef[name] {
+				continue
+			}
+			out = append(out, ConfigReferenceTask{Ref: name, Label: name})
+			seenRef[name] = true
+		}
+	}
+	return out
+}
+
+func stripAtPrefix(s string) string {
+	if len(s) > 0 && s[0] == '@' {
+		return s[1:]
+	}
+	return s
+}
+
+// sortStrings sorts a string slice in place.
+func sortStrings(ss []string) { sort.Strings(ss) }
+
+// mergeSorted merges two string slices into a sorted, deduplicated result.
+// Used when a state-store entry may already have data from a previous
+// state_stores-pass and needs to accumulate more.
+func mergeSorted(a, b []string) []string {
+	if len(a) == 0 {
+		return uniqueSorted(b)
+	}
+	if len(b) == 0 {
+		return uniqueSorted(a)
+	}
+	combined := make([]string, 0, len(a)+len(b))
+	combined = append(combined, a...)
+	combined = append(combined, b...)
+	return uniqueSorted(combined)
+}

--- a/plugins/corezoid/mcp-server/index_check.go
+++ b/plugins/corezoid/mcp-server/index_check.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// StaleReport describes the delta between the on-disk index and the current
+// state of the project's .conv.json files. All three slices carry conv_ids as
+// strings. Empty slices in all three positions means the index is fresh.
+type StaleReport struct {
+	Changed []string `json:"changed"`
+	Added   []string `json:"added"`
+	Removed []string `json:"removed"`
+}
+
+// CheckIndexFreshness answers the "is the index stale relative to disk?"
+// question without rebuilding it. Cost model per TZ §8:
+//   1. size+mtime match → skip (no hash read)
+//   2. size or mtime differs → recompute hash, compare with stored hash
+//   3. only hash differs → mark stale
+//
+// A bare mtime change is deliberately NOT enough to declare stale:
+// `git checkout` and `pull-folder` both stamp mtimes without changing bytes,
+// so a "by mtime only" check false-fires on every rebase. The two-step
+// filter buys us "fast in the common case, correct in the edge case".
+//
+// Returns (report, false) when there is no index yet (removed=nil,
+// added=every .conv.json on disk) and (nil, true, nil) is not used — errors
+// are surfaced through the error return.
+func CheckIndexFreshness(projectRoot string) (*StaleReport, error) {
+	rpt := &StaleReport{}
+	path := filepath.Join(projectRoot, IndexOutputDir, IndexMapFile)
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		// No index yet — every conv.json on disk is "added" and there's
+		// nothing to be removed or changed.
+		conv, err := listConvFiles(projectRoot)
+		if err != nil {
+			return nil, err
+		}
+		for cid := range conv {
+			rpt.Added = append(rpt.Added, cid)
+		}
+		rpt.Added = uniqueSorted(rpt.Added)
+		return rpt, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var pm ProjectMap
+	if err := json.Unmarshal(data, &pm); err != nil {
+		return nil, fmt.Errorf("parsing existing project-map.json: %v", err)
+	}
+
+	current, err := listConvFiles(projectRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	// Removed: in index but no longer on disk.
+	for cid := range pm.Processes {
+		if _, ok := current[cid]; !ok {
+			rpt.Removed = append(rpt.Removed, cid)
+		}
+	}
+	// Added: on disk but not in index.
+	for cid := range current {
+		if _, ok := pm.Processes[cid]; !ok {
+			rpt.Added = append(rpt.Added, cid)
+		}
+	}
+	// Changed: on disk and in index, but content differs. Two-phase check.
+	for cid, cur := range current {
+		prev, ok := pm.Processes[cid]
+		if !ok {
+			continue
+		}
+		info, err := os.Stat(cur)
+		if err != nil {
+			continue
+		}
+		mtime := info.ModTime().UTC().Format(time.RFC3339Nano)
+		if mtime == prev.MTime {
+			continue // fast path: mtime unchanged → assume content unchanged
+		}
+		h, err := hashFile(cur)
+		if err != nil {
+			continue
+		}
+		if h != prev.Hash {
+			rpt.Changed = append(rpt.Changed, cid)
+		}
+	}
+
+	rpt.Changed = uniqueSorted(rpt.Changed)
+	rpt.Added = uniqueSorted(rpt.Added)
+	rpt.Removed = uniqueSorted(rpt.Removed)
+	return rpt, nil
+}
+
+// listConvFiles walks the project and returns a conv_id -> absolute path map.
+// Skips .corezoid/, .git/, node_modules/ for the same reason the builder does.
+func listConvFiles(root string) (map[string]string, error) {
+	out := map[string]string{}
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			base := d.Name()
+			if base == IndexOutputDir || base == ".git" || base == "node_modules" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := d.Name()
+		if !strings.HasSuffix(name, ".conv.json") {
+			return nil
+		}
+		m := reProcessFileName.FindStringSubmatch(name)
+		if m == nil {
+			return nil
+		}
+		out[m[1]] = path
+		return nil
+	})
+	return out, err
+}
+
+// FormatStaleReport renders a StaleReport as text suitable for MCP tool
+// output. Deliberately terse — this is a check, not a full rebuild.
+func FormatStaleReport(r *StaleReport) string {
+	if r == nil {
+		return "Index freshness: unknown"
+	}
+	total := len(r.Changed) + len(r.Added) + len(r.Removed)
+	if total == 0 {
+		return "Index freshness: up-to-date"
+	}
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Index freshness: %d file(s) diverged\n", total)
+	if len(r.Changed) > 0 {
+		fmt.Fprintf(&sb, "  Changed (%d): %s\n", len(r.Changed), strings.Join(r.Changed, ", "))
+	}
+	if len(r.Added) > 0 {
+		fmt.Fprintf(&sb, "  Added (%d): %s\n", len(r.Added), strings.Join(r.Added, ", "))
+	}
+	if len(r.Removed) > 0 {
+		fmt.Fprintf(&sb, "  Removed (%d): %s\n", len(r.Removed), strings.Join(r.Removed, ", "))
+	}
+	sb.WriteString("Run build-project-index (or the corezoid-index skill) to refresh.")
+	return sb.String()
+}

--- a/plugins/corezoid/mcp-server/index_config.go
+++ b/plugins/corezoid/mcp-server/index_config.go
@@ -1,0 +1,379 @@
+package main
+
+import (
+	"encoding/json"
+	"strconv"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// IndexConfig holds the per-project heuristic keyword lists used by the
+// entry_point / suspicious_name classification. Kept in
+// .corezoid/index-config.json so teams working with non-English process names
+// (Cyrillic in particular) can override the defaults without recompiling.
+type IndexConfig struct {
+	EntryPointNamePrefixes    []string `json:"entry_point_name_prefixes"`
+	EntryPointLocationKeywords []string `json:"entry_point_location_keywords"`
+	SuspiciousNameKeywords    []string `json:"suspicious_name_keywords"`
+
+	// ConfigReferences is an explicit allow-list of Simulator tasks whose
+	// contents get materialised into project-map.json's config_references
+	// section. Contents that are not on this list are never fetched — that
+	// is the mechanism that keeps client-data tasks out of the on-disk
+	// index. See ConfigReferencesConfig for the field-level masking rules.
+	ConfigReferences ConfigReferencesConfig `json:"config_references"`
+}
+
+// ConfigReferenceTask names one Simulator task to fetch during build.
+// `ref` is the Simulator identifier used to call the API; `label` is the
+// key under which the flattened contents appear in
+// project-map.json's config_references{}.
+type ConfigReferenceTask struct {
+	Ref   string `json:"ref"`
+	Label string `json:"label"`
+}
+
+// ConfigReferencesConfig controls both which tasks to fetch and how to
+// redact leaf field values before writing them to project-map.json.
+//
+// Masking priority (applied per leaf field):
+//   1. name ∈ NeverMaskFieldNames  → value kept, no matter what
+//   2. name ∈ MaskFieldNames OR any of MaskFieldNamePatterns matches (i-flag) → value stripped
+//   3. otherwise                    → value kept
+//
+// This lets a team scope-in one specific field ("secret_id_that_is_actually_public")
+// while keeping the default mask permissive.
+type ConfigReferencesConfig struct {
+	Tasks                 []ConfigReferenceTask `json:"tasks"`
+	MaskFieldNames        []string              `json:"mask_field_names"`
+	MaskFieldNamePatterns []string              `json:"mask_field_name_patterns"`
+	NeverMaskFieldNames   []string              `json:"never_mask_field_names"`
+}
+
+func defaultIndexConfig() IndexConfig {
+	return IndexConfig{
+		EntryPointNamePrefixes:     []string{"api", "page", "viewmodel", "webhook"},
+		EntryPointLocationKeywords: []string{"api"},
+		SuspiciousNameKeywords:     []string{"test", "tmp", "temp", "old", "draft", "backup", "copy of", "wip", "deprecated"},
+
+		// Preseeded with common Simulator config-task refs. NOT universally
+		// safe — see TZ §4 note: if a project uses one of these refs for
+		// client data, the team must remove that row from
+		// index-config.json before the first build. The indexer does not
+		// distinguish "config" from "data" by content.
+		ConfigReferences: ConfigReferencesConfig{
+			Tasks: []ConfigReferenceTask{
+				{Ref: "config", Label: "config"},
+				{Ref: "c", Label: "c"},
+				{Ref: "dev", Label: "dev"},
+				{Ref: "prod", Label: "prod"},
+				{Ref: "test", Label: "test"},
+				{Ref: "accounts", Label: "accounts"},
+				{Ref: "gmail", Label: "gmail"},
+				{Ref: "simulator", Label: "simulator"},
+				{Ref: "corezoid", Label: "corezoid"},
+				{Ref: "jira", Label: "jira"},
+			},
+			MaskFieldNames:        []string{"token", "apiToken", "jwt", "secret", "password", "liteLLMToken"},
+			// Patterns match the same names as reSecretFieldName in index_secrets.go
+			// so hotspot detection and config masking cover the same field names.
+			MaskFieldNamePatterns: []string{"token", "secret", "password", "api_key", "apikey", "private_key"},
+			NeverMaskFieldNames:   []string{},
+		},
+	}
+}
+
+// LoadOrCreateIndexConfig reads .corezoid/index-config.json if present,
+// filling any missing / malformed keys from defaults. If the file doesn't
+// exist yet, writes a fresh default file and returns the defaults. This is the
+// one file in the .corezoid/ set that isn't purely derived — it embodies a
+// team choice about naming heuristics, so it must survive rebuilds.
+//
+// warnings is populated with human-readable diagnostics (bad key type,
+// unreadable file) so the tool can surface them in its output without
+// failing the whole build.
+func LoadOrCreateIndexConfig(projectRoot string) (IndexConfig, []string, error) {
+	cfg := defaultIndexConfig()
+	var warnings []string
+
+	dir := filepath.Join(projectRoot, IndexOutputDir)
+	path := filepath.Join(dir, IndexConfigFile)
+
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			return cfg, warnings, err
+		}
+		if err := writeIndexConfig(path, cfg); err != nil {
+			return cfg, warnings, err
+		}
+		return cfg, warnings, nil
+	}
+	if err != nil {
+		warnings = append(warnings, "index-config.json unreadable: "+err.Error()+" — using defaults for this run")
+		return cfg, warnings, nil
+	}
+
+	// Existing file — parse leniently. Per-key fallback: a malformed key
+	// should degrade only that key, not the whole heuristic. Missing keys are
+	// kept at their defaults.
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		warnings = append(warnings, "index-config.json is not valid JSON: "+err.Error()+" — using defaults for this run")
+		return cfg, warnings, nil
+	}
+
+	if v, ok := raw["entry_point_name_prefixes"]; ok {
+		if list, ok := stringList(v); ok {
+			cfg.EntryPointNamePrefixes = list
+		} else {
+			warnings = append(warnings, "index-config.json: entry_point_name_prefixes must be an array of strings — using default")
+		}
+	}
+	if v, ok := raw["entry_point_location_keywords"]; ok {
+		if list, ok := stringList(v); ok {
+			cfg.EntryPointLocationKeywords = list
+		} else {
+			warnings = append(warnings, "index-config.json: entry_point_location_keywords must be an array of strings — using default")
+		}
+	}
+	if v, ok := raw["suspicious_name_keywords"]; ok {
+		if list, ok := stringList(v); ok {
+			cfg.SuspiciousNameKeywords = list
+		} else {
+			warnings = append(warnings, "index-config.json: suspicious_name_keywords must be an array of strings — using default")
+		}
+	}
+
+	if v, ok := raw["config_references"]; ok && v != nil {
+		if obj, ok := v.(map[string]interface{}); ok {
+			// Sub-keys use the same per-key fallback pattern as the
+			// top-level: one bad sub-key → default for that sub-key + warning,
+			// the rest of the block still loads from the file.
+			//
+			// A `null` value at any sub-key is treated as "key intentionally
+			// omitted, use default without warning" — the same interpretation
+			// a missing key gets. json.Marshal of a Go struct with nil
+			// slices produces `"tasks": null`, so a config file written
+			// programmatically from a partially-populated struct doesn't
+			// generate warning noise on the next load.
+			cr := defaultIndexConfig().ConfigReferences
+
+			if tv, ok := obj["tasks"]; ok && tv != nil {
+				if tasks, warn := parseConfigTasks(tv); warn == "" {
+					cr.Tasks = tasks
+				} else {
+					warnings = append(warnings, "index-config.json: config_references.tasks — "+warn+"; using default list")
+				}
+			}
+			if mv, ok := obj["mask_field_names"]; ok && mv != nil {
+				if list, ok := stringList(mv); ok {
+					cr.MaskFieldNames = list
+				} else {
+					warnings = append(warnings, "index-config.json: config_references.mask_field_names must be an array of strings — using default")
+				}
+			}
+			if mv, ok := obj["mask_field_name_patterns"]; ok && mv != nil {
+				if list, ok := stringList(mv); ok {
+					cr.MaskFieldNamePatterns = list
+				} else {
+					warnings = append(warnings, "index-config.json: config_references.mask_field_name_patterns must be an array of strings — using default")
+				}
+			}
+			if mv, ok := obj["never_mask_field_names"]; ok && mv != nil {
+				if list, ok := stringList(mv); ok {
+					cr.NeverMaskFieldNames = list
+				} else {
+					warnings = append(warnings, "index-config.json: config_references.never_mask_field_names must be an array of strings — using default")
+				}
+			}
+			cfg.ConfigReferences = cr
+		} else {
+			warnings = append(warnings, "index-config.json: config_references must be an object — using default")
+		}
+	}
+
+	return cfg, warnings, nil
+}
+
+// parseConfigTasks accepts either a list of task objects
+// ([{"ref":"...", "label":"..."}]) or a bare string list (["config", ...]),
+// so hand-editing the file stays forgiving — a person writing just the ref
+// strings and expecting `label` to default to `ref` is a plausible mistake
+// worth accommodating.
+func parseConfigTasks(v interface{}) ([]ConfigReferenceTask, string) {
+	arr, ok := v.([]interface{})
+	if !ok {
+		return nil, "not an array"
+	}
+	out := make([]ConfigReferenceTask, 0, len(arr))
+	for i, item := range arr {
+		switch x := item.(type) {
+		case string:
+			if strings.TrimSpace(x) == "" {
+				continue
+			}
+			out = append(out, ConfigReferenceTask{Ref: x, Label: x})
+		case map[string]interface{}:
+			ref, _ := x["ref"].(string)
+			label, _ := x["label"].(string)
+			if strings.TrimSpace(ref) == "" {
+				return nil, "entry " + strconv.Itoa(i) + " missing ref"
+			}
+			if strings.TrimSpace(label) == "" {
+				label = ref
+			}
+			out = append(out, ConfigReferenceTask{Ref: ref, Label: label})
+		default:
+			return nil, "entry " + strconv.Itoa(i) + " is not an object or string"
+		}
+	}
+	return out, ""
+}
+
+func writeIndexConfig(path string, cfg IndexConfig) error {
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+func stringList(v interface{}) ([]string, bool) {
+	arr, ok := v.([]interface{})
+	if !ok {
+		return nil, false
+	}
+	out := make([]string, 0, len(arr))
+	for _, item := range arr {
+		s, ok := item.(string)
+		if !ok {
+			return nil, false
+		}
+		out = append(out, s)
+	}
+	return out, true
+}
+
+// shouldMaskField applies the priority-ordered masking rule from
+// ConfigReferencesConfig's doc comment. The check is case-insensitive
+// throughout — Simulator field naming is inconsistent (mix of camelCase,
+// snake_case, PascalCase in different tasks), so lower-casing both sides
+// is the only robust choice.
+func (c ConfigReferencesConfig) shouldMaskField(fieldName string) bool {
+	lower := strings.ToLower(fieldName)
+	for _, n := range c.NeverMaskFieldNames {
+		if strings.ToLower(n) == lower {
+			return false
+		}
+	}
+	for _, n := range c.MaskFieldNames {
+		if strings.ToLower(n) == lower {
+			return true
+		}
+	}
+	for _, pat := range c.MaskFieldNamePatterns {
+		if pat == "" {
+			continue
+		}
+		if strings.Contains(lower, strings.ToLower(pat)) {
+			return true
+		}
+	}
+	return false
+}
+
+// isEntryPointName returns true if the process title starts with one of the
+// configured entry-point prefixes (case-insensitive).
+func (c IndexConfig) isEntryPointName(title string) bool {
+	lower := strings.ToLower(strings.TrimSpace(title))
+	for _, p := range c.EntryPointNamePrefixes {
+		p = strings.ToLower(p)
+		if p == "" {
+			continue
+		}
+		if strings.HasPrefix(lower, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// isEntryPointLocation returns true if the breadcrumb path contains any of the
+// configured location keywords (case-insensitive substring match, since real
+// exports use both "API" and "api"-suffixed folder names).
+func (c IndexConfig) isEntryPointLocation(location string) bool {
+	lower := strings.ToLower(location)
+	for _, k := range c.EntryPointLocationKeywords {
+		k = strings.ToLower(k)
+		if k == "" {
+			continue
+		}
+		if strings.Contains(lower, k) {
+			return true
+		}
+	}
+	return false
+}
+
+// isSuspiciousName returns true if the process title contains one of the
+// suspicious keywords as a whole word or a colon/underscore/dash-separated
+// segment. A bare substring match would false-fire on names like
+// "test_result_ok" containing "old" — that's why we split on non-word chars.
+func (c IndexConfig) isSuspiciousName(title string) bool {
+	lower := strings.ToLower(title)
+	for _, kw := range c.SuspiciousNameKeywords {
+		kw = strings.ToLower(strings.TrimSpace(kw))
+		if kw == "" {
+			continue
+		}
+		if containsWholeToken(lower, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+// containsWholeToken checks whether needle appears in haystack as a full
+// alphanumeric token (bounded by non-alphanumeric on both sides, or by string
+// edges). Both inputs are expected lowercase.
+func containsWholeToken(haystack, needle string) bool {
+	if needle == "" {
+		return false
+	}
+	// Multi-word needles ("copy of") — bounded substring match is enough,
+	// tokenising by whitespace inside the needle would break them.
+	if strings.ContainsAny(needle, " -_") {
+		idx := 0
+		for {
+			pos := strings.Index(haystack[idx:], needle)
+			if pos < 0 {
+				return false
+			}
+			start := idx + pos
+			end := start + len(needle)
+			if (start == 0 || !isAlnum(rune(haystack[start-1]))) &&
+				(end == len(haystack) || !isAlnum(rune(haystack[end]))) {
+				return true
+			}
+			idx = start + 1
+			if idx >= len(haystack) {
+				return false
+			}
+		}
+	}
+	// Single-token needle — tokenise haystack and check exact matches.
+	tokens := strings.FieldsFunc(haystack, func(r rune) bool { return !isAlnum(r) })
+	for _, tok := range tokens {
+		if tok == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func isAlnum(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')
+}

--- a/plugins/corezoid/mcp-server/index_graph.go
+++ b/plugins/corezoid/mcp-server/index_graph.go
@@ -1,0 +1,182 @@
+package main
+
+import "sort"
+
+// computeGraphStats populates the derived graph-analysis fields of ProjectMap
+// — fan_in/fan_out per conv_id, high-* lists over thresholds, orphaned and
+// entry_point classification (via the heuristic in IndexConfig), and cycle
+// detection using DFS with a coloring algorithm.
+//
+// State processes (conv_type == "state") are excluded from orphaned /
+// entry_points entirely: an empty state_stores[cid].written_by is a
+// legitimate read-only state (a lookup table, or a cache not yet populated) —
+// not a signal of orphan status. This distinction is load-bearing for
+// corezoid-project-review, which must not surface state stores as "dead
+// code" candidates.
+func computeGraphStats(pm *ProjectMap, cfg IndexConfig) *GraphStats {
+	stats := &GraphStats{
+		HighFanIn:   []string{},
+		HighFanOut:  []string{},
+		Orphaned:    []OrphanedInfo{},
+		EntryPoints: []string{},
+		Cycles:      [][]string{},
+	}
+
+	// fanIn/fanOut are computed locally — they're needed for the high-*
+	// lists and orphaned classification, but are no longer serialised into
+	// project-map.json (they're per-process counters derivable from edges
+	// via jq and were the biggest contributor to file size).
+	fanIn := make(map[string]int, len(pm.Processes))
+	fanOut := make(map[string]int, len(pm.Processes))
+	for cid := range pm.Processes {
+		fanIn[cid] = 0
+		fanOut[cid] = 0
+	}
+	for _, e := range pm.Edges {
+		fanOut[e.From]++
+		fanIn[e.To]++
+	}
+
+	for cid, n := range fanIn {
+		if n > IndexHighFanIn {
+			stats.HighFanIn = append(stats.HighFanIn, cid)
+		}
+	}
+	for cid, n := range fanOut {
+		if n > IndexHighFanOut {
+			stats.HighFanOut = append(stats.HighFanOut, cid)
+		}
+	}
+	sort.Strings(stats.HighFanIn)
+	sort.Strings(stats.HighFanOut)
+
+	// Entry-point / orphaned classification only for real processes with no
+	// internal caller. See TZ §7 — this is a heuristic, not a diagnosis, so
+	// callers must phrase output as "no internal caller, verify before
+	// deletion" and not "dead code".
+	for cid, entry := range pm.Processes {
+		if entry.ConvType == "state" {
+			continue
+		}
+		if fanIn[cid] != 0 {
+			continue
+		}
+		if isEntryPoint(entry, cfg) {
+			stats.EntryPoints = append(stats.EntryPoints, cid)
+		} else {
+			stats.Orphaned = append(stats.Orphaned, OrphanedInfo{
+				ConvID:         cid,
+				SuspiciousName: cfg.isSuspiciousName(entry.Title),
+			})
+		}
+	}
+	sort.Strings(stats.EntryPoints)
+	sort.Slice(stats.Orphaned, func(i, j int) bool {
+		return stats.Orphaned[i].ConvID < stats.Orphaned[j].ConvID
+	})
+
+	stats.Cycles = findCycles(pm)
+	return stats
+}
+
+func isEntryPoint(entry *ProcessEntry, cfg IndexConfig) bool {
+	if len(entry.Aliases) > 0 {
+		return true
+	}
+	if entry.HasReceiverNode {
+		return true
+	}
+	if cfg.isEntryPointName(entry.Title) {
+		return true
+	}
+	if cfg.isEntryPointLocation(entry.Location) {
+		return true
+	}
+	return false
+}
+
+// findCycles returns a slice of simple cycles in the call graph. Uses DFS
+// with recursion-stack tracking and reports each cycle exactly once,
+// normalised so the smallest lexicographic conv_id starts the cycle.
+//
+// The earlier globalDone optimisation was dropped: it caused missed cycles
+// when a node was reachable via multiple paths (e.g. A→B→C→A exists, but
+// A→B→D→C→A was not found because C was already in globalDone). Correctness
+// beats a minor performance win for the project sizes we support.
+func findCycles(pm *ProjectMap) [][]string {
+	adj := map[string][]string{}
+	for _, e := range pm.Edges {
+		adj[e.From] = append(adj[e.From], e.To)
+	}
+	// Deterministic neighbour order so cycle enumeration is reproducible.
+	for k := range adj {
+		sort.Strings(adj[k])
+		adj[k] = uniqueSorted(adj[k])
+	}
+
+	// Gather starting nodes in deterministic order.
+	starts := mapKeysSorted(pm.Processes)
+
+	seen := map[string]struct{}{}
+	// Initialised (not nil) so JSON serialises an empty result as [], not null.
+	out := [][]string{}
+
+	var dfs func(node string, stack []string, onStack map[string]int)
+	dfs = func(node string, stack []string, onStack map[string]int) {
+		onStack[node] = len(stack)
+		stack = append(stack, node)
+		for _, nb := range adj[node] {
+			if idx, in := onStack[nb]; in {
+				// Back edge — cycle detected.
+				cyc := append([]string(nil), stack[idx:]...)
+				norm := normaliseCycle(cyc)
+				key := ""
+				for _, n := range norm {
+					key += n + "|"
+				}
+				if _, dup := seen[key]; !dup {
+					seen[key] = struct{}{}
+					out = append(out, norm)
+				}
+				continue
+			}
+			dfs(nb, stack, onStack)
+		}
+		delete(onStack, node)
+	}
+
+	for _, s := range starts {
+		dfs(s, nil, map[string]int{})
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		a, b := out[i], out[j]
+		for k := 0; k < len(a) && k < len(b); k++ {
+			if a[k] != b[k] {
+				return a[k] < b[k]
+			}
+		}
+		return len(a) < len(b)
+	})
+	return out
+}
+
+// normaliseCycle rotates a cycle so its lexicographically smallest node comes
+// first. Two rotations of the same cycle will produce identical output — the
+// key used for dedup in findCycles depends on this.
+func normaliseCycle(cyc []string) []string {
+	if len(cyc) == 0 {
+		return cyc
+	}
+	minIdx := 0
+	for i := 1; i < len(cyc); i++ {
+		if cyc[i] < cyc[minIdx] {
+			minIdx = i
+		}
+	}
+	out := make([]string, len(cyc))
+	for i := range cyc {
+		out[i] = cyc[(minIdx+i)%len(cyc)]
+	}
+	return out
+}

--- a/plugins/corezoid/mcp-server/index_output.go
+++ b/plugins/corezoid/mcp-server/index_output.go
@@ -1,0 +1,286 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// writeAtomically writes data to path atomically via os.CreateTemp + Rename
+// in the same directory. Using the same directory is required so that Rename
+// is a filesystem-level move, not a cross-device copy. A fixed .tmp name
+// was previously used — os.CreateTemp avoids races when two builds run
+// concurrently (e.g. parallel tool calls in the same session).
+func writeAtomically(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".idx-tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		tmp.Close()
+		os.Remove(tmpName) // clean up if Rename was never reached
+	}()
+	if err := tmp.Chmod(perm); err != nil {
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, path)
+}
+
+// WriteProjectMap serialises the index to .corezoid/project-map.json in the
+// given project root. Uses an atomic write-to-temp-then-rename so a crash
+// mid-write cannot leave a truncated file that breaks the next build.
+func WriteProjectMap(projectRoot string, pm *ProjectMap) error {
+	dir := filepath.Join(projectRoot, IndexOutputDir)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(pm, "", "  ")
+	if err != nil {
+		return err
+	}
+	return writeAtomically(filepath.Join(dir, IndexMapFile), data, 0644)
+}
+
+// WriteQueriesMD emits the query cookbook next to project-map.json. The file
+// is a deterministic template (no LLM), documenting every common lookup an
+// agent will need. Kept short — the point is to be a command reference, not
+// a project overview.
+func WriteQueriesMD(projectRoot string) error {
+	dir := filepath.Join(projectRoot, IndexOutputDir)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, IndexQueriesFile), []byte(queriesMDTemplate), 0644)
+}
+
+const queriesMDTemplate = "# Project Index Queries\n" +
+	"\n" +
+	"`.corezoid/project-map.json` is the source of truth for who calls what, which\n" +
+	"env variables are used where, and which processes look risky to touch. Use\n" +
+	"`jq` (or Python) to answer specific questions instead of loading the whole\n" +
+	"file into context.\n" +
+	"\n" +
+	"Replace `<id>` with a numeric conv_id (as a string), `@name` with an alias.\n" +
+	"\n" +
+	"## 1. Who calls process `<id>`\n" +
+	"\n" +
+	"```\n" +
+	"jq --arg id \"<id>\" '.calls_in[$id] // []' .corezoid/project-map.json\n" +
+	"```\n" +
+	"Returns the list of conv_ids that reference this process via `api_rpc`,\n" +
+	"`api_copy`, or `api_get_task`. Empty list means either an entry point or an\n" +
+	"orphaned candidate — cross-check `.graph_stats.entry_points` /\n" +
+	"`.graph_stats.orphaned`.\n" +
+	"\n" +
+	"## 2. What does process `<id>` call\n" +
+	"\n" +
+	"```\n" +
+	"jq --arg id \"<id>\" '[.edges[] | select(.from == $id)]' .corezoid/project-map.json\n" +
+	"```\n" +
+	"Each element carries `to`, `type`, `mode` (for `api_copy`), and `via_alias`.\n" +
+	"Title of the target: `jq --arg id \"<to_id>\" '.processes[$id].title'`.\n" +
+	"\n" +
+	"## 3. Resolve an alias\n" +
+	"\n" +
+	"```\n" +
+	"jq --arg a \"@name\" '.by_alias[$a]' .corezoid/project-map.json\n" +
+	"```\n" +
+	"Works with or without the leading `@`. `null` means the alias does not\n" +
+	"resolve inside this project (possibly external or dynamic).\n" +
+	"\n" +
+	"## 4. Where is env variable `@name` used\n" +
+	"\n" +
+	"```\n" +
+	"jq --arg n \"name\" '.env_vars[$n].used_by' .corezoid/project-map.json\n" +
+	"```\n" +
+	"The variable name is passed WITHOUT the leading `@`. Returns the list of\n" +
+	"conv_ids that reference `{{env_var[@name]}}` anywhere in their logics. If the\n" +
+	"variable is not listed at all, either it isn't in `_ENV_VARS_.json` and no\n" +
+	"process references it, or the file wasn't part of the export.\n" +
+	"\n" +
+	"## 5. Does a process for X already exist (fuzzy title search)\n" +
+	"\n" +
+	"```\n" +
+	"jq '.processes | to_entries | map(select(.value.title | test(\"payment\"; \"i\"))) |\n" +
+	"    map({conv_id: .key, title: .value.title, path: .value.path})' \\\n" +
+	"    .corezoid/project-map.json\n" +
+	"```\n" +
+	"Regexp is case-insensitive. Use before creating a new process — a hit here\n" +
+	"often means the flow already exists somewhere in the tree.\n" +
+	"\n" +
+	"## 6. Full card for process `<id>`\n" +
+	"\n" +
+	"```\n" +
+	"jq --arg id \"<id>\" '.processes[$id]' .corezoid/project-map.json\n" +
+	"```\n" +
+	"Includes title, location breadcrumb, aliases, external URLs called,\n" +
+	"env-var references, node count, and hash (compare with actual file hash\n" +
+	"to see if the index has drifted since last rebuild).\n" +
+	"\n" +
+	"## 7. What is risky to touch right now\n" +
+	"\n" +
+	"```\n" +
+	"jq '.graph_stats | {cycles, high_fan_in, high_fan_out, orphaned}' \\\n" +
+	"    .corezoid/project-map.json\n" +
+	"```\n" +
+	"`orphaned` is a heuristic — \"no internal caller in this project\", not a\n" +
+	"diagnosis. Verify before deleting anything.\n" +
+	"\n" +
+	"## 8. External systems and detected secrets\n" +
+	"\n" +
+	"```\n" +
+	"jq '{external_apis, instances, security_hotspots}' .corezoid/project-map.json\n" +
+	"```\n" +
+	"`security_hotspots` reports field NAMES and locations only — values are\n" +
+	"never included, even partially. `source: instance` means a `.instance.json`\n" +
+	"connector definition; `source: diagram` means a hardcoded-looking field in\n" +
+	"an `api` node's `extra`/`extra_headers`/`url`.\n" +
+	"\n" +
+	"## 9. Rebuilding the index\n" +
+	"\n" +
+	"The index rebuilds automatically after `pull-folder` (via `corezoid-init`)\n" +
+	"and after each successful `push-process` (via `corezoid-edit` /\n" +
+	"`corezoid-create`). To rebuild manually — for example after editing\n" +
+	"`.conv.json` files outside the plugin — run the `build-project-index` MCP\n" +
+	"tool or invoke the `corezoid-index` skill.\n"
+
+// UpdateClaudeMD writes/refreshes the auto-generated block in CLAUDE.md at
+// the project root. Preserves user content outside the marker pair and does
+// nothing if project-map.json is missing (index-driven artefact only makes
+// sense when there is an index to summarise). Returns firstCreation=true when
+// a fresh CLAUDE.md was created or when a pre-existing CLAUDE.md gained
+// markers for the first time — callers use this to decide whether to notify
+// the user (see TZ §6.2).
+func UpdateClaudeMD(projectRoot string, pm *ProjectMap) (firstCreation bool, err error) {
+	path := filepath.Join(projectRoot, "CLAUDE.md")
+	block := renderClaudeBlock(pm)
+
+	existing, readErr := os.ReadFile(path)
+	if readErr != nil && !errors.Is(readErr, os.ErrNotExist) {
+		return false, readErr
+	}
+	var content string
+	if errors.Is(readErr, os.ErrNotExist) {
+		content = claudeMDScaffold + block + "\n"
+		firstCreation = true
+	} else {
+		var hadMarkers bool
+		content, hadMarkers = replaceAutoBlock(string(existing), block)
+		firstCreation = !hadMarkers
+	}
+	return firstCreation, writeAtomically(path, []byte(content), 0644)
+}
+
+const claudeMDScaffold = "# Project Notes\n" +
+	"\n" +
+	"This file is loaded by Claude Code at the start of every session in this\n" +
+	"project. Add your team's workflow rules, naming conventions, and pointers\n" +
+	"to `.env` / credentials here — anything outside the auto-generated block\n" +
+	"below is preserved across rebuilds.\n" +
+	"\n"
+
+// renderClaudeBlock produces the marker-delimited summary that gets injected
+// into CLAUDE.md. Must stay short (~30–50 lines total for the whole file,
+// per TZ §6.2) — CLAUDE.md is loaded whole into every session and cannot
+// grow linearly with project size.
+func renderClaudeBlock(pm *ProjectMap) string {
+	var sb strings.Builder
+	sb.WriteString("<!-- ")
+	sb.WriteString(IndexClaudeMdMarker)
+	sb.WriteString(":start -->\n")
+	sb.WriteString("## Corezoid project index (auto-generated)\n")
+	sb.WriteString(fmt.Sprintf("- **Processes:** %d (state stores: %d, instances: %d, env variables: %d)\n",
+		pm.ProcessCount, pm.StateStoreCount, pm.InstanceCount, len(pm.EnvVars)))
+	if pm.StageID != 0 {
+		sb.WriteString(fmt.Sprintf("- **Stage ID:** %d\n", pm.StageID))
+	}
+	sb.WriteString("- **Full data:** `.corezoid/project-map.json` — query with `jq`, recipes in `.corezoid/QUERIES.md`.\n")
+
+	if pm.GraphStats != nil {
+		if len(pm.GraphStats.HighFanIn) > 0 {
+			shown := pm.GraphStats.HighFanIn
+			if len(shown) > 2 {
+				shown = shown[:2]
+			}
+			var pairs []string
+			for _, cid := range shown {
+				if p, ok := pm.Processes[cid]; ok {
+					pairs = append(pairs, fmt.Sprintf("%s (%s)", cid, p.Title))
+				} else {
+					pairs = append(pairs, cid)
+				}
+			}
+			extra := ""
+			if len(pm.GraphStats.HighFanIn) > 2 {
+				extra = fmt.Sprintf(" (+%d more)", len(pm.GraphStats.HighFanIn)-2)
+			}
+			sb.WriteString(fmt.Sprintf("- **High fan-in (touch carefully):** %s%s\n",
+				strings.Join(pairs, ", "), extra))
+		}
+		if n := len(pm.GraphStats.Cycles); n > 0 {
+			sb.WriteString(fmt.Sprintf("- **Cycles detected:** %d — see `.graph_stats.cycles` in project-map.json.\n", n))
+		}
+		if n := len(pm.GraphStats.Orphaned); n > 0 {
+			sb.WriteString(fmt.Sprintf("- **Orphaned candidates:** %d — verify before deletion (heuristic, not diagnosis).\n", n))
+		}
+	}
+	if n := len(pm.SecurityHotspots); n > 0 {
+		sb.WriteString(fmt.Sprintf("- **Security hotspots:** %d — see `.security_hotspots` (field names + locations only, no values).\n", n))
+	}
+	sb.WriteString(fmt.Sprintf("- **Generated:** %s\n", pm.GeneratedAt))
+	sb.WriteString("<!-- ")
+	sb.WriteString(IndexClaudeMdMarker)
+	sb.WriteString(":end -->")
+	return sb.String()
+}
+
+// replaceAutoBlock swaps or appends the marker-delimited auto-block. Returns
+// (updatedContent, markersFoundAndReplaced). The behaviour matrix (TZ §12):
+//   - both markers present in order  → replace
+//   - both markers absent            → append at end, hadMarkers=false
+//   - only start marker present      → treat as no markers (append fresh)
+//   - only end marker present        → treat as no markers (append fresh)
+//   - markers reversed               → treat as no markers (append fresh)
+//
+// Rationale: attempting to "fix" broken markers is guessing — either the file
+// was hand-edited (in which case a fresh block is the safer choice) or the
+// previous run crashed mid-write (same conclusion). Never modify content
+// outside a well-formed marker pair.
+func replaceAutoBlock(content, block string) (string, bool) {
+	startTag := "<!-- " + IndexClaudeMdMarker + ":start -->"
+	endTag := "<!-- " + IndexClaudeMdMarker + ":end -->"
+	startIdx := strings.Index(content, startTag)
+	endIdx := strings.Index(content, endTag)
+	if startIdx >= 0 && endIdx > startIdx {
+		before := content[:startIdx]
+		after := content[endIdx+len(endTag):]
+		// Trim exactly one leading newline in `after` if present so we don't
+		// accumulate blank lines on repeated rebuilds.
+		if strings.HasPrefix(after, "\n") {
+			after = after[1:]
+		}
+		return before + block + "\n" + after, true
+	}
+	// Malformed or absent markers — append fresh block after ensuring
+	// exactly one blank line of separation.
+	sep := ""
+	if content != "" && !strings.HasSuffix(content, "\n\n") {
+		if strings.HasSuffix(content, "\n") {
+			sep = "\n"
+		} else {
+			sep = "\n\n"
+		}
+	}
+	return content + sep + block + "\n", false
+}

--- a/plugins/corezoid/mcp-server/index_test.go
+++ b/plugins/corezoid/mcp-server/index_test.go
@@ -1,0 +1,1557 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runBuildOnFixture builds the index against a copy of the fixture directory
+// (so tests never mutate committed fixture data — .corezoid/ is created
+// alongside the .conv.json files) and returns the ProjectMap.
+func runBuildOnFixture(t *testing.T, name string) (*ProjectMap, string) {
+	t.Helper()
+	src := filepath.Join("testdata", "index_fixtures", name)
+	if _, err := os.Stat(src); err != nil {
+		t.Fatalf("fixture %s missing: %v", name, err)
+	}
+	dst := t.TempDir()
+	if err := copyDir(src, dst); err != nil {
+		t.Fatalf("copy fixture: %v", err)
+	}
+	pm, warnings, err := BuildProjectIndex(context.Background(), dst)
+	if err != nil {
+		t.Fatalf("build failed: %v (warnings: %v)", err, warnings)
+	}
+	for _, w := range warnings {
+		t.Logf("warning: %s", w)
+	}
+	return pm, dst
+}
+
+func copyDir(src, dst string) error {
+	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if info.IsDir() {
+			return os.MkdirAll(target, 0755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, info.Mode())
+	})
+}
+
+// TestIndex_BasicFixture is the primary happy-path test — a small project
+// with aliases, env vars, cross-process edges of all three types, an api node
+// with an external URL, a state store, and an orphaned-candidate with a
+// suspicious name. Verifies the full pipeline in one go.
+func TestIndex_BasicFixture(t *testing.T) {
+	pm, _ := runBuildOnFixture(t, "basic")
+
+	if pm.ProcessCount != 3 {
+		t.Errorf("ProcessCount = %d, want 3 (100, 200, 400 — state store 300 is separate)", pm.ProcessCount)
+	}
+	if pm.StateStoreCount != 1 {
+		t.Errorf("StateStoreCount = %d, want 1", pm.StateStoreCount)
+	}
+	if _, ok := pm.Processes["100"]; !ok {
+		t.Fatalf("process 100 missing from index")
+	}
+	if _, ok := pm.StateStores["300"]; !ok {
+		t.Fatalf("state store 300 missing")
+	}
+
+	// Edges: 100 -> 200 (api_rpc via @notify), 100 -> 300 (api_copy create),
+	// 200 -> 100 (api_get_task).
+	edges := indexEdges(pm)
+	expect := []string{
+		"100->200/api_rpc/@notify",
+		"100->300/api_copy/create",
+		"200->100/api_get_task",
+	}
+	for _, e := range expect {
+		if _, ok := edges[e]; !ok {
+			t.Errorf("missing edge: %s (got: %v)", e, keys(edges))
+		}
+	}
+
+	// calls_in derived from edges
+	if callers := pm.CallsIn["100"]; len(callers) != 1 || callers[0] != "200" {
+		t.Errorf("calls_in[100] = %v, want [200]", callers)
+	}
+	// state_stores.written_by derived from api_copy edges
+	if wb := pm.StateStores["300"].WrittenBy; len(wb) != 1 || wb[0] != "100" {
+		t.Errorf("state_stores[300].written_by = %v, want [100]", wb)
+	}
+
+	// Aliases resolved
+	if pm.ByAlias["@notify"] != "200" {
+		t.Errorf("by_alias[@notify] = %q, want 200", pm.ByAlias["@notify"])
+	}
+	if pm.ByAlias["notify"] != "200" {
+		t.Errorf("by_alias without @ should also resolve: got %q", pm.ByAlias["notify"])
+	}
+
+	// Env vars: STRIPE_URL and STRIPE_TOKEN used by 100 (via api node).
+	if used := pm.EnvVars["STRIPE_URL"].UsedBy; len(used) != 1 || used[0] != "100" {
+		t.Errorf("env_vars[STRIPE_URL].used_by = %v, want [100]", used)
+	}
+	if used := pm.EnvVars["STRIPE_TOKEN"].UsedBy; len(used) != 1 || used[0] != "100" {
+		t.Errorf("env_vars[STRIPE_TOKEN].used_by = %v, want [100]", used)
+	}
+
+	// External APIs — the api node's url has a template expression, so the
+	// stored url is the raw template string. Verify 100 is listed as a caller.
+	found := false
+	for _, callers := range pm.ExternalAPIs {
+		for _, c := range callers {
+			if c == "100" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("external_apis has no entry from process 100: %+v", pm.ExternalAPIs)
+	}
+
+	// graph_stats: 400 has fan_in=0, no alias, no callback, boring name
+	// starting with "test" — should be orphaned (suspicious).
+	sawOrphaned400 := false
+	for _, o := range pm.GraphStats.Orphaned {
+		if o.ConvID == "400" {
+			sawOrphaned400 = true
+			if !o.SuspiciousName {
+				t.Errorf("400 title starts with 'test' — SuspiciousName should be true")
+			}
+		}
+	}
+	if !sawOrphaned400 {
+		t.Errorf("process 400 should be orphaned; got %+v", pm.GraphStats.Orphaned)
+	}
+
+	// State store 300 should NOT be in orphaned/entry_points at all.
+	for _, o := range pm.GraphStats.Orphaned {
+		if o.ConvID == "300" {
+			t.Errorf("state store 300 must not be marked orphaned (heuristic excludes conv_type=state)")
+		}
+	}
+	for _, ep := range pm.GraphStats.EntryPoints {
+		if ep == "300" {
+			t.Errorf("state store 300 must not be marked entry_point")
+		}
+	}
+
+	// 100 has fan_in > 0 (200 calls it via api_get_task), so it's not
+	// classified as entry_point. Verify via calls_in (fan_in/fan_out maps
+	// are no longer stored in graph_stats — derive from edges or calls_in).
+	if callers := pm.CallsIn["100"]; len(callers) != 1 || callers[0] != "200" {
+		t.Errorf("calls_in[100] = %v, want [200] (api_get_task from 200)", callers)
+	}
+	outgoing := 0
+	for _, e := range pm.Edges {
+		if e.From == "100" {
+			outgoing++
+		}
+	}
+	if outgoing != 2 {
+		t.Errorf("outgoing edges from 100 = %d, want 2 (api_rpc to 200, api_copy to 300)", outgoing)
+	}
+}
+
+// TestIndex_NoOptionalFiles verifies TZ §12 requirement: a project with no
+// _ALIASES_.json, no _ENV_VARS_.json, and no *.instance.json builds cleanly,
+// producing empty-but-valid sections rather than errors.
+func TestIndex_NoOptionalFiles(t *testing.T) {
+	pm, _ := runBuildOnFixture(t, "no_optional")
+
+	if pm.ProcessCount != 1 {
+		t.Errorf("ProcessCount = %d, want 1", pm.ProcessCount)
+	}
+	if pm.ByAlias == nil {
+		t.Error("by_alias must be initialised (empty), not nil")
+	}
+	if pm.EnvVars == nil {
+		t.Error("env_vars must be initialised, not nil")
+	}
+	if pm.Instances == nil {
+		t.Error("instances must be initialised, not nil")
+	}
+	if len(pm.ByAlias) != 0 {
+		t.Errorf("by_alias should be empty, got %v", pm.ByAlias)
+	}
+	if len(pm.EnvVars) != 0 {
+		t.Errorf("env_vars should be empty, got %v", pm.EnvVars)
+	}
+	if len(pm.Instances) != 0 {
+		t.Errorf("instances should be empty, got %v", pm.Instances)
+	}
+	if len(pm.SecurityHotspots) != 0 {
+		t.Errorf("security_hotspots should be empty, got %v", pm.SecurityHotspots)
+	}
+}
+
+// TestIndex_Cycles verifies both A→B→A and self-loop detection.
+func TestIndex_Cycles(t *testing.T) {
+	pm, _ := runBuildOnFixture(t, "cycle")
+
+	if len(pm.GraphStats.Cycles) < 2 {
+		t.Fatalf("expected at least 2 cycles (600↔601 and 602 self), got %v", pm.GraphStats.Cycles)
+	}
+	sawAB := false
+	sawSelf := false
+	for _, c := range pm.GraphStats.Cycles {
+		joined := strings.Join(c, "->")
+		if strings.Contains(joined, "600->601") || strings.Contains(joined, "601->600") {
+			sawAB = true
+		}
+		if len(c) == 1 && c[0] == "602" {
+			sawSelf = true
+		}
+	}
+	if !sawAB {
+		t.Errorf("missing 600↔601 cycle: %v", pm.GraphStats.Cycles)
+	}
+	if !sawSelf {
+		t.Errorf("missing 602 self-loop: %v", pm.GraphStats.Cycles)
+	}
+}
+
+// TestIndex_UnresolvedAlias verifies that an @alias missing from
+// _ALIASES_.json ends up in unresolved_targets, not silently dropped.
+func TestIndex_UnresolvedAlias(t *testing.T) {
+	dst := t.TempDir()
+	// Process that references @nonexistent.
+	proc := `{
+	  "obj_type":1, "obj_id":900, "title":"Broken",
+	  "conv_type":"process", "status":"active",
+	  "scheme":{"nodes":[
+	    {"id":"9990000000000000000000f1","title":"Start","obj_type":1,
+	     "condition":{"logics":[{"type":"go","to_node_id":"9990000000000000000000f2"}]}},
+	    {"id":"9990000000000000000000f2","title":"Call missing","obj_type":0,
+	     "condition":{"logics":[{"type":"api_rpc","conv_id":"@nonexistent"}]}}
+	  ]}
+	}`
+	if err := os.WriteFile(filepath.Join(dst, "900_broken.conv.json"), []byte(proc), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Empty aliases file — real Corezoid exports use a JSON array shape.
+	if err := os.WriteFile(filepath.Join(dst, "_ALIASES_.json"), []byte(`[]`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	pm, _, err := BuildProjectIndex(context.Background(), dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	list, ok := pm.UnresolvedTargets["900"]
+	if !ok || len(list) == 0 {
+		t.Fatalf("expected unresolved_targets[900] to contain @nonexistent, got %v", pm.UnresolvedTargets)
+	}
+	if len(pm.Edges) != 0 {
+		t.Errorf("expected 0 edges (broken alias), got %d: %+v", len(pm.Edges), pm.Edges)
+	}
+}
+
+// TestIndex_AliasRealExportShape locks in the actual _ALIASES_.json shape
+// that Corezoid exports write — a JSON **array** of alias records with
+// short_name / obj_to_id / obj_to_type, not a flat name→id map. An earlier
+// implementation only accepted the flat map (matched an assumed shape), and
+// on a real project 73/95 processes' cross-alias calls silently disappeared
+// from the graph because Unmarshal into a map fails on an array payload.
+//
+// This test is deliberately verbose about the shape — it's the regression
+// guard against re-introducing the "wrong assumed shape" bug.
+func TestIndex_AliasRealExportShape(t *testing.T) {
+	dst := t.TempDir()
+	// Real-shape aliases file: array of records.
+	// Includes an entry with obj_to_id: null (unresolved alias, must be
+	// silently skipped) and an entry with obj_to_type: "folder" (still
+	// tracked in by_alias but only edges emitted if the target conv_id is a
+	// process in the inventory).
+	aliases := `[
+	  {"short_name": "payments", "obj_to_id": 5000, "obj_to_type": "conv",
+	   "title": "payments", "obj_id": 1},
+	  {"short_name": "orphan-alias", "obj_to_id": null, "obj_to_type": null,
+	   "title": "orphan-alias", "obj_id": 2},
+	  {"short_name": "some-folder", "obj_to_id": 9999, "obj_to_type": "folder",
+	   "title": "some-folder", "obj_id": 3},
+	  {"short_name": "", "obj_to_id": 5001, "obj_to_type": "conv",
+	   "title": "notify", "obj_id": 4}
+	]`
+	if err := os.WriteFile(filepath.Join(dst, "_ALIASES_.json"), []byte(aliases), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Two processes: 5000 (referenced by @payments) and 5001 (referenced by
+	// @notify via the title fallback since short_name was empty). A third
+	// process that calls both via alias, so we can verify edges resolve.
+	os.WriteFile(filepath.Join(dst, "5000_pay.conv.json"), []byte(`{
+	  "obj_id":5000,"title":"Pay","conv_type":"process","status":"active",
+	  "scheme":{"nodes":[{"id":"aaaa000000000000000050001","title":"S","obj_type":1,
+	   "condition":{"logics":[{"type":"go","to_node_id":"aaaa000000000000000050002"}]}},
+	   {"id":"aaaa000000000000000050002","title":"E","obj_type":2,"condition":{"logics":[]}}]}
+	}`), 0644)
+	os.WriteFile(filepath.Join(dst, "5001_notify.conv.json"), []byte(`{
+	  "obj_id":5001,"title":"N","conv_type":"process","status":"active",
+	  "scheme":{"nodes":[{"id":"bbbb000000000000000050101","title":"S","obj_type":1,
+	   "condition":{"logics":[{"type":"go","to_node_id":"bbbb000000000000000050102"}]}},
+	   {"id":"bbbb000000000000000050102","title":"E","obj_type":2,"condition":{"logics":[]}}]}
+	}`), 0644)
+	os.WriteFile(filepath.Join(dst, "5100_caller.conv.json"), []byte(`{
+	  "obj_id":5100,"title":"Caller","conv_type":"process","status":"active",
+	  "scheme":{"nodes":[
+	   {"id":"cccc000000000000000051001","title":"S","obj_type":1,
+	    "condition":{"logics":[{"type":"go","to_node_id":"cccc000000000000000051002"}]}},
+	   {"id":"cccc000000000000000051002","title":"CallPay","obj_type":0,
+	    "condition":{"logics":[{"type":"api_rpc","conv_id":"@payments"}]}},
+	   {"id":"cccc000000000000000051003","title":"CallNotify","obj_type":0,
+	    "condition":{"logics":[{"type":"api_rpc","conv_id":"@notify"}]}}
+	  ]}
+	}`), 0644)
+
+	pm, warnings, err := BuildProjectIndex(context.Background(), dst)
+	if err != nil {
+		t.Fatalf("build failed on real-shape aliases: %v (warnings: %v)", err, warnings)
+	}
+
+	// Aliases must resolve — this is the critical assertion the bug broke.
+	if pm.ByAlias["@payments"] != "5000" {
+		t.Errorf("by_alias[@payments] = %q, want 5000 (real-shape array parsing broken)", pm.ByAlias["@payments"])
+	}
+	if pm.ByAlias["@notify"] != "5001" {
+		t.Errorf("by_alias[@notify] = %q, want 5001 (title fallback when short_name empty broken)", pm.ByAlias["@notify"])
+	}
+	// Alias to a folder should still be tracked in by_alias, but no edge
+	// materialises because 9999 isn't a process in this project.
+	if pm.ByAlias["@some-folder"] != "9999" {
+		t.Errorf("by_alias[@some-folder] = %q, want 9999 (folder-typed aliases still trackable)", pm.ByAlias["@some-folder"])
+	}
+	// obj_to_id: null must be silently skipped, not emit @orphan-alias.
+	if _, present := pm.ByAlias["@orphan-alias"]; present {
+		t.Errorf("orphan alias with obj_to_id=null must be skipped, but by_alias has it")
+	}
+
+	// Cross-check that the caller's edges resolved via the alias map.
+	sawPay, sawNotify := false, false
+	for _, e := range pm.Edges {
+		if e.From == "5100" && e.To == "5000" && e.Type == "api_rpc" {
+			sawPay = true
+		}
+		if e.From == "5100" && e.To == "5001" && e.Type == "api_rpc" {
+			sawNotify = true
+		}
+	}
+	if !sawPay {
+		t.Errorf("edge 5100→5000 (via @payments) missing — alias resolution broken")
+	}
+	if !sawNotify {
+		t.Errorf("edge 5100→5001 (via @notify, title-fallback) missing")
+	}
+	// And that unresolved_targets is empty for this caller (nothing dropped).
+	if len(pm.UnresolvedTargets["5100"]) != 0 {
+		t.Errorf("5100 has unresolved targets: %v — should all resolve via aliases",
+			pm.UnresolvedTargets["5100"])
+	}
+}
+
+// TestIndex_ApiGetTaskEdge is the explicit test called out in TZ §12: without
+// api_get_task recognition the graph systematically undercounts links and
+// diverges from stage-scan output.
+func TestIndex_ApiGetTaskEdge(t *testing.T) {
+	pm, _ := runBuildOnFixture(t, "basic")
+	found := false
+	for _, e := range pm.Edges {
+		if e.Type == "api_get_task" && e.From == "200" && e.To == "100" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("api_get_task edge 200->100 not found; edges: %+v", pm.Edges)
+	}
+}
+
+// TestIndex_SecretsNeverLeakValues is the security-critical test: no output
+// file may contain the value of any secret-shaped field. We deliberately put
+// unusual, high-entropy-looking values in the fixture and grep the serialised
+// output for them.
+func TestIndex_SecretsNeverLeakValues(t *testing.T) {
+	pm, dst := runBuildOnFixture(t, "secrets")
+
+	// Persist the map like the real handler would.
+	if err := WriteProjectMap(dst, pm); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteQueriesMD(dst); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := UpdateClaudeMD(dst, pm); err != nil {
+		t.Fatal(err)
+	}
+
+	forbidden := []string{
+		"FAKE_sk_live_actualsecrethere",
+		"FAKE_P@ssw0rd-ShouldBeCaught",
+		"FAKE_S3cret!Value",
+		"FAKE_abcdefghij_012345_secret_value",
+	}
+	filesToScan := []string{
+		filepath.Join(dst, IndexOutputDir, IndexMapFile),
+		filepath.Join(dst, IndexOutputDir, IndexQueriesFile),
+		filepath.Join(dst, "CLAUDE.md"),
+	}
+	for _, f := range filesToScan {
+		body, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		for _, needle := range forbidden {
+			if strings.Contains(string(body), needle) {
+				t.Errorf("SECURITY: secret value %q leaked into %s", needle, f)
+			}
+		}
+	}
+
+	// But the FIELD NAMES must be recorded, otherwise the feature is useless.
+	if len(pm.SecurityHotspots) == 0 {
+		t.Fatal("no security_hotspots recorded — detection is broken")
+	}
+	sawInstance := false
+	sawDiagram := false
+	for _, sh := range pm.SecurityHotspots {
+		if sh.Source == "instance" && contains(sh.Fields, "password") {
+			sawInstance = true
+		}
+		if sh.Source == "diagram" {
+			sawDiagram = true
+			// Should include field names (values-shaped) but NOT the templated
+			// X-Password-Templated (value is {{...}}) nor the short Authorization.
+			if contains(sh.Fields, "X-Password-Templated") {
+				t.Errorf("templated field must be filtered out: got %v", sh.Fields)
+			}
+			if contains(sh.Fields, "Authorization") {
+				t.Errorf("short 'short' value should be filtered as unlikely-secret: got %v", sh.Fields)
+			}
+		}
+	}
+	if !sawInstance {
+		t.Error("no instance-source hotspot recorded for db password")
+	}
+	if !sawDiagram {
+		t.Error("no diagram-source hotspot recorded for hardcoded diagram fields")
+	}
+}
+
+// TestIndex_EnvVarUsageAggregation ensures {{env_var[@X]}} references from
+// nested logic blocks (set_param.extra map, api_code.code string) all get
+// aggregated into env_vars[X].used_by.
+func TestIndex_EnvVarUsageAggregation(t *testing.T) {
+	pm, _ := runBuildOnFixture(t, "envvars")
+
+	if len(pm.EnvVars) < 3 {
+		t.Fatalf("expected at least 3 env vars discovered from usage (API_URL, API_TOKEN, WORKSPACE); got %v",
+			pm.EnvVars)
+	}
+	for _, name := range []string{"API_URL", "API_TOKEN", "WORKSPACE"} {
+		ev, ok := pm.EnvVars[name]
+		if !ok {
+			t.Errorf("env var %s not discovered from {{env_var[@%s]}} usage", name, name)
+			continue
+		}
+		if len(ev.UsedBy) != 1 || ev.UsedBy[0] != "800" {
+			t.Errorf("env_vars[%s].used_by = %v, want [800]", name, ev.UsedBy)
+		}
+	}
+}
+
+// TestIndex_CallsInFromEdges verifies calls_in is derived from edges only —
+// calls_out was removed (derive via '[.edges[] | select(.from == $id)]' in jq).
+func TestIndex_CallsInFromEdges(t *testing.T) {
+	pm, _ := runBuildOnFixture(t, "basic")
+
+	// Recompute calls_in from edges and compare.
+	rebuilt := map[string]map[string]struct{}{}
+	for _, e := range pm.Edges {
+		if rebuilt[e.To] == nil {
+			rebuilt[e.To] = map[string]struct{}{}
+		}
+		rebuilt[e.To][e.From] = struct{}{}
+	}
+	for cid, set := range rebuilt {
+		want := mapKeysSorted(set)
+		got := pm.CallsIn[cid]
+		if !equalStrings(want, got) {
+			t.Errorf("calls_in[%s] = %v, want %v", cid, got, want)
+		}
+	}
+}
+
+// TestIndex_HashStabilityOnRawBytes locks in the definition from TZ §5: hash
+// is the SHA-1 of raw file bytes as they exist on disk. If a future change
+// switches to hashing the parsed-and-remarshalled JSON, this test breaks
+// (which is the point — the change would silently invalidate every existing
+// index without bumping schema_version).
+func TestIndex_HashStabilityOnRawBytes(t *testing.T) {
+	src := filepath.Join("testdata", "index_fixtures", "no_optional", "500_simple.conv.json")
+	raw, err := os.ReadFile(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	direct := hashBytes(raw)
+
+	pm, _ := runBuildOnFixture(t, "no_optional")
+	if pm.Processes["500"].Hash != direct {
+		t.Errorf("stored hash %q != raw-bytes hash %q — hash must be over the on-disk bytes",
+			pm.Processes["500"].Hash, direct)
+	}
+	if len(pm.Processes["500"].Hash) != IndexHashHexLen {
+		t.Errorf("hash length %d, want %d", len(pm.Processes["500"].Hash), IndexHashHexLen)
+	}
+}
+
+// TestIndex_CheckFreshness_NoChangesAfterCheckout is the specific test called
+// out in TZ criterion #14 — `git checkout` / repeated `pull-folder` stamps
+// new mtimes but doesn't change content, and --check must NOT report those
+// files as stale. Simulate by rebuilding the index, then bumping mtimes.
+func TestIndex_CheckFreshness_NoChangesAfterCheckout(t *testing.T) {
+	pm, dst := runBuildOnFixture(t, "basic")
+	if err := WriteProjectMap(dst, pm); err != nil {
+		t.Fatal(err)
+	}
+
+	// Bump mtime of every .conv.json without touching content, simulating
+	// `git checkout`.
+	newTime := os.FileInfo(nil)
+	_ = newTime
+	err := filepath.Walk(dst, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil || info.IsDir() {
+			return walkErr
+		}
+		if !strings.HasSuffix(info.Name(), ".conv.json") {
+			return nil
+		}
+		// Push mtime forward by 60 seconds — enough to defeat RFC3339 second
+		// resolution comparison.
+		t := info.ModTime().Add(60_000_000_000) // 60s in ns
+		return os.Chtimes(path, t, t)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rpt, err := CheckIndexFreshness(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rpt.Changed) != 0 || len(rpt.Added) != 0 || len(rpt.Removed) != 0 {
+		t.Errorf("mtime-only change should NOT be reported stale; got %+v", rpt)
+	}
+}
+
+// TestIndex_CheckFreshness_RealChange verifies the check does detect real
+// content changes (the other side of criterion #14).
+func TestIndex_CheckFreshness_RealChange(t *testing.T) {
+	pm, dst := runBuildOnFixture(t, "no_optional")
+	if err := WriteProjectMap(dst, pm); err != nil {
+		t.Fatal(err)
+	}
+
+	// Modify one file's contents.
+	target := filepath.Join(dst, "500_simple.conv.json")
+	data, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatal(err)
+	}
+	modified := strings.Replace(string(data), `"title": "Simple"`, `"title": "Simple2"`, 1)
+	if err := os.WriteFile(target, []byte(modified), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Bump mtime by 2 seconds so the --check mtime fast-path doesn't skip
+	// hash comparison (same-second write → mtime unchanged at RFC3339 resolution).
+	info2, _ := os.Stat(target)
+	future := info2.ModTime().Add(2 * 1e9)
+	_ = os.Chtimes(target, future, future)
+
+	rpt, err := CheckIndexFreshness(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(rpt.Changed, "500") {
+		t.Errorf("expected 500 in Changed, got %+v", rpt)
+	}
+}
+
+// --- helpers -----------------------------------------------------------
+
+func indexEdges(pm *ProjectMap) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, e := range pm.Edges {
+		key := e.From + "->" + e.To + "/" + e.Type
+		if e.Mode != "" {
+			key += "/" + e.Mode
+		}
+		if e.ViaAlias != "" {
+			key += "/" + e.ViaAlias
+		}
+		out[key] = struct{}{}
+	}
+	return out
+}
+
+func keys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+func contains(list []string, s string) bool {
+	for _, v := range list {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+
+// TestIndex_AutoRebuildHelper verifies the shared helper that
+// handlePullFolder and handlePushProcess call at the end of a successful
+// operation. This is the code-level guarantee that a fresh pull/push
+// produces a fresh index without relying on a SKILL.md prompt to remember —
+// see the note in handlePullFolder and handlePushProcess for the rationale.
+func TestIndex_AutoRebuildHelper(t *testing.T) {
+	src := filepath.Join("testdata", "index_fixtures", "basic")
+	dst := t.TempDir()
+	if err := copyDir(src, dst); err != nil {
+		t.Fatal(err)
+	}
+	cwd, _ := os.Getwd()
+	defer os.Chdir(cwd)
+	if err := os.Chdir(dst); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fresh project — no .corezoid yet.
+	if _, err := os.Stat(filepath.Join(dst, IndexOutputDir)); err == nil {
+		t.Fatalf("fixture should not contain .corezoid before auto-rebuild")
+	}
+
+	out := autoRebuildIndex(context.Background(), ".")
+	if !strings.Contains(out, "Project index refreshed") {
+		t.Errorf("expected success message; got %q", out)
+	}
+	// All three artefacts must exist after the helper returns.
+	for _, name := range []string{IndexMapFile, IndexQueriesFile, IndexConfigFile} {
+		p := filepath.Join(dst, IndexOutputDir, name)
+		if _, err := os.Stat(p); err != nil {
+			t.Errorf("expected %s after auto-rebuild, missing: %v", name, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dst, "CLAUDE.md")); err != nil {
+		t.Errorf("CLAUDE.md not created by auto-rebuild: %v", err)
+	}
+	// First-creation notice must be present so the user knows CLAUDE.md
+	// was touched — see TZ §6.2 social contract.
+	if !strings.Contains(out, "Added an auto-generated section to CLAUDE.md") {
+		t.Errorf("first-run auto-rebuild should announce CLAUDE.md creation; got %q", out)
+	}
+
+	// Second run — same directory, no new files — must not announce
+	// first-creation again (block is idempotent, markers exist).
+	out2 := autoRebuildIndex(context.Background(), ".")
+	if strings.Contains(out2, "Added an auto-generated section to CLAUDE.md") {
+		t.Errorf("second run should not repeat the first-creation notice; got %q", out2)
+	}
+}
+
+// TestIndex_CyclesEmptyIsArrayNotNull locks in that graph_stats.cycles
+// serialises as [] when no cycles are found, not null. Go's zero value for
+// [][]string is nil, and nil slices JSON-encode to null — but the rest of
+// the schema uses [] uniformly for "empty", and downstream consumers
+// (corezoid-project-review reading .graph_stats.cycles directly, jq recipes
+// in QUERIES.md query #7) rely on that invariant. Regressing to null would
+// silently break them.
+func TestIndex_CyclesEmptyIsArrayNotNull(t *testing.T) {
+	// no_optional fixture has one process with no cross-process calls →
+	// zero cycles.
+	pm, _ := runBuildOnFixture(t, "no_optional")
+	if pm.GraphStats == nil {
+		t.Fatal("GraphStats nil — fixture broken?")
+	}
+	if pm.GraphStats.Cycles == nil {
+		t.Fatal("Cycles is nil — must be an empty slice so JSON emits [] not null")
+	}
+	if len(pm.GraphStats.Cycles) != 0 {
+		t.Fatalf("expected 0 cycles on no_optional fixture, got %d", len(pm.GraphStats.Cycles))
+	}
+	data, err := json.Marshal(pm.GraphStats)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(data)
+	if strings.Contains(s, `"cycles":null`) {
+		t.Errorf(`graph_stats serialised "cycles":null; want "cycles":[]. Payload: %s`, s)
+	}
+	if !strings.Contains(s, `"cycles":[]`) {
+		t.Errorf(`graph_stats does not contain "cycles":[]. Payload: %s`, s)
+	}
+}
+
+// TestIndex_JSONShape guards the schema field names — jq queries in
+// QUERIES.md depend on them. If someone accidentally renames a struct field
+// (or forgets a `json:` tag), the QUERIES.md commands stop working with no
+// compile-time signal, so we assert the shape here.
+func TestIndex_JSONShape(t *testing.T) {
+	pm, _ := runBuildOnFixture(t, "basic")
+	data, err := json.MarshalIndent(pm, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	must := []string{
+		`"schema_version"`,
+		`"processes"`,
+		`"by_alias"`,
+		`"env_vars"`,
+		`"edges"`,
+		`"calls_in"`,
+		`"unresolved_targets"`,
+		`"external_apis"`,
+		`"state_stores"`,
+		`"instances"`,
+		`"graph_stats"`,
+		`"security_hotspots"`,
+	}
+	s := string(data)
+	for _, k := range must {
+		if !strings.Contains(s, k) {
+			t.Errorf("project-map.json missing required top-level key %s", k)
+		}
+	}
+	// Fields inside graph_stats used by QUERIES.md query #7
+	for _, k := range []string{`"high_fan_in"`, `"high_fan_out"`, `"orphaned"`, `"entry_points"`, `"cycles"`} {
+		if !strings.Contains(s, k) {
+			t.Errorf("graph_stats missing required key %s", k)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// from index_claude_md_test.go
+// ---------------------------------------------------------------------------
+
+
+
+func makeStubPM() *ProjectMap {
+	return &ProjectMap{
+		SchemaVersion: IndexSchemaVersion,
+		GeneratedAt:   "2026-07-02T00:00:00Z",
+		ProcessCount:  3,
+		StateStoreCount: 0,
+		InstanceCount: 0,
+		Processes:     map[string]*ProcessEntry{},
+		EnvVars:       map[string]*EnvVarEntry{},
+		GraphStats:    &GraphStats{},
+	}
+}
+
+// TestCLAUDE_CreateFromScratch — TZ §12: file doesn't exist → scaffold+block.
+func TestCLAUDE_CreateFromScratch(t *testing.T) {
+	dir := t.TempDir()
+	pm := makeStubPM()
+	first, err := UpdateClaudeMD(dir, pm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !first {
+		t.Errorf("expected firstCreation=true when file didn't exist")
+	}
+	body, err := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(body)
+	if !strings.Contains(s, "# Project Notes") {
+		t.Errorf("scaffold missing — file must include user-facing header when created fresh")
+	}
+	if !strings.Contains(s, "<!-- corezoid-index:start -->") {
+		t.Errorf("start marker missing")
+	}
+	if !strings.Contains(s, "<!-- corezoid-index:end -->") {
+		t.Errorf("end marker missing")
+	}
+}
+
+// TestCLAUDE_NoMarkers — TZ §12: existing file without markers → block
+// appended, original content preserved.
+func TestCLAUDE_NoMarkers(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "CLAUDE.md")
+	orig := "# Team CLAUDE.md\n\nOur rules here.\n"
+	if err := os.WriteFile(path, []byte(orig), 0644); err != nil {
+		t.Fatal(err)
+	}
+	first, err := UpdateClaudeMD(dir, makeStubPM())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !first {
+		t.Errorf("expected firstCreation=true when markers were absent")
+	}
+	body, _ := os.ReadFile(path)
+	s := string(body)
+	if !strings.HasPrefix(s, "# Team CLAUDE.md\n\nOur rules here.\n") {
+		t.Errorf("original content was not preserved verbatim at start:\n%s", s)
+	}
+	if !strings.Contains(s, "<!-- corezoid-index:start -->") {
+		t.Errorf("marker start missing")
+	}
+}
+
+// TestCLAUDE_OrphanStartMarker — TZ §12: only start marker present. Behaviour
+// documented: treat as if no markers exist, append fresh block, do not
+// attempt to guess the intended block boundary.
+func TestCLAUDE_OrphanStartMarker(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "CLAUDE.md")
+	orig := "# Broken\n\n<!-- corezoid-index:start -->\nleftover content\n\nsome team notes below.\n"
+	if err := os.WriteFile(path, []byte(orig), 0644); err != nil {
+		t.Fatal(err)
+	}
+	first, err := UpdateClaudeMD(dir, makeStubPM())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !first {
+		t.Errorf("expected firstCreation=true when markers are malformed (start only)")
+	}
+	body, _ := os.ReadFile(path)
+	s := string(body)
+	// Original content must be preserved verbatim.
+	if !strings.Contains(s, "leftover content") {
+		t.Errorf("original content lost after malformed-marker recovery: %s", s)
+	}
+	// A fresh, well-formed block must be appended (so there are now two
+	// start markers, which is fine — the next run will find the first
+	// well-formed pair).
+	if strings.Count(s, "<!-- corezoid-index:end -->") != 1 {
+		t.Errorf("expected exactly one end marker after recovery, got %d", strings.Count(s, "<!-- corezoid-index:end -->"))
+	}
+}
+
+// TestCLAUDE_UserContentPreservedAroundBlock — TZ §12: user content before
+// AND after the block round-trips verbatim.
+func TestCLAUDE_UserContentPreservedAroundBlock(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "CLAUDE.md")
+	before := "# Header\n\nRules above.\n\n"
+	block := "<!-- corezoid-index:start -->\nold auto-block\n<!-- corezoid-index:end -->"
+	after := "\n\nMore rules below.\n"
+	orig := before + block + after
+	if err := os.WriteFile(path, []byte(orig), 0644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := UpdateClaudeMD(dir, makeStubPM())
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, _ := os.ReadFile(path)
+	s := string(body)
+	if !strings.HasPrefix(s, before) {
+		t.Errorf("content before block not preserved verbatim:\n%s", s)
+	}
+	if !strings.Contains(s, "More rules below.") {
+		t.Errorf("content after block not preserved:\n%s", s)
+	}
+	if strings.Contains(s, "old auto-block") {
+		t.Errorf("stale auto-block content not replaced:\n%s", s)
+	}
+}
+
+// TestCLAUDE_NoOp — TZ §12: rebuild with same input produces byte-identical
+// output (ignoring the generated_at timestamp, which we hold fixed via
+// makeStubPM).
+func TestCLAUDE_NoOp(t *testing.T) {
+	dir := t.TempDir()
+	pm := makeStubPM()
+	if _, err := UpdateClaudeMD(dir, pm); err != nil {
+		t.Fatal(err)
+	}
+	body1, _ := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
+	// Second call with same pm: on the not-first path, firstCreation=false
+	// (well-formed markers exist).
+	first, err := UpdateClaudeMD(dir, pm)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if first {
+		t.Errorf("expected firstCreation=false on repeat run")
+	}
+	body2, _ := os.ReadFile(filepath.Join(dir, "CLAUDE.md"))
+	if string(body1) != string(body2) {
+		t.Errorf("repeat rebuild changed CLAUDE.md — expected byte-for-byte identical:\n--- first ---\n%s\n--- second ---\n%s",
+			body1, body2)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// from index_config_test.go
+// ---------------------------------------------------------------------------
+
+
+
+// TestConfig_AutoCreateWithDefaults — TZ §7 config lifecycle: file absent →
+// created with defaults on first run.
+func TestConfig_AutoCreateWithDefaults(t *testing.T) {
+	dir := t.TempDir()
+	cfg, warnings, err := LoadOrCreateIndexConfig(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("no warnings expected on first creation, got %v", warnings)
+	}
+	defaults := defaultIndexConfig()
+	if !equalStrings(cfg.EntryPointNamePrefixes, defaults.EntryPointNamePrefixes) {
+		t.Errorf("prefixes differ from defaults: %v vs %v", cfg.EntryPointNamePrefixes, defaults.EntryPointNamePrefixes)
+	}
+	path := filepath.Join(dir, IndexOutputDir, IndexConfigFile)
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("index-config.json not created: %v", err)
+	}
+}
+
+// TestConfig_NotOverwrittenOnSecondRun — TZ §7: existing config with custom
+// values must not be overwritten on subsequent rebuilds.
+func TestConfig_NotOverwrittenOnSecondRun(t *testing.T) {
+	dir := t.TempDir()
+	// Prime a custom config.
+	custom := IndexConfig{
+		EntryPointNamePrefixes:     []string{"эндпоинт", "публичный"},
+		EntryPointLocationKeywords: []string{"api", "public"},
+		SuspiciousNameKeywords:     []string{"тест", "временный", "копия"},
+	}
+	os.MkdirAll(filepath.Join(dir, IndexOutputDir), 0755)
+	data, _ := json.MarshalIndent(custom, "", "  ")
+	os.WriteFile(filepath.Join(dir, IndexOutputDir, IndexConfigFile), data, 0644)
+
+	cfg, warnings, err := LoadOrCreateIndexConfig(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", warnings)
+	}
+	if !equalStrings(cfg.SuspiciousNameKeywords, custom.SuspiciousNameKeywords) {
+		t.Errorf("custom Cyrillic list lost on reload: %v", cfg.SuspiciousNameKeywords)
+	}
+	// Verify file on disk still holds the custom content byte-for-byte.
+	onDisk, _ := os.ReadFile(filepath.Join(dir, IndexOutputDir, IndexConfigFile))
+	if !strings.Contains(string(onDisk), "тест") {
+		t.Errorf("existing config was rewritten — should be immutable across runs")
+	}
+}
+
+// TestConfig_PartialBrokenPerKeyFallback — TZ §7: malformed key falls back to
+// default without breaking the others, and produces a diagnostic warning.
+func TestConfig_PartialBrokenPerKeyFallback(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, IndexOutputDir), 0755)
+	broken := `{
+	  "entry_point_name_prefixes": ["public"],
+	  "suspicious_name_keywords": "not-an-array",
+	  "entry_point_location_keywords": ["ext"]
+	}`
+	os.WriteFile(filepath.Join(dir, IndexOutputDir, IndexConfigFile), []byte(broken), 0644)
+
+	cfg, warnings, err := LoadOrCreateIndexConfig(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warnings) == 0 {
+		t.Errorf("expected a warning about bad suspicious_name_keywords key")
+	}
+	// Good keys survived
+	if len(cfg.EntryPointNamePrefixes) != 1 || cfg.EntryPointNamePrefixes[0] != "public" {
+		t.Errorf("good prefix list lost: %v", cfg.EntryPointNamePrefixes)
+	}
+	if len(cfg.EntryPointLocationKeywords) != 1 || cfg.EntryPointLocationKeywords[0] != "ext" {
+		t.Errorf("good location list lost: %v", cfg.EntryPointLocationKeywords)
+	}
+	// Bad key fell back to defaults, not to empty.
+	defaults := defaultIndexConfig()
+	if !equalStrings(cfg.SuspiciousNameKeywords, defaults.SuspiciousNameKeywords) {
+		t.Errorf("bad key should fall back to default list, got %v", cfg.SuspiciousNameKeywords)
+	}
+}
+
+// TestConfig_CustomKeywordsChangeClassification — TZ §7 criterion #15:
+// overriding suspicious_name_keywords must actually change classification
+// without recompiling.
+func TestConfig_CustomKeywordsChangeClassification(t *testing.T) {
+	// Use a fixture with a process named "test_playground" (a default match)
+	// and override the config to drop "test" from suspicious words.
+	src := filepath.Join("testdata", "index_fixtures", "basic")
+	dst := t.TempDir()
+	if err := copyDir(src, dst); err != nil {
+		t.Fatal(err)
+	}
+	os.MkdirAll(filepath.Join(dst, IndexOutputDir), 0755)
+	custom := IndexConfig{
+		EntryPointNamePrefixes:     []string{"api"},
+		EntryPointLocationKeywords: []string{"api"},
+		SuspiciousNameKeywords:     []string{"unused_word_only"},
+	}
+	data, _ := json.MarshalIndent(custom, "", "  ")
+	os.WriteFile(filepath.Join(dst, IndexOutputDir, IndexConfigFile), data, 0644)
+
+	pm, _, err := BuildProjectIndex(context.Background(), dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, o := range pm.GraphStats.Orphaned {
+		if o.ConvID == "400" && o.SuspiciousName {
+			t.Errorf("400 was flagged suspicious even though 'test' isn't in the override list")
+		}
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// ---------------------------------------------------------------------------
+// from index_config_references_test.go
+// ---------------------------------------------------------------------------
+
+
+
+// --- 1. defaults ----------------------------------------------------------
+
+// TestConfigRefs_DefaultsSeeded — the 10 preseeded refs from
+// defaultIndexConfig() appear in index-config.json on first creation.
+// Regressing the preseed would blank out config_references for every
+// project that relies on the default list.
+func TestConfigRefs_DefaultsSeeded(t *testing.T) {
+	dir := t.TempDir()
+	cfg, warnings, err := LoadOrCreateIndexConfig(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("first-run warnings should be empty: %v", warnings)
+	}
+	if len(cfg.ConfigReferences.Tasks) != 10 {
+		t.Fatalf("expected 10 default tasks, got %d: %+v",
+			len(cfg.ConfigReferences.Tasks), cfg.ConfigReferences.Tasks)
+	}
+	must := map[string]bool{"config": false, "simulator": false, "corezoid": false}
+	for _, task := range cfg.ConfigReferences.Tasks {
+		if _, ok := must[task.Ref]; ok {
+			must[task.Ref] = true
+		}
+	}
+	for ref, seen := range must {
+		if !seen {
+			t.Errorf("default tasks missing ref %q", ref)
+		}
+	}
+}
+
+// --- 2. local scan populates used_by + read_fields -----------------------
+
+// TestConfigRefs_LocalScanUsedByAndFields is the primary happy-path test
+// for the local-scan model. Two processes reference @config differently:
+// one reads two fields, the other reads one field plus mentions the ref
+// bare. The result should merge both readers under `used_by` and expose
+// the union of read fields under `read_fields`.
+func TestConfigRefs_LocalScanUsedByAndFields(t *testing.T) {
+	dir := t.TempDir()
+
+	// Config allow-list — override defaults so we test just one ref.
+	os.MkdirAll(filepath.Join(dir, IndexOutputDir), 0755)
+	os.WriteFile(filepath.Join(dir, IndexOutputDir, IndexConfigFile), []byte(`{
+	  "config_references": {
+	    "tasks": [{"ref": "config", "label": "config"}],
+	    "mask_field_names": [], "mask_field_name_patterns": [], "never_mask_field_names": []
+	  }
+	}`), 0644)
+
+	// Reader A: {{conv[@config].ref[api_url]}} and {{conv[@config].ref[dev_mode]}}
+	os.WriteFile(filepath.Join(dir, "100_reader_a.conv.json"), []byte(`{
+	  "obj_id":100,"title":"Reader A","conv_type":"process","status":"active",
+	  "scheme":{"nodes":[
+	    {"id":"aaaa000000000000000000a1","title":"S","obj_type":1,
+	     "condition":{"logics":[{"type":"go","to_node_id":"aaaa000000000000000000a2"}]}},
+	    {"id":"aaaa000000000000000000a2","title":"Use","obj_type":0,
+	     "condition":{"logics":[{"type":"set_param","extra":{
+	       "url":"{{conv[@config].ref[api_url]}}/x",
+	       "flag":"{{conv[@config].ref[dev_mode]}}"
+	     }}]}}
+	  ]}
+	}`), 0644)
+	// Reader B: only .ref[timeout], plus a bare {{conv[@config]}} check.
+	os.WriteFile(filepath.Join(dir, "200_reader_b.conv.json"), []byte(`{
+	  "obj_id":200,"title":"Reader B","conv_type":"process","status":"active",
+	  "scheme":{"nodes":[
+	    {"id":"bbbb000000000000000000b1","title":"S","obj_type":1,
+	     "condition":{"logics":[{"type":"go","to_node_id":"bbbb000000000000000000b2"}]}},
+	    {"id":"bbbb000000000000000000b2","title":"UseAndCheck","obj_type":0,
+	     "condition":{"logics":[{"type":"set_param","extra":{
+	       "timeout":"{{conv[@config].ref[timeout]}}",
+	       "exists":"{{conv[@config]}}"
+	     }}]}}
+	  ]}
+	}`), 0644)
+	// A third process that doesn't touch @config — should NOT appear in used_by.
+	os.WriteFile(filepath.Join(dir, "300_bystander.conv.json"), []byte(`{
+	  "obj_id":300,"title":"Bystander","conv_type":"process","status":"active",
+	  "scheme":{"nodes":[
+	    {"id":"cccc000000000000000000c1","title":"S","obj_type":1,
+	     "condition":{"logics":[{"type":"go","to_node_id":"cccc000000000000000000c2"}]}},
+	    {"id":"cccc000000000000000000c2","title":"E","obj_type":2,"condition":{"logics":[]}}
+	  ]}
+	}`), 0644)
+
+	pm, _, err := BuildProjectIndex(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := pm.ConfigReferences["config"]
+	if entry == nil {
+		t.Fatalf("config entry missing; got %+v", pm.ConfigReferences)
+	}
+	if entry.SourceRef != "config" {
+		t.Errorf("SourceRef = %q, want config", entry.SourceRef)
+	}
+	// used_by should contain 100 and 200, not 300.
+	if !equalStrings(entry.UsedBy, []string{"100", "200"}) {
+		t.Errorf("UsedBy = %v, want [100 200]", entry.UsedBy)
+	}
+	// read_fields — union of api_url, dev_mode, timeout. Sorted.
+	if !equalStrings(entry.ReadFields, []string{"api_url", "dev_mode", "timeout"}) {
+		t.Errorf("ReadFields = %v, want [api_url dev_mode timeout]", entry.ReadFields)
+	}
+	// No alias defined for @config in this fixture → LocalConvID stays empty.
+	if entry.LocalConvID != "" {
+		t.Errorf("LocalConvID should be empty (no alias defined), got %q", entry.LocalConvID)
+	}
+}
+
+// --- 3. Ref resolves to local state-store cross-populates state_stores ---
+
+// TestConfigRefs_CrossPopulatesLocalStateStore ensures that when a
+// configured ref resolves via _ALIASES_.json to a local state-store
+// process, both the config_references entry and the state_stores entry
+// carry the reader info. This is the "record in state_stores" outcome
+// from the user's clarification.
+func TestConfigRefs_CrossPopulatesLocalStateStore(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, IndexOutputDir), 0755)
+	os.WriteFile(filepath.Join(dir, IndexOutputDir, IndexConfigFile), []byte(`{
+	  "config_references": {
+	    "tasks": [{"ref": "config", "label": "config"}],
+	    "mask_field_names": [], "mask_field_name_patterns": [], "never_mask_field_names": []
+	  }
+	}`), 0644)
+
+	// State-store process with alias @config.
+	os.WriteFile(filepath.Join(dir, "_ALIASES_.json"), []byte(`[
+	  {"short_name":"config","obj_to_id":500,"obj_to_type":"conv","title":"config","obj_id":1}
+	]`), 0644)
+	os.WriteFile(filepath.Join(dir, "500_config_store.conv.json"), []byte(`{
+	  "obj_id":500,"title":"Config Store","conv_type":"state","status":"active",
+	  "scheme":{"nodes":[
+	    {"id":"eeee000000000000000000e1","title":"S","obj_type":1,
+	     "condition":{"logics":[{"type":"go","to_node_id":"eeee000000000000000000e2"}]}},
+	    {"id":"eeee000000000000000000e2","title":"Set","obj_type":0,
+	     "condition":{"logics":[{"type":"set_param","extra":{"api_url":"init"}}]}}
+	  ]}
+	}`), 0644)
+	// Reader
+	os.WriteFile(filepath.Join(dir, "100_reader.conv.json"), []byte(`{
+	  "obj_id":100,"title":"Reader","conv_type":"process","status":"active",
+	  "scheme":{"nodes":[
+	    {"id":"aaaa000000000000000000a1","title":"S","obj_type":1,
+	     "condition":{"logics":[{"type":"go","to_node_id":"aaaa000000000000000000a2"}]}},
+	    {"id":"aaaa000000000000000000a2","title":"Read","obj_type":0,
+	     "condition":{"logics":[{"type":"set_param","extra":{"u":"{{conv[@config].ref[api_url]}}"}}]}}
+	  ]}
+	}`), 0644)
+
+	pm, _, err := BuildProjectIndex(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// config_references entry has LocalConvID pointing at the state store
+	entry := pm.ConfigReferences["config"]
+	if entry == nil || entry.LocalConvID != "500" {
+		t.Fatalf("expected LocalConvID=500 on config entry, got %+v", entry)
+	}
+	if !equalStrings(entry.UsedBy, []string{"100"}) {
+		t.Errorf("UsedBy = %v, want [100]", entry.UsedBy)
+	}
+	if !equalStrings(entry.ReadFields, []string{"api_url"}) {
+		t.Errorf("ReadFields = %v, want [api_url]", entry.ReadFields)
+	}
+	// state_stores[500] carries ReadBy and ReadFields alongside WrittenBy.
+	ss := pm.StateStores["500"]
+	if ss == nil {
+		t.Fatalf("state_stores[500] missing")
+	}
+	if !equalStrings(ss.ReadBy, []string{"100"}) {
+		t.Errorf("state_stores[500].ReadBy = %v, want [100]", ss.ReadBy)
+	}
+	if !equalStrings(ss.ReadFields, []string{"api_url"}) {
+		t.Errorf("state_stores[500].ReadFields = %v, want [api_url]", ss.ReadFields)
+	}
+}
+
+// --- 4. Unused refs are omitted -----------------------------------------
+
+// TestConfigRefs_UnusedRefsOmitted — a ref listed in the allow-list but
+// never referenced by any diagram must NOT appear as a zero-usage stub.
+// Presence signals real usage; absence signals "not part of the flow".
+func TestConfigRefs_UnusedRefsOmitted(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, IndexOutputDir), 0755)
+	os.WriteFile(filepath.Join(dir, IndexOutputDir, IndexConfigFile), []byte(`{
+	  "config_references": {
+	    "tasks": [
+	      {"ref": "config", "label": "config"},
+	      {"ref": "never_used", "label": "never_used"}
+	    ],
+	    "mask_field_names": [], "mask_field_name_patterns": [], "never_mask_field_names": []
+	  }
+	}`), 0644)
+	os.WriteFile(filepath.Join(dir, "100_uses_config.conv.json"), []byte(`{
+	  "obj_id":100,"title":"UsesConfig","conv_type":"process","status":"active",
+	  "scheme":{"nodes":[
+	    {"id":"aaaa000000000000000000a1","title":"S","obj_type":1,
+	     "condition":{"logics":[{"type":"go","to_node_id":"aaaa000000000000000000a2"}]}},
+	    {"id":"aaaa000000000000000000a2","title":"R","obj_type":0,
+	     "condition":{"logics":[{"type":"set_param","extra":{"u":"{{conv[@config].ref[x]}}"}}]}}
+	  ]}
+	}`), 0644)
+
+	pm, _, err := BuildProjectIndex(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := pm.ConfigReferences["config"]; !ok {
+		t.Errorf("config entry should be present (has usage)")
+	}
+	if _, ok := pm.ConfigReferences["never_used"]; ok {
+		t.Errorf("never_used should be omitted (0 usages), got: %+v", pm.ConfigReferences["never_used"])
+	}
+}
+
+// --- 5. Auto-include local state-store aliases -------------------------
+
+// TestConfigRefs_AutoIncludeLocalStateStoreAliases — a state-store alias
+// that is NOT in the user's index-config allow-list still gets scanned
+// and reported, because the effective allow-list unions the config with
+// every local state-store's aliases. Rationale: state-stores are
+// config-sources by construction (other processes read them via
+// {{conv[@X].ref[Y]}}), so requiring each project to hand-add their
+// stores to the seed list means silent gaps for projects whose aliases
+// aren't in the default 10.
+func TestConfigRefs_AutoIncludeLocalStateStoreAliases(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, IndexOutputDir), 0755)
+	// Deliberately narrow config: NO refs configured. Auto-include must
+	// still surface the local state-store alias.
+	os.WriteFile(filepath.Join(dir, IndexOutputDir, IndexConfigFile), []byte(`{
+	  "config_references": {
+	    "tasks": [],
+	    "mask_field_names": [], "mask_field_name_patterns": [], "never_mask_field_names": []
+	  }
+	}`), 0644)
+	// Alias @cache-sessions → local state-store 500.
+	os.WriteFile(filepath.Join(dir, "_ALIASES_.json"), []byte(`[
+	  {"short_name":"cache-sessions","obj_to_id":500,"obj_to_type":"conv","title":"cache-sessions","obj_id":1}
+	]`), 0644)
+	os.WriteFile(filepath.Join(dir, "500_cache.conv.json"), []byte(`{
+	  "obj_id":500,"title":"Cache","conv_type":"state","status":"active",
+	  "scheme":{"nodes":[
+	    {"id":"eeee000000000000000000e1","title":"S","obj_type":1,
+	     "condition":{"logics":[{"type":"go","to_node_id":"eeee000000000000000000e2"}]}},
+	    {"id":"eeee000000000000000000e2","title":"E","obj_type":2,"condition":{"logics":[]}}
+	  ]}
+	}`), 0644)
+	// A reader referencing @cache-sessions.ref[user_id]
+	os.WriteFile(filepath.Join(dir, "100_reader.conv.json"), []byte(`{
+	  "obj_id":100,"title":"Reader","conv_type":"process","status":"active",
+	  "scheme":{"nodes":[
+	    {"id":"aaaa000000000000000000a1","title":"S","obj_type":1,
+	     "condition":{"logics":[{"type":"go","to_node_id":"aaaa000000000000000000a2"}]}},
+	    {"id":"aaaa000000000000000000a2","title":"R","obj_type":0,
+	     "condition":{"logics":[{"type":"set_param","extra":{"u":"{{conv[@cache-sessions].ref[user_id]}}"}}]}}
+	  ]}
+	}`), 0644)
+
+	pm, _, err := BuildProjectIndex(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := pm.ConfigReferences["cache-sessions"]
+	if entry == nil {
+		t.Fatalf("cache-sessions entry missing — auto-inclusion of state-store aliases broken; got %+v", pm.ConfigReferences)
+	}
+	if entry.LocalConvID != "500" {
+		t.Errorf("LocalConvID = %q, want 500", entry.LocalConvID)
+	}
+	if !equalStrings(entry.UsedBy, []string{"100"}) {
+		t.Errorf("UsedBy = %v, want [100]", entry.UsedBy)
+	}
+	if !equalStrings(entry.ReadFields, []string{"user_id"}) {
+		t.Errorf("ReadFields = %v, want [user_id]", entry.ReadFields)
+	}
+}
+
+// --- 6. No refs configured → section omitted ---------------------------
+
+// TestConfigRefs_EmptyAllowlistNoSection — with an empty tasks list the
+// section is absent from project-map.json (omitempty).
+func TestConfigRefs_EmptyAllowlistNoSection(t *testing.T) {
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, IndexOutputDir), 0755)
+	os.WriteFile(filepath.Join(dir, IndexOutputDir, IndexConfigFile), []byte(`{
+	  "config_references": {
+	    "tasks": [],
+	    "mask_field_names": [], "mask_field_name_patterns": [], "never_mask_field_names": []
+	  }
+	}`), 0644)
+	os.WriteFile(filepath.Join(dir, "100_x.conv.json"), []byte(`{
+	  "obj_id":100,"title":"X","conv_type":"process","status":"active",
+	  "scheme":{"nodes":[]}
+	}`), 0644)
+	pm, _, err := BuildProjectIndex(context.Background(), dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pm.ConfigReferences != nil {
+		t.Errorf("empty allow-list should yield nil ConfigReferences, got %+v", pm.ConfigReferences)
+	}
+	data, _ := json.Marshal(pm)
+	if hasSubstring(string(data), `"config_references"`) {
+		t.Errorf("empty section should be omitted (omitempty); found key in JSON: %s", data)
+	}
+}
+
+func hasSubstring(s, sub string) bool {
+	return len(sub) > 0 && len(s) >= len(sub) && indexOf(s, sub) >= 0
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+// ---------------------------------------------------------------------------
+// from index_describe_test.go
+// ---------------------------------------------------------------------------
+
+
+
+func buildAndPersist(t *testing.T, fixture string) string {
+	t.Helper()
+	src := filepath.Join("testdata", "index_fixtures", fixture)
+	dst := t.TempDir()
+	if err := copyDir(src, dst); err != nil {
+		t.Fatal(err)
+	}
+	pm, _, err := BuildProjectIndex(context.Background(), dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteProjectMap(dst, pm); err != nil {
+		t.Fatal(err)
+	}
+	return dst
+}
+
+func callDescribe(t *testing.T, root string, args map[string]interface{}) describeProcessResult {
+	t.Helper()
+	args["project_path"] = root
+	// Use direct path — but describe-process uses confineToWorkdir which
+	// rejects absolute paths. Simulate the intended usage: cd into project.
+	cur, _ := os.Getwd()
+	defer os.Chdir(cur)
+	if err := os.Chdir(root); err != nil {
+		t.Fatal(err)
+	}
+	args["project_path"] = "."
+	result, isErr := handleDescribeProcess(nil, args)
+	if isErr {
+		t.Fatalf("describe-process errored: %s", result)
+	}
+	var r describeProcessResult
+	if err := json.Unmarshal([]byte(result), &r); err != nil {
+		t.Fatalf("describe-process output not valid JSON: %v\n%s", err, result)
+	}
+	return r
+}
+
+// TestDescribe_ByConvID — the primary resolution path used by corezoid-edit
+// when the user provides a numeric ID.
+func TestDescribe_ByConvID(t *testing.T) {
+	root := buildAndPersist(t, "basic")
+	r := callDescribe(t, root, map[string]interface{}{"identifier": "100"})
+	if !r.Found {
+		t.Fatalf("expected found=true, got %+v", r)
+	}
+	if r.ConvID != "100" {
+		t.Errorf("ConvID = %q, want 100", r.ConvID)
+	}
+	if r.Title == "" {
+		t.Errorf("Title empty; want the payment title")
+	}
+	if r.CallsInCount != 1 {
+		t.Errorf("CallsInCount = %d, want 1 (200 calls 100 via api_get_task)", r.CallsInCount)
+	}
+	if r.HighFanIn {
+		t.Errorf("HighFanIn = true, want false (calls_in=1 <= 5)")
+	}
+	if r.Stale {
+		t.Errorf("Stale=true right after build; want false")
+	}
+	if r.IndexHash == "" || r.CurrentFileHash == "" {
+		t.Errorf("both hashes should be populated: index=%q current=%q", r.IndexHash, r.CurrentFileHash)
+	}
+	if r.IndexHash != r.CurrentFileHash {
+		t.Errorf("hashes differ right after build: index=%q current=%q", r.IndexHash, r.CurrentFileHash)
+	}
+}
+
+// TestDescribe_ByAlias — @alias resolution, with and without leading @.
+func TestDescribe_ByAlias(t *testing.T) {
+	root := buildAndPersist(t, "basic")
+	for _, id := range []string{"@notify", "notify"} {
+		r := callDescribe(t, root, map[string]interface{}{"identifier": id})
+		if !r.Found || r.ConvID != "200" {
+			t.Errorf("identifier=%q → ConvID=%q, want 200 (found=%v)", id, r.ConvID, r.Found)
+		}
+	}
+}
+
+// TestDescribe_StaleDetection — after the fixture's .conv.json is modified,
+// the field arrives as stale=true so the edit skill sees it without any
+// extra "remember to check" prompting.
+func TestDescribe_StaleDetection(t *testing.T) {
+	root := buildAndPersist(t, "basic")
+	target := filepath.Join(root, "100_payment.conv.json")
+	data, _ := os.ReadFile(target)
+	modified := strings.Replace(string(data), `"title": "API: Create Payment"`, `"title": "API: Create Payment v2"`, 1)
+	if err := os.WriteFile(target, []byte(modified), 0644); err != nil {
+		t.Fatal(err)
+	}
+	r := callDescribe(t, root, map[string]interface{}{"identifier": "100"})
+	if !r.Stale {
+		t.Errorf("Stale=false after file modification; expected true (index_hash=%q current_hash=%q)",
+			r.IndexHash, r.CurrentFileHash)
+	}
+}
+
+// TestDescribe_MultipleTitleMatches — ambiguous title fragment returns
+// candidates instead of guessing. corezoid-edit will surface the list to the
+// user for disambiguation.
+func TestDescribe_MultipleTitleMatches(t *testing.T) {
+	// Build a two-process fixture where both titles contain the word "user".
+	dst := t.TempDir()
+	os.WriteFile(filepath.Join(dst, "10_create_user.conv.json"), []byte(`{
+	  "obj_id":10,"title":"Create user","conv_type":"process","status":"active",
+	  "scheme":{"nodes":[]}
+	}`), 0644)
+	os.WriteFile(filepath.Join(dst, "11_delete_user.conv.json"), []byte(`{
+	  "obj_id":11,"title":"Delete user","conv_type":"process","status":"active",
+	  "scheme":{"nodes":[]}
+	}`), 0644)
+	pm, _, _ := BuildProjectIndex(context.Background(), dst)
+	WriteProjectMap(dst, pm)
+
+	r := callDescribe(t, dst, map[string]interface{}{"identifier": "user"})
+	if r.Found {
+		t.Errorf("expected Found=false with multiple candidates; got %+v", r)
+	}
+	if len(r.Candidates) < 2 {
+		t.Errorf("expected ≥2 candidates for ambiguous 'user'; got %+v", r.Candidates)
+	}
+}
+
+// TestDescribe_IndexMissingFallback — without an index the tool falls back
+// to filesystem scan and reports index_missing=true so the caller can decide
+// whether to grep or build first.
+func TestDescribe_IndexMissingFallback(t *testing.T) {
+	dst := t.TempDir()
+	os.WriteFile(filepath.Join(dst, "42_foo.conv.json"), []byte(`{"obj_id":42,"title":"Foo","conv_type":"process","scheme":{"nodes":[]}}`), 0644)
+	r := callDescribe(t, dst, map[string]interface{}{"identifier": "42"})
+	if !r.IndexMissing {
+		t.Errorf("expected index_missing=true (no .corezoid/project-map.json), got %+v", r)
+	}
+	if len(r.Candidates) == 0 {
+		t.Errorf("expected filesystem candidates even without index; got none")
+	}
+}
+
+// TestDescribe_HighFanInFlag — a process with calls_in > IndexHighFanIn (5)
+// gets HighFanIn=true reported to the caller. This is the flag the model
+// consumes to trigger the blast-radius warning without a separate MANDATORY
+// prompt.
+func TestDescribe_HighFanInFlag(t *testing.T) {
+	dst := t.TempDir()
+	// One popular process (id 1000) called by seven others (2001..2007).
+	popular := `{"obj_id":1000,"title":"Popular","conv_type":"process","status":"active","scheme":{"nodes":[]}}`
+	os.WriteFile(filepath.Join(dst, "1000_popular.conv.json"), []byte(popular), 0644)
+	for i := 2001; i <= 2007; i++ {
+		caller := `{"obj_id":` + itoa(i) + `,"title":"Caller","conv_type":"process","status":"active",` +
+			`"scheme":{"nodes":[{"id":"cccc00000000000000000` + itoa(i)[len(itoa(i))-3:] + `","title":"C","obj_type":0,` +
+			`"condition":{"logics":[{"type":"api_rpc","conv_id":1000}]}}]}}`
+		os.WriteFile(filepath.Join(dst, itoa(i)+"_c.conv.json"), []byte(caller), 0644)
+	}
+	pm, _, err := BuildProjectIndex(context.Background(), dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	WriteProjectMap(dst, pm)
+
+	r := callDescribe(t, dst, map[string]interface{}{"identifier": "1000"})
+	if !r.HighFanIn {
+		t.Errorf("HighFanIn=false with %d callers; expected true (threshold=%d)", r.CallsInCount, IndexHighFanIn)
+	}
+	if r.CallsInCount != 7 {
+		t.Errorf("CallsInCount = %d, want 7", r.CallsInCount)
+	}
+}
+
+func itoa(n int) string {
+	s := ""
+	for n > 0 {
+		s = string(rune('0'+n%10)) + s
+		n /= 10
+	}
+	return s
+}

--- a/plugins/corezoid/mcp-server/index_types.go
+++ b/plugins/corezoid/mcp-server/index_types.go
@@ -1,0 +1,181 @@
+package main
+
+// Constants controlling the build-project-index behavior. Threshold values are
+// referenced from both the builder (populating graph_stats.high_fan_in/out) and
+// from the describe-process helper (populating high_fan_in flag on identify
+// results) so any change flows through both call sites automatically.
+const (
+	IndexSchemaVersion  = 1
+	IndexHashHexLen     = 12
+	IndexHighFanIn      = 5
+	IndexHighFanOut     = 7
+	IndexOutputDir      = ".corezoid"
+	IndexMapFile        = "project-map.json"
+	IndexQueriesFile    = "QUERIES.md"
+	IndexConfigFile     = "index-config.json"
+	IndexClaudeMdMarker = "corezoid-index"
+)
+
+// crossProcessLogicTypes is the canonical set of logic type strings that
+// represent a cross-process reference in this codebase. Kept as a package-level
+// helper so an accidental future addition (e.g. a new api_dispatch type)
+// requires editing one place, not scattered switches.
+var crossProcessLogicTypes = map[string]struct{}{
+	"api_rpc":      {},
+	"api_copy":     {},
+	"api_get_task": {},
+}
+
+func isCrossProcessType(t string) bool {
+	_, ok := crossProcessLogicTypes[t]
+	return ok
+}
+
+// ProjectMap is the on-disk schema for .corezoid/project-map.json. Field order
+// matches the schema documented in the TZ (Section 5) — do not reorder without
+// bumping IndexSchemaVersion, since the field names are the public API used by
+// jq queries in QUERIES.md and by consumers reading the file directly.
+type ProjectMap struct {
+	SchemaVersion     int                          `json:"schema_version"`
+	GeneratedAt       string                       `json:"generated_at"`
+	Root              string                       `json:"root"`
+	WorkspaceID       string                       `json:"workspace_id,omitempty"`
+	StageID           int                          `json:"stage_id,omitempty"`
+	ProcessCount      int                          `json:"process_count"`
+	StateStoreCount   int                          `json:"state_store_count"`
+	InstanceCount     int                          `json:"instance_count"`
+	Processes         map[string]*ProcessEntry     `json:"processes"`
+	ByAlias           map[string]string            `json:"by_alias"`
+	EnvVars           map[string]*EnvVarEntry      `json:"env_vars"`
+	Edges             []Edge                       `json:"edges"`
+	CallsIn           map[string][]string          `json:"calls_in"`
+	UnresolvedTargets map[string][]string          `json:"unresolved_targets"`
+	ExternalAPIs      map[string][]string          `json:"external_apis"`
+	StateStores       map[string]*StateStoreEntry  `json:"state_stores"`
+	Instances         map[string]*InstanceEntry    `json:"instances"`
+	GraphStats        *GraphStats                  `json:"graph_stats"`
+	SecurityHotspots  []SecurityHotspot            `json:"security_hotspots"`
+
+	// ConfigReferences holds materialised contents of Simulator config-tasks
+	// listed in IndexConfig.ConfigReferences.Tasks. Absent (omitempty) when
+	// no fetch has been performed yet — this lets push-process rebuilds
+	// preserve the block from the last pull-folder rather than serialising
+	// an empty object on every save. See TZ #2 §7 for the reasoning: fetch
+	// is expensive (network calls per ref), so it runs on pull, not push.
+	ConfigReferences map[string]*ConfigReferenceEntry `json:"config_references,omitempty"`
+}
+
+// ConfigReferenceEntry summarises one configured ref name's usage across
+// the local project. Everything here is derived from a pure local scan of
+// .conv.json files — no network calls, no auth required, no values stored.
+//
+// To read the actual runtime values of the config, agents should call
+// `list-node-tasks` on the LocalConvID process after building the index
+// (see corezoid-index skill). Values are intentionally NOT stored in the
+// index so that (a) no live tokens end up on disk, (b) agents always see
+// fresh values rather than a stale snapshot from the last pull.
+type ConfigReferenceEntry struct {
+	// SourceRef is the ref name from index-config, e.g. "config".
+	SourceRef string `json:"source_ref"`
+	// UsedBy is the sorted, unique list of conv_ids that reference this
+	// ref anywhere in their diagrams via {{conv[@ref]...}}.
+	UsedBy []string `json:"used_by"`
+	// ReadFields is the sorted, unique list of `.ref[X]` field names
+	// observed across all diagrams — telling the reader which specific
+	// fields of the config are consumed by the project.
+	ReadFields []string `json:"read_fields"`
+	// LocalConvID is populated when SourceRef resolves via _ALIASES_.json
+	// to a conv_id present in the current project. Use this to call
+	// `list-node-tasks` when you need the actual runtime values.
+	LocalConvID string `json:"local_conv_id,omitempty"`
+}
+
+// ProcessEntry describes a single .conv.json process. Cross-process calls are
+// NOT stored here — they live in ProjectMap.Edges. This is a deliberate
+// invariant: the graph is stored once and calls_in/calls_out/state_stores
+// derive from it, so an inconsistency between "raw calls per process" and
+// "resolved edges" can't happen by construction.
+type ProcessEntry struct {
+	Title           string   `json:"title"`
+	ConvType        string   `json:"conv_type"`
+	Status          string   `json:"status"`
+	Path            string   `json:"path"`
+	Location        string   `json:"location"`
+	Aliases         []string `json:"aliases"`
+	DBCalls         []string `json:"db_calls"`
+	EnvVarRefs      []string `json:"env_var_refs"`
+	HasReceiverNode bool     `json:"has_receiver_node"`
+	NodeCount       int      `json:"node_count"`
+	Hash            string   `json:"hash"`
+	MTime           string   `json:"mtime"`
+}
+
+// Edge is one directed link between processes. type is one of api_rpc,
+// api_copy, api_get_task (see crossProcessLogicTypes). mode is only populated
+// for api_copy (create/modify/delete). via_alias is populated when the target
+// was referenced by @alias and resolved through _ALIASES_.json.
+// Titles are omitted — resolve via .processes[$id].title to avoid duplication.
+type Edge struct {
+	From     string `json:"from"`
+	To       string `json:"to"`
+	Type     string `json:"type"`
+	Mode     string `json:"mode,omitempty"`
+	ViaAlias string `json:"via_alias,omitempty"`
+}
+
+type EnvVarEntry struct {
+	Description string   `json:"description"`
+	UsedBy      []string `json:"used_by"`
+}
+
+type StateStoreEntry struct {
+	Title     string   `json:"title"`
+	Aliases   []string `json:"aliases"`
+	Path      string   `json:"path"`
+	// WrittenBy — processes that mutate this state via api_copy edges
+	// (derived from the graph; existing behaviour).
+	WrittenBy []string `json:"written_by"`
+	// ReadBy — processes that read this state via {{conv[@alias]...}}
+	// references, populated only for state stores whose alias appears in
+	// the index-config config_references allow-list. Complementary to
+	// WrittenBy: together they answer "who writes, who reads".
+	ReadBy []string `json:"read_by,omitempty"`
+	// ReadFields — the specific `.ref[X]` field names observed across
+	// diagram scans, so consumers see which parts of the state each
+	// reader actually consumes.
+	ReadFields []string `json:"read_fields,omitempty"`
+}
+
+type InstanceEntry struct {
+	Title                string   `json:"title"`
+	InstanceType         string   `json:"instance_type"`
+	Path                 string   `json:"path"`
+	SecretFieldsPresent  []string `json:"secret_fields_present"`
+}
+
+type OrphanedInfo struct {
+	ConvID          string `json:"conv_id"`
+	SuspiciousName  bool   `json:"suspicious_name"`
+}
+
+type GraphStats struct {
+	HighFanIn   []string        `json:"high_fan_in"`
+	HighFanOut  []string        `json:"high_fan_out"`
+	Orphaned    []OrphanedInfo  `json:"orphaned"`
+	EntryPoints []string        `json:"entry_points"`
+	Cycles      [][]string      `json:"cycles"`
+}
+
+// SecurityHotspot is one location where a secret-shaped field name was
+// detected. Source is "instance" or "diagram". For "instance" source,
+// InstanceID and Path are populated; for "diagram" source, ConvID/NodeID/Path
+// are populated. Fields lists the offending field names — NEVER their values.
+type SecurityHotspot struct {
+	Source      string   `json:"source"`
+	InstanceID  string   `json:"instance_id,omitempty"`
+	ConvID      string   `json:"conv_id,omitempty"`
+	NodeID      string   `json:"node_id,omitempty"`
+	Title       string   `json:"title"`
+	Path        string   `json:"path"`
+	Fields      []string `json:"fields"`
+}

--- a/plugins/corezoid/mcp-server/mcp_handlers.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers.go
@@ -28,6 +28,8 @@ var toolHandlers = map[string]toolHandler{
 	"create-variable":      handleCreateVariable,
 	"push-process":         handlePushProcess,
 	"lint-process":         handleLintProcess,
+	"build-project-index":  handleBuildProjectIndex,
+	"describe-process":     handleDescribeProcess,
 	"run-task":             handleRunTask,
 	"create-process":       handleCreateProcess,
 	"create-state-diagram": handleCreateStateDiagram,
@@ -89,10 +91,12 @@ var toolHandlers = map[string]toolHandler{
 // send-feedback must not require auth so users can report problems that
 // occurred before or during the login flow.
 var noAuthTools = map[string]struct{}{
-	"lint-process":  {},
-	"login":         {},
-	"logout":        {},
-	"send-feedback": {},
+	"lint-process":        {},
+	"login":               {},
+	"logout":              {},
+	"send-feedback":       {},
+	"build-project-index": {},
+	"describe-process":    {},
 }
 
 // tokenOnlyTools need an OAuth token but not a fully configured workspace or

--- a/plugins/corezoid/mcp-server/mcp_handlers_describe.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_describe.go
@@ -1,0 +1,277 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// describeProcessResult is what handleDescribeProcess returns to the model.
+// Kept small on purpose: this is the payload consumed at the MANDATORY
+// "Identify the Process" step in corezoid-edit, so the fields are only the
+// ones the model needs to make the go/no-go decision (blast radius, staleness)
+// plus the path it uses to open the file.
+type describeProcessResult struct {
+	Found              bool     `json:"found"`
+	ConvID             string   `json:"conv_id,omitempty"`
+	Title              string   `json:"title,omitempty"`
+	Path               string   `json:"path,omitempty"`
+	Location           string   `json:"location,omitempty"`
+	Aliases            []string `json:"aliases,omitempty"`
+	CallsInCount       int      `json:"calls_in_count"`
+	CallsIn            []string `json:"calls_in,omitempty"`
+	HighFanIn          bool     `json:"high_fan_in"`
+	IndexHash          string   `json:"index_hash,omitempty"`
+	CurrentFileHash    string   `json:"current_file_hash,omitempty"`
+	Stale              bool     `json:"stale"`
+	IndexMissing       bool     `json:"index_missing"`
+	Candidates         []describeCandidate `json:"candidates,omitempty"`
+	Message            string   `json:"message,omitempty"`
+}
+
+type describeCandidate struct {
+	ConvID string `json:"conv_id"`
+	Title  string `json:"title"`
+	Path   string `json:"path"`
+}
+
+// handleDescribeProcess resolves a process identifier — numeric conv_id,
+// @alias, or a fuzzy title fragment — against .corezoid/project-map.json and
+// returns everything corezoid-edit needs at its MANDATORY first step in one
+// payload:
+//   - path to the file on disk (for the edit step)
+//   - calls_in count + a high_fan_in bool computed against IndexHighFanIn
+//     (so the model doesn't have to remember the threshold or forget the check)
+//   - index_hash + current_file_hash + stale bool (so the model sees staleness
+//     as data, not as an instruction to "remember to check")
+//
+// The point is that these fields arrive as part of the mandatory step, not as
+// a separate prompt to be honoured or forgotten. See TZ §10a.
+//
+// If the index is missing (index_missing=true), the caller must fall back to
+// filesystem grep — the tool still tries to help by returning best-effort
+// candidates from a filesystem scan when a title fragment is supplied.
+func handleDescribeProcess(_ context.Context, args map[string]interface{}) (string, bool) {
+	projectPath := optStrArg(args, "project_path")
+	if projectPath == "" {
+		projectPath = "."
+	}
+	safe, err := confineToWorkdir(projectPath)
+	if err != nil {
+		return "Error: " + err.Error(), true
+	}
+	absRoot, err := filepath.Abs(safe)
+	if err != nil {
+		return fmt.Sprintf("Error: %v", err), true
+	}
+
+	// Identifier: any one of these; the model calls us with whichever the
+	// user provided.
+	identifier := strings.TrimSpace(optStrArg(args, "identifier"))
+	if identifier == "" {
+		identifier = strings.TrimSpace(optStrArg(args, "process_id"))
+	}
+	if identifier == "" {
+		identifier = strings.TrimSpace(optStrArg(args, "process_name"))
+	}
+	if identifier == "" {
+		return "Error: identifier (process_id, process_name, or @alias) is required", true
+	}
+
+	res := describeProcessResult{}
+
+	pmPath := filepath.Join(absRoot, IndexOutputDir, IndexMapFile)
+	data, err := os.ReadFile(pmPath)
+	if errors.Is(err, os.ErrNotExist) {
+		res.IndexMissing = true
+		// Best-effort candidate list from filesystem so the caller still has
+		// something to work with. No calls_in / staleness info possible.
+		res.Candidates = findCandidatesByFilesystem(absRoot, identifier)
+		res.Message = "Project index not built yet. Run the corezoid-index skill (or MCP tool build-project-index) to enable blast-radius and staleness reporting."
+		return marshalDescribe(res)
+	}
+	if err != nil {
+		return fmt.Sprintf("Error reading %s: %v", pmPath, err), true
+	}
+	var pm ProjectMap
+	if err := json.Unmarshal(data, &pm); err != nil {
+		return fmt.Sprintf("Error parsing %s: %v", pmPath, err), true
+	}
+
+	// Resolution order: exact conv_id → alias (with or without @) → title
+	// fragment (case-insensitive). Title fragments are last because they can
+	// produce multiple matches, in which case we return the candidate list
+	// and force the caller to disambiguate — never guess.
+	convID := resolveIdentifier(identifier, &pm)
+	if convID == "" {
+		matches := matchByTitle(identifier, &pm)
+		switch len(matches) {
+		case 0:
+			res.Message = fmt.Sprintf("No process resolves to identifier %q. Try a numeric conv_id, an @alias, or a substring of the title.", identifier)
+			return marshalDescribe(res)
+		case 1:
+			convID = matches[0]
+		default:
+			for _, cid := range matches {
+				res.Candidates = append(res.Candidates, describeCandidate{
+					ConvID: cid,
+					Title:  pm.Processes[cid].Title,
+					Path:   pm.Processes[cid].Path,
+				})
+			}
+			res.Message = fmt.Sprintf("Multiple processes match %q — ask the user which one.", identifier)
+			return marshalDescribe(res)
+		}
+	}
+
+	pe, ok := pm.Processes[convID]
+	if !ok {
+		res.Message = fmt.Sprintf("Resolved to conv_id %s but it is not in the index. The index may need rebuilding.", convID)
+		return marshalDescribe(res)
+	}
+
+	res.Found = true
+	res.ConvID = convID
+	res.Title = pe.Title
+	res.Path = pe.Path
+	res.Location = pe.Location
+	res.Aliases = append([]string(nil), pe.Aliases...)
+	res.CallsIn = append([]string(nil), pm.CallsIn[convID]...)
+	res.CallsInCount = len(res.CallsIn)
+	res.HighFanIn = res.CallsInCount > IndexHighFanIn
+	res.IndexHash = pe.Hash
+
+	// Validate pe.Path — it comes from the on-disk project-map.json (which
+	// a user could modify) and must not contain "../" path traversal.
+	// confineToWorkdir rejects absolute paths and ".." escapes.
+	if safePath, pathErr := confineToWorkdir(pe.Path); pathErr == nil && safePath != "" {
+		if absPath := filepath.Join(absRoot, safePath); absPath != "" {
+			if h, err := hashFile(absPath); err == nil {
+				res.CurrentFileHash = h
+				res.Stale = h != pe.Hash
+			} else {
+				// File missing → the index is definitely stale (or worse).
+				res.Stale = true
+			}
+		}
+	}
+
+	// Compose a short human-readable summary that goes AFTER the JSON. The
+	// model doesn't strictly need it — the JSON has everything — but for a
+	// human debugging tool output it helps.
+	return marshalDescribe(res)
+}
+
+func marshalDescribe(res describeProcessResult) (string, bool) {
+	b, err := json.MarshalIndent(res, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("Error: %v", err), true
+	}
+	return string(b), false
+}
+
+func resolveIdentifier(id string, pm *ProjectMap) string {
+	// Numeric conv_id.
+	if _, err := strconv.Atoi(id); err == nil {
+		if _, ok := pm.Processes[id]; ok {
+			return id
+		}
+	}
+	// @alias: flattenAliases in index_builder.go stores both "@name" and "name"
+	// (without @), so two lookups cover all forms. The third redundant lookup
+	// `pm.ByAlias["@"+TrimPrefix(id, "@")]` is intentionally omitted.
+	if cid, ok := pm.ByAlias[id]; ok {
+		return cid
+	}
+	if cid, ok := pm.ByAlias[strings.TrimPrefix(id, "@")]; ok {
+		return cid
+	}
+	return ""
+}
+
+// matchByTitle returns conv_ids whose title contains all words in fragment.
+// For single-word queries, this is equivalent to the old Contains check.
+// For multi-word phrases (e.g. "accounts actor"), every word must appear in
+// the title in any order — this prevents multi-word action+object phrases
+// from matching nothing when the words are non-adjacent.
+func matchByTitle(fragment string, pm *ProjectMap) []string {
+	words := strings.Fields(strings.ToLower(fragment))
+	if len(words) == 0 {
+		return nil
+	}
+	var matches []string
+	for cid, pe := range pm.Processes {
+		lower := strings.ToLower(pe.Title)
+		allMatch := true
+		for _, w := range words {
+			if !strings.Contains(lower, w) {
+				allMatch = false
+				break
+			}
+		}
+		if allMatch {
+			matches = append(matches, cid)
+		}
+	}
+	return uniqueSorted(matches)
+}
+
+// findCandidatesByFilesystem is the fallback path when there is no index and
+// the caller supplied a title fragment. Scans .conv.json filenames and
+// returns matches — no calls_in / staleness info can be derived without the
+// index, so this is deliberately less useful than the indexed path.
+func findCandidatesByFilesystem(root, fragment string) []describeCandidate {
+	var out []describeCandidate
+	// Try exact numeric conv_id first as a filename prefix.
+	if _, err := strconv.Atoi(fragment); err == nil {
+		re := regexp.MustCompile("^" + regexp.QuoteMeta(fragment) + `_.*\.conv\.json$`)
+		_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+			if err != nil || info.IsDir() {
+				return err
+			}
+			if re.MatchString(info.Name()) {
+				rel, _ := filepath.Rel(root, path)
+				out = append(out, describeCandidate{
+					ConvID: fragment,
+					Title:  "",
+					Path:   filepath.ToSlash(rel),
+				})
+			}
+			return nil
+		})
+		return out
+	}
+	// Fragment match against filename basename (a coarse approximation of
+	// title match without loading every file).
+	lower := strings.ToLower(fragment)
+	_ = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		name := info.Name()
+		if !strings.HasSuffix(name, ".conv.json") {
+			return nil
+		}
+		if !strings.Contains(strings.ToLower(name), lower) {
+			return nil
+		}
+		m := reProcessFileName.FindStringSubmatch(name)
+		if m == nil {
+			return nil
+		}
+		rel, _ := filepath.Rel(root, path)
+		out = append(out, describeCandidate{
+			ConvID: m[1],
+			Title:  "",
+			Path:   filepath.ToSlash(rel),
+		})
+		return nil
+	})
+	return out
+}

--- a/plugins/corezoid/mcp-server/mcp_handlers_index.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_index.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// handleBuildProjectIndex builds the .corezoid/ artefacts for the project
+// rooted at the current working directory (or an explicit project_path).
+// Local-file-only, no auth needed — see noAuthTools registration in
+// mcp_handlers.go.
+//
+// Mode selection:
+//   - "check"  → run CheckIndexFreshness only, no rebuild
+//   - default  → full rebuild (writes project-map.json, QUERIES.md, updates
+//     CLAUDE.md, creates index-config.json if missing)
+func handleBuildProjectIndex(ctx context.Context, args map[string]interface{}) (string, bool) {
+	projectPath := optStrArg(args, "project_path")
+	if projectPath != "" {
+		safe, err := confineToWorkdir(projectPath)
+		if err != nil {
+			return "Error: " + err.Error(), true
+		}
+		projectPath = safe
+	} else {
+		projectPath = "."
+	}
+	absRoot, err := filepath.Abs(projectPath)
+	if err != nil {
+		return fmt.Sprintf("Error: cannot resolve absolute path: %v", err), true
+	}
+
+	mode := strings.ToLower(optStrArg(args, "mode"))
+	if mode == "check" {
+		rpt, err := CheckIndexFreshness(absRoot)
+		if err != nil {
+			return fmt.Sprintf("Error: %v", err), true
+		}
+		return FormatStaleReport(rpt), false
+	}
+
+	// Explicit build-project-index calls (via the corezoid-index skill or
+	// a manual MCP call) are the natural place to refresh online task
+	// contents — they're user-initiated, not part of a hot loop.
+	pm, warnings, err := BuildProjectIndex(ctx, absRoot)
+	if err != nil {
+		return fmt.Sprintf("Error: %v", err), true
+	}
+	if err := WriteProjectMap(absRoot, pm); err != nil {
+		return fmt.Sprintf("Error writing project-map.json: %v", err), true
+	}
+	if err := WriteQueriesMD(absRoot); err != nil {
+		return fmt.Sprintf("Error writing QUERIES.md: %v", err), true
+	}
+	firstCreation, err := UpdateClaudeMD(absRoot, pm)
+	if err != nil {
+		return fmt.Sprintf("Error updating CLAUDE.md: %v", err), true
+	}
+
+	return formatBuildResult(absRoot, pm, warnings, firstCreation), false
+}
+
+// formatBuildResult produces the human-readable summary the tool returns to
+// the MCP client. Kept short (≤ ~15 lines) — details live in project-map.json.
+// The "first creation" line is present only when the CLAUDE.md block was
+// created for the first time in this project, per TZ §6.2 social-contract
+// requirement (mutating a user file silently is a surprise even when the
+// mutation is technically correct).
+func formatBuildResult(root string, pm *ProjectMap, warnings []string, firstCreation bool) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "Project index built at %s\n", filepath.Join(root, IndexOutputDir))
+	fmt.Fprintf(&sb, "  Processes: %d (state stores: %d, instances: %d)\n",
+		pm.ProcessCount, pm.StateStoreCount, pm.InstanceCount)
+	fmt.Fprintf(&sb, "  Env variables: %d\n", len(pm.EnvVars))
+	fmt.Fprintf(&sb, "  Edges: %d, external APIs: %d\n", len(pm.Edges), len(pm.ExternalAPIs))
+	if pm.GraphStats != nil {
+		if n := len(pm.GraphStats.HighFanIn); n > 0 {
+			fmt.Fprintf(&sb, "  High fan-in: %d process(es)\n", n)
+		}
+		if n := len(pm.GraphStats.Cycles); n > 0 {
+			fmt.Fprintf(&sb, "  Cycles: %d\n", n)
+		}
+		if n := len(pm.GraphStats.Orphaned); n > 0 {
+			fmt.Fprintf(&sb, "  Orphaned candidates: %d (heuristic — verify before deletion)\n", n)
+		}
+	}
+	if n := len(pm.SecurityHotspots); n > 0 {
+		fmt.Fprintf(&sb, "  Security hotspots: %d (field names + locations only, no values)\n", n)
+	}
+	if n := len(pm.ConfigReferences); n > 0 {
+		// Count refs that resolve to a local state-store (informative:
+		// "these are backed by state we can see") vs. purely external
+		// ones ("look elsewhere for the values"). Both are legitimate.
+		local, external := 0, 0
+		for _, e := range pm.ConfigReferences {
+			if e == nil {
+				continue
+			}
+			if e.LocalConvID != "" {
+				local++
+			} else {
+				external++
+			}
+		}
+		fmt.Fprintf(&sb, "  Config references: %d used (local state-store: %d, external: %d)\n",
+			n, local, external)
+	}
+	if firstCreation {
+		fmt.Fprintf(&sb, "\n"+
+			"Added a short auto-generated section to CLAUDE.md between "+
+			"<!-- %s:start --> / <!-- %s:end -->; content outside those markers is untouched.\n",
+			IndexClaudeMdMarker, IndexClaudeMdMarker)
+		// Also mention gitignore hygiene once, at first creation.
+		if hint := gitignoreHint(root); hint != "" {
+			sb.WriteString(hint)
+		}
+	}
+	if len(warnings) > 0 {
+		sb.WriteString("\nWarnings:\n")
+		for _, w := range warnings {
+			fmt.Fprintf(&sb, "  - %s\n", w)
+		}
+	}
+	sb.WriteString("\nQuery recipes: .corezoid/QUERIES.md")
+	return sb.String()
+}
+
+// autoRebuildIndex runs BuildProjectIndex + writers in a project root
+// non-fatally: any error becomes a one-line warning appended to the caller's
+// tool output, never a hard failure of the surrounding operation. Meant to
+// be called at the end of pull-folder and push-process handlers so the index
+// stays fresh even when the user bypasses corezoid-init / corezoid-edit /
+// corezoid-create and calls those tools directly. This is the code-level
+// counterpart of the SKILL.md "Step 3: Build the project index" — reliable
+// where a prompt instruction is not.
+//
+// If projectRoot is "." or empty, resolves against the current working
+// directory. If the directory contains no .conv.json files (e.g. the caller
+// pulled a single process into an empty tree), the tool still runs and
+// produces an index with process_count=0 — harmless.
+//
+// Returns a short status suffix to append to the caller's output. Empty
+// string on success (silence). "\n\n" prefix keeps formatting clean.
+//
+func autoRebuildIndex(ctx context.Context, projectRoot string) string {
+	if projectRoot == "" {
+		projectRoot = "."
+	}
+	absRoot, err := filepath.Abs(projectRoot)
+	if err != nil {
+		logger.Warn("auto-rebuild index: cannot resolve %q: %v", projectRoot, err)
+		return "\n\nWarning: could not build project index — " + err.Error()
+	}
+
+	pm, warnings, err := BuildProjectIndex(ctx, absRoot)
+	if err != nil {
+		logger.Warn("auto-rebuild index: build failed: %v", err)
+		return "\n\nWarning: project index build failed (" + err.Error() +
+			"). Run the corezoid-index skill to retry."
+	}
+	if err := WriteProjectMap(absRoot, pm); err != nil {
+		logger.Warn("auto-rebuild index: write project-map.json failed: %v", err)
+		return "\n\nWarning: could not write project-map.json — " + err.Error()
+	}
+	if err := WriteQueriesMD(absRoot); err != nil {
+		logger.Warn("auto-rebuild index: write QUERIES.md failed: %v", err)
+		return "\n\nWarning: could not write QUERIES.md — " + err.Error()
+	}
+	firstCreation, err := UpdateClaudeMD(absRoot, pm)
+	if err != nil {
+		logger.Warn("auto-rebuild index: update CLAUDE.md failed: %v", err)
+		return "\n\nWarning: could not update CLAUDE.md — " + err.Error()
+	}
+
+	var sb strings.Builder
+	sb.WriteString("\n\nProject index refreshed at ")
+	sb.WriteString(filepath.Join(absRoot, IndexOutputDir))
+	sb.WriteString(fmt.Sprintf(" — processes: %d, edges: %d", pm.ProcessCount, len(pm.Edges)))
+	if pm.GraphStats != nil {
+		if n := len(pm.GraphStats.Cycles); n > 0 {
+			sb.WriteString(fmt.Sprintf(", cycles: %d", n))
+		}
+		if n := len(pm.GraphStats.HighFanIn); n > 0 {
+			sb.WriteString(fmt.Sprintf(", high fan-in: %d", n))
+		}
+	}
+	if n := len(pm.SecurityHotspots); n > 0 {
+		sb.WriteString(fmt.Sprintf(", security hotspots: %d", n))
+	}
+	sb.WriteString(".")
+	if firstCreation {
+		sb.WriteString("\n" +
+			"Added an auto-generated section to CLAUDE.md between <!-- " + IndexClaudeMdMarker +
+			":start --> / <!-- " + IndexClaudeMdMarker + ":end -->; content outside those markers is untouched.")
+		if hint := gitignoreHint(absRoot); hint != "" {
+			sb.WriteString(hint)
+		}
+	}
+	if len(warnings) > 0 {
+		sb.WriteString("\nIndex build warnings:")
+		for _, w := range warnings {
+			sb.WriteString("\n  - " + w)
+		}
+	}
+	sb.WriteString("\nQuery recipes: " + filepath.Join(IndexOutputDir, IndexQueriesFile))
+	return sb.String()
+}
+
+// gitignoreHint returns a one-off suggestion to gitignore the derived
+// artefacts (project-map.json + QUERIES.md) — but explicitly NOT
+// index-config.json (which embodies a team choice and should be committed).
+// Only emits when the project has a .git directory (there's no point
+// suggesting .gitignore if git isn't involved).
+func gitignoreHint(root string) string {
+	if _, err := os.Stat(filepath.Join(root, ".git")); err != nil {
+		return ""
+	}
+	return "\nTip: this project has a .git directory. Consider adding to `.gitignore`:\n" +
+		"  " + IndexOutputDir + "/" + IndexMapFile + "\n" +
+		"  " + IndexOutputDir + "/" + IndexQueriesFile + "\n" +
+		"Do NOT gitignore " + IndexOutputDir + "/" + IndexConfigFile +
+		" — it holds team-shared heuristic settings.\n"
+}

--- a/plugins/corezoid/mcp-server/mcp_handlers_process.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_process.go
@@ -95,6 +95,13 @@ func handlePullProcess(ctx context.Context, args map[string]interface{}) (string
 
 // handlePullFolder recursively downloads a folder (stage) and all its
 // processes/subfolders into the current working directory.
+//
+// On success, auto-rebuilds .corezoid/project-map.json, QUERIES.md and the
+// CLAUDE.md auto-block. This lives in the handler (not just in the
+// corezoid-init SKILL.md) so the index refreshes even when the user calls
+// pull-folder directly, bypassing the init skill entirely. Index build
+// failure is a warning, never a rollback — the pulled files are still on
+// disk and usable.
 func handlePullFolder(ctx context.Context, args map[string]interface{}) (string, bool) {
 	folderID, err := intArg(args, "folder_id")
 	if err != nil {
@@ -105,7 +112,11 @@ func handlePullFolder(ctx context.Context, args map[string]interface{}) (string,
 	if err := downloadStageRecursively(v, folderID, "."); err != nil {
 		return fmt.Sprintf("Error fetching folder: %v", err), true
 	}
-	return fmt.Sprintf("Folder %d saved to current directory", folderID), false
+	msg := fmt.Sprintf("Folder %d saved to current directory", folderID)
+	// pull-folder is the once-per-session event where refreshing
+	// state-store task contents is worth an extra Corezoid round-trip.
+	msg += autoRebuildIndex(ctx, ".")
+	return msg, false
 }
 
 // handleCreateVariable creates a Corezoid env variable scoped to the given stage.
@@ -178,7 +189,14 @@ func handlePushProcess(ctx context.Context, args map[string]interface{}) (string
 		return fmt.Sprintf("Error deploying process: %v", err), true
 	}
 
-	return fmt.Sprintf("Process deployed successfully, ProcessID: %d", procID), false
+	// Auto-rebuild the project index so describe-process / QUERIES /
+	// project-review see the just-deployed changes immediately. push
+	// path passes fetchStateContents=false: the tasks[] block preserved
+	// from the last build stays intact, and the edit loop doesn't pay
+	// for a fresh Corezoid round-trip on every save.
+	msg := fmt.Sprintf("Process deployed successfully, ProcessID: %d", procID)
+	msg += autoRebuildIndex(ctx, ".")
+	return msg, false
 }
 
 // handleLintProcess validates a local .conv.json without touching the server.

--- a/plugins/corezoid/mcp-server/testdata/index_fixtures/basic/100_payment.conv.json
+++ b/plugins/corezoid/mcp-server/testdata/index_fixtures/basic/100_payment.conv.json
@@ -1,0 +1,43 @@
+{
+  "obj_type": 1,
+  "obj_id": 100,
+  "title": "API: Create Payment",
+  "conv_type": "process",
+  "status": "active",
+  "scheme": {
+    "nodes": [
+      {
+        "id": "aaaa000000000000000000a1",
+        "title": "Start",
+        "obj_type": 1,
+        "condition": {"logics": [{"type": "go", "to_node_id": "aaaa000000000000000000a2"}]}
+      },
+      {
+        "id": "aaaa000000000000000000a2",
+        "title": "Charge",
+        "obj_type": 0,
+        "condition": {"logics": [
+          {"type": "api", "url": "{{env_var[@STRIPE_URL]}}/charge", "method": "POST",
+           "extra_headers": {"Authorization": "Bearer {{env_var[@STRIPE_TOKEN]}}"},
+           "extra": {"amount": "{{amount}}"}}
+        ]}
+      },
+      {
+        "id": "aaaa000000000000000000a3",
+        "title": "Save state",
+        "obj_type": 0,
+        "condition": {"logics": [
+          {"type": "api_copy", "conv_id": 300, "mode": "create"}
+        ]}
+      },
+      {
+        "id": "aaaa000000000000000000a4",
+        "title": "Notify",
+        "obj_type": 0,
+        "condition": {"logics": [
+          {"type": "api_rpc", "conv_id": "@notify", "extra": {}}
+        ]}
+      }
+    ]
+  }
+}

--- a/plugins/corezoid/mcp-server/testdata/index_fixtures/basic/200_notify.conv.json
+++ b/plugins/corezoid/mcp-server/testdata/index_fixtures/basic/200_notify.conv.json
@@ -1,0 +1,25 @@
+{
+  "obj_type": 1,
+  "obj_id": 200,
+  "title": "notify: send",
+  "conv_type": "process",
+  "status": "active",
+  "scheme": {
+    "nodes": [
+      {
+        "id": "bbbb000000000000000000b1",
+        "title": "Start",
+        "obj_type": 1,
+        "condition": {"logics": [{"type": "go", "to_node_id": "bbbb000000000000000000b2"}]}
+      },
+      {
+        "id": "bbbb000000000000000000b2",
+        "title": "GetPaymentTask",
+        "obj_type": 0,
+        "condition": {"logics": [
+          {"type": "api_get_task", "conv_id": 100, "node_id": "aaaa000000000000000000a2"}
+        ]}
+      }
+    ]
+  }
+}

--- a/plugins/corezoid/mcp-server/testdata/index_fixtures/basic/300_state_store.conv.json
+++ b/plugins/corezoid/mcp-server/testdata/index_fixtures/basic/300_state_store.conv.json
@@ -1,0 +1,23 @@
+{
+  "obj_type": 1,
+  "obj_id": 300,
+  "title": "payments-store",
+  "conv_type": "state",
+  "status": "active",
+  "scheme": {
+    "nodes": [
+      {
+        "id": "cccc000000000000000000c1",
+        "title": "Start",
+        "obj_type": 1,
+        "condition": {"logics": [{"type": "go", "to_node_id": "cccc000000000000000000c2"}]}
+      },
+      {
+        "id": "cccc000000000000000000c2",
+        "title": "Set state",
+        "obj_type": 0,
+        "condition": {"logics": [{"type": "set_param", "extra": {"state": "created"}}]}
+      }
+    ]
+  }
+}

--- a/plugins/corezoid/mcp-server/testdata/index_fixtures/basic/400_test_process.conv.json
+++ b/plugins/corezoid/mcp-server/testdata/index_fixtures/basic/400_test_process.conv.json
@@ -1,0 +1,23 @@
+{
+  "obj_type": 1,
+  "obj_id": 400,
+  "title": "test_playground",
+  "conv_type": "process",
+  "status": "active",
+  "scheme": {
+    "nodes": [
+      {
+        "id": "dddd000000000000000000d1",
+        "title": "Start",
+        "obj_type": 1,
+        "condition": {"logics": [{"type": "go", "to_node_id": "dddd000000000000000000d2"}]}
+      },
+      {
+        "id": "dddd000000000000000000d2",
+        "title": "End",
+        "obj_type": 2,
+        "condition": {"logics": []}
+      }
+    ]
+  }
+}

--- a/plugins/corezoid/mcp-server/testdata/index_fixtures/basic/_ALIASES_.json
+++ b/plugins/corezoid/mcp-server/testdata/index_fixtures/basic/_ALIASES_.json
@@ -1,0 +1,26 @@
+[
+  {
+    "description": "",
+    "obj_id": 1,
+    "obj_to_id": 100,
+    "obj_to_title": "API: Create Payment",
+    "obj_to_type": "conv",
+    "obj_type": 9,
+    "parent_id": 8262,
+    "short_name": "payment",
+    "title": "payment",
+    "uuid": "aaaaaaaa-0000-0000-0000-000000000001"
+  },
+  {
+    "description": "",
+    "obj_id": 2,
+    "obj_to_id": 200,
+    "obj_to_title": "notify: send",
+    "obj_to_type": "conv",
+    "obj_type": 9,
+    "parent_id": 8262,
+    "short_name": "notify",
+    "title": "notify",
+    "uuid": "aaaaaaaa-0000-0000-0000-000000000002"
+  }
+]

--- a/plugins/corezoid/mcp-server/testdata/index_fixtures/basic/_ENV_VARS_.json
+++ b/plugins/corezoid/mcp-server/testdata/index_fixtures/basic/_ENV_VARS_.json
@@ -1,0 +1,4 @@
+{
+  "STRIPE_URL": {"description": "Stripe API endpoint"},
+  "STRIPE_TOKEN": {"description": "Stripe secret key"}
+}

--- a/plugins/corezoid/mcp-server/testdata/index_fixtures/cycle/600_a.conv.json
+++ b/plugins/corezoid/mcp-server/testdata/index_fixtures/cycle/600_a.conv.json
@@ -1,0 +1,23 @@
+{
+  "obj_type": 1,
+  "obj_id": 600,
+  "title": "A",
+  "conv_type": "process",
+  "status": "active",
+  "scheme": {
+    "nodes": [
+      {
+        "id": "ffff000000000000000000f1",
+        "title": "Start",
+        "obj_type": 1,
+        "condition": {"logics": [{"type": "go", "to_node_id": "ffff000000000000000000f2"}]}
+      },
+      {
+        "id": "ffff000000000000000000f2",
+        "title": "Call B",
+        "obj_type": 0,
+        "condition": {"logics": [{"type": "api_rpc", "conv_id": 601}]}
+      }
+    ]
+  }
+}

--- a/plugins/corezoid/mcp-server/testdata/index_fixtures/cycle/601_b.conv.json
+++ b/plugins/corezoid/mcp-server/testdata/index_fixtures/cycle/601_b.conv.json
@@ -1,0 +1,23 @@
+{
+  "obj_type": 1,
+  "obj_id": 601,
+  "title": "B",
+  "conv_type": "process",
+  "status": "active",
+  "scheme": {
+    "nodes": [
+      {
+        "id": "0011000000000000000000f1",
+        "title": "Start",
+        "obj_type": 1,
+        "condition": {"logics": [{"type": "go", "to_node_id": "0011000000000000000000f2"}]}
+      },
+      {
+        "id": "0011000000000000000000f2",
+        "title": "Call A",
+        "obj_type": 0,
+        "condition": {"logics": [{"type": "api_rpc", "conv_id": 600}]}
+      }
+    ]
+  }
+}

--- a/plugins/corezoid/mcp-server/testdata/index_fixtures/cycle/602_self.conv.json
+++ b/plugins/corezoid/mcp-server/testdata/index_fixtures/cycle/602_self.conv.json
@@ -1,0 +1,23 @@
+{
+  "obj_type": 1,
+  "obj_id": 602,
+  "title": "SelfLoop",
+  "conv_type": "process",
+  "status": "active",
+  "scheme": {
+    "nodes": [
+      {
+        "id": "0022000000000000000000f1",
+        "title": "Start",
+        "obj_type": 1,
+        "condition": {"logics": [{"type": "go", "to_node_id": "0022000000000000000000f2"}]}
+      },
+      {
+        "id": "0022000000000000000000f2",
+        "title": "Recurse",
+        "obj_type": 0,
+        "condition": {"logics": [{"type": "api_rpc", "conv_id": 602}]}
+      }
+    ]
+  }
+}

--- a/plugins/corezoid/mcp-server/testdata/index_fixtures/envvars/800_uses.conv.json
+++ b/plugins/corezoid/mcp-server/testdata/index_fixtures/envvars/800_uses.conv.json
@@ -1,0 +1,36 @@
+{
+  "obj_type": 1,
+  "obj_id": 800,
+  "title": "Uses vars",
+  "conv_type": "process",
+  "status": "active",
+  "scheme": {
+    "nodes": [
+      {
+        "id": "0044000000000000000000g1",
+        "title": "Start",
+        "obj_type": 1,
+        "condition": {"logics": [{"type": "go", "to_node_id": "0044000000000000000000g2"}]}
+      },
+      {
+        "id": "0044000000000000000000g2",
+        "title": "Set params using vars",
+        "obj_type": 0,
+        "condition": {"logics": [
+          {"type": "set_param", "extra": {
+            "endpoint": "{{env_var[@API_URL]}}/v2",
+            "auth": "Bearer {{env_var[@API_TOKEN]}}"
+          }}
+        ]}
+      },
+      {
+        "id": "0044000000000000000000g3",
+        "title": "Third var deep",
+        "obj_type": 0,
+        "condition": {"logics": [
+          {"type": "api_code", "code": "return { workspace: '{{env_var[@WORKSPACE]}}' };"}
+        ]}
+      }
+    ]
+  }
+}

--- a/plugins/corezoid/mcp-server/testdata/index_fixtures/no_optional/500_simple.conv.json
+++ b/plugins/corezoid/mcp-server/testdata/index_fixtures/no_optional/500_simple.conv.json
@@ -1,0 +1,23 @@
+{
+  "obj_type": 1,
+  "obj_id": 500,
+  "title": "Simple",
+  "conv_type": "process",
+  "status": "active",
+  "scheme": {
+    "nodes": [
+      {
+        "id": "eeee000000000000000000e1",
+        "title": "Start",
+        "obj_type": 1,
+        "condition": {"logics": [{"type": "go", "to_node_id": "eeee000000000000000000e2"}]}
+      },
+      {
+        "id": "eeee000000000000000000e2",
+        "title": "End",
+        "obj_type": 2,
+        "condition": {"logics": []}
+      }
+    ]
+  }
+}

--- a/plugins/corezoid/mcp-server/testdata/index_fixtures/secrets/700_leaky.conv.json
+++ b/plugins/corezoid/mcp-server/testdata/index_fixtures/secrets/700_leaky.conv.json
@@ -1,0 +1,34 @@
+{
+  "obj_type": 1,
+  "obj_id": 700,
+  "title": "Leaky Diagram",
+  "conv_type": "process",
+  "status": "active",
+  "scheme": {
+    "nodes": [
+      {
+        "id": "0033000000000000000000g1",
+        "title": "Start",
+        "obj_type": 1,
+        "condition": {"logics": [{"type": "go", "to_node_id": "0033000000000000000000g2"}]}
+      },
+      {
+        "id": "0033000000000000000000g2",
+        "title": "Hardcoded call",
+        "obj_type": 0,
+        "condition": {"logics": [
+          {"type": "api", "url": "https://api.example.com", "method": "POST",
+           "extra_headers": {
+             "X-Api-Key": "FAKE_sk_live_actualsecrethere_zzz",
+             "X-Password": "FAKE_P@ssw0rd-ShouldBeCaught!",
+             "X-Password-Templated": "{{env_var[@REAL_PASS]}}",
+             "Authorization": "short"
+           },
+           "extra": {
+             "token": "FAKE_abcdefghij_012345_secret_value"
+           }}
+        ]}
+      }
+    ]
+  }
+}

--- a/plugins/corezoid/mcp-server/testdata/index_fixtures/secrets/999_db.instance.json
+++ b/plugins/corezoid/mcp-server/testdata/index_fixtures/secrets/999_db.instance.json
@@ -1,0 +1,12 @@
+{
+  "obj_id": 999,
+  "title": "Prod DB",
+  "instance_type": "mysql",
+  "data": {
+    "host": "db.example.com",
+    "port": 3306,
+    "user": "svc",
+    "password": "FAKE_S3cret!Value",
+    "db_name": "orders"
+  }
+}

--- a/plugins/corezoid/mcp-server/tools_registry.go
+++ b/plugins/corezoid/mcp-server/tools_registry.go
@@ -87,6 +87,55 @@ var toolRegistry = []mcpTool{
 		},
 	},
 	{
+		Name:        "describe-process",
+		Description: "Resolve a process identifier (numeric conv_id, @alias, or title substring) against .corezoid/project-map.json and return conv_id, title, path, aliases, calls_in count with high_fan_in flag, and staleness (comparing index hash with current file hash). Meant to be called at the MANDATORY \"Identify the Process\" step of corezoid-edit so blast-radius and staleness data arrive with resolution — not as separate steps the model might skip. Multiple title matches return a candidates[] list instead of guessing.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"identifier": map[string]interface{}{
+					"type":        "string",
+					"description": "Numeric conv_id, @alias (with or without @), or title substring.",
+				},
+				"process_id": map[string]interface{}{
+					"type":        "string",
+					"description": "Alias for identifier — numeric conv_id form.",
+				},
+				"process_name": map[string]interface{}{
+					"type":        "string",
+					"description": "Alias for identifier — title substring form.",
+				},
+				"project_path": map[string]interface{}{
+					"type":        "string",
+					"description": "Relative path to the project root. Omit for current directory.",
+				},
+			},
+			// At least one of identifier/process_id/process_name is required.
+			"anyOf": []interface{}{
+				map[string]interface{}{"required": []string{"identifier"}},
+				map[string]interface{}{"required": []string{"process_id"}},
+				map[string]interface{}{"required": []string{"process_name"}},
+			},
+		},
+	},
+	{
+		Name:        "build-project-index",
+		Description: "Build or refresh .corezoid/project-map.json + QUERIES.md + auto-block in CLAUDE.md for the current project. Pure local scan — no network calls, no Corezoid auth required. Detects cross-process calls, aliases, env variables used, external HTTP endpoints, DB instances, secret-shaped fields in both .instance.json and diagram nodes, and config-reference usage (which processes read which config refs and which fields). Config task runtime values are NOT stored in the index — agents read live values on demand via list-node-tasks when they need them. Pass mode=\"check\" to detect index staleness without rebuilding.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"project_path": map[string]interface{}{
+					"type":        "string",
+					"description": "Relative path to the project root. Omit for current directory.",
+				},
+				"mode": map[string]interface{}{
+					"type":        "string",
+					"description": "'check' to report staleness without rebuilding; omit or 'build' for full rebuild.",
+					"enum":        []string{"build", "check"},
+				},
+			},
+		},
+	},
+	{
 		Name:        "run-task",
 		Description: "Run a task on an already-deployed Corezoid process (without re-deploying).",
 		InputSchema: map[string]interface{}{

--- a/plugins/corezoid/skills/corezoid-create/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-create/SKILL.md
@@ -14,12 +14,19 @@ You are a specialist in creating Corezoid BPM processes using the `corezoid` MCP
 
 ## Step 1: Gather Requirements
 
-Ask the user for the following before proceeding:
+Extract a **structured** requirements record from the user's request — this record drives both the duplicate-avoidance decision (Step 1a) and the audit log written into the created process's description (Step 4 / Step 6). Do not skip the structure just because the request is short; a one-line request produces a short record, not no record.
 
-- **Process purpose** — what should it do?
-- **Input parameters** — what data does it receive?
-- **Expected output** — what should it return on success?
-- **Process type** — API connector (calls an external HTTP API) or business logic (orchestrates other Corezoid processes)?
+```
+requirements:
+  action:         <verb, e.g. "get", "list", "create", "notify">
+  object:         <target, e.g. "accounts by actor id", "invoice", "user profile">
+  inputs:         [{name, type, required}]        # empty if none
+  output:         <shape summary: what fields the reply must contain>
+  side_effects:   read-only | mutating | external-api
+  process_type:   api-connector | business-logic
+```
+
+If any of `action` / `object` / `inputs` / `output` is genuinely missing from what the user said, ask a single clarifying question **only in interactive mode**. In autonomous mode (unattended run, no human at the console), fill unknown fields with `"unspecified"` and continue — the decision tree in Step 1a handles ambiguity by falling back to "create new" for low-match cases, so unspecified fields simply degrade to conservative behaviour rather than blocking the run.
 
 For **API connector**, also require:
 - `METHOD` — HTTP method (GET, POST, PUT, etc.)
@@ -28,7 +35,72 @@ For **API connector**, also require:
 
 > ⚠️ If the target API is the **Corezoid public API** (`/api/2/json/`), stop here and use `/corezoid-api-connector` instead — it follows a different pattern (`api_secret_outer`, `ops` array, no Code Node for signing).
 
-If any required information is missing, ask the user before proceeding.
+---
+
+## Step 1a: Duplicate-avoidance decision (MANDATORY, deterministic)
+
+The purpose of this step is to prevent silent duplicates in autonomous runs. It is **not** a "do you want to continue?" prompt — the outcome is decided by a fixed table, not by asking the user. Skip only when `index_missing: true` (no index exists yet — Step 1a-A degrades to "create new").
+
+### Step 1a-A: Find candidates
+
+Search `.corezoid/project-map.json` for existing processes that could serve the requirement. The search key is `action + object` from the requirements record, **not** the domain word.
+
+- Example (good): requirement `action="get", object="accounts by actor id"` → search keywords `"accounts actor"`, `"list accounts"`, `"accounts by actor"`.
+- Example (bad): searching by the domain word `"simulator"` — this over-matches every process that mentions the domain and misses the actual duplicate whose title uses a synonym.
+
+Call MCP tool **`describe-process`** with `identifier: "<action-object phrase>"`. If it returns > 10 candidates, narrow with a second call using 2–3 more specific keywords from the object phrase.
+
+If `index_missing: true` — record `Decision: index-missing, cannot detect duplicates` for the audit log (Step 4) and go to Step 2 (create new). Do not gate creation on rebuilding the index.
+
+### Step 1a-B: Score each candidate on three axes
+
+For every candidate in the (possibly narrowed) `candidates[]`:
+
+| Axis | Meaning | How to compute |
+|---|---|---|
+| **title_match** | Does the title describe the same action+object? | Word-overlap between the candidate's `title` and `action + object`. **Full** = every requirement word appears (in any order). **Partial** = ≥ half. **Low** = less. |
+| **signature_match** | Do the candidate's inputs and outputs cover the requirement? | `pull-process` the candidate, read `params[]` for inputs and reply-node `extra`/`extra_type` for outputs. **Full** = every required input is present and every required output field is emitted. **Partial** = candidate covers most; requirement adds one optional param or one extra output field. **Breaking-diff** = requirement renames, retypes, or drops something the candidate has. **Low** = doesn't cover the required contract at all. |
+| **blast_radius** | How many callers already depend on this process? | `calls_in_count` from the `describe-process` response — it is already there, do not skip using it. |
+
+### Step 1a-C: Pick action from the decision table
+
+| title_match | signature_match | callers | Action |
+|---|---|---|---|
+| Full or Partial | **Full** | — | **REUSE as-is.** Do not create. Return the existing `conv_id`/alias to the user (see Step 4). Exit the skill. |
+| Full or Partial | **Partial, additive** (new optional param OR new reply field, no removals) | any | **EXTEND.** Hand off to `corezoid-edit` with a precise patch description ("add optional param `X`", "add field `Y` to reply"). Do not create. |
+| Full or Partial | **Breaking-diff** | **0** | **MODIFY-IN-PLACE.** Hand off to `corezoid-edit`. Safe because nothing else calls this process yet. |
+| Full or Partial | **Breaking-diff** | **> 0** | **FORK.** Create a new process (Step 2 onwards). The duplicate is justified — existing callers keep the old contract, new logic gets a new conv_id. |
+| **Low** | — | — | **CREATE new.** No candidate is close enough. |
+
+Notes on reading this table:
+- The first row is the one that catches the reported bug: a signature-full match must reuse, never create.
+- `signature_match=Full` requires **both** input coverage and output coverage; if inputs match but the reply is a different shape, that's `Partial` or `Breaking-diff`, not `Full`.
+- Never ask the user "which one should I use" in autonomous mode. If the table doesn't give a unique answer (e.g. two candidates are both `Full` matches), pick the one with the higher `calls_in_count` (the more-established one) and record the tie-break in the audit log.
+
+### Step 1a-D: Record the decision (mandatory for every path)
+
+Regardless of which branch fired, record a one-line audit entry that will be written to the target process's `description` in Step 4 (for REUSE / EXTEND / MODIFY) or Step 6 (for FORK / CREATE). Format:
+
+```
+Decision (YYYY-MM-DD): <action> — <reason with numbers>
+  requirement: <action> <object>
+  matched: conv_id=<id>, callers=<n>, signature=<full|partial|breaking|low>
+```
+
+Examples:
+```
+Decision (2026-07-02): reuse conv_id=1877387 — signature full match, callers=3
+Decision (2026-07-02): extended conv_id=1877387 with optional param "incomeType" (additive, callers=3)
+Decision (2026-07-02): forked from conv_id=1877387 — breaking rename of param "user_id"→"actorId", callers=5
+Decision (2026-07-02): created new — no signature match ≥ partial in the project (searched "accounts actor")
+Decision (2026-07-02): created new — index-missing, cannot detect duplicates
+```
+
+### Step 1a-E: If REUSE, ensure a canonical alias exists
+
+Before exiting the skill, check `describe-process`'s response: if `aliases[]` is empty, call MCP tool **`create-alias`** with a slug derived from `action + object` (kebab-case, no spaces, no special chars — e.g. `get-accounts-by-actor-id`). This makes the next autonomous run resolve the same requirement in one lookup instead of another candidate scoring pass.
+
+If `aliases[]` already contains a slug that describes the same action+object, leave it — no need to add duplicates.
 
 ---
 
@@ -92,7 +164,7 @@ Produce a valid `.conv.json` file.
   "obj_id": null,
   "parent_id": null,
   "title": "Process Name",
-  "description": "",
+  "description": "Decision (YYYY-MM-DD): created new — no signature match ≥ partial in the project (searched \"...\").\n  requirement: <action> <object>",
   "status": "active",
   "params": [],
   "ref_mask": true,
@@ -104,11 +176,13 @@ Produce a valid `.conv.json` file.
 }
 ```
 
+`description` — must contain the audit line from Step 1a-D. This is not optional: it makes the decision auditable and lets the next autonomous run see that this process was already chosen as the mapping for a given requirement (so the next agent doesn't re-derive the same conclusion or re-fork it). Prepend the audit line to any user-supplied description text; keep it as a single line so it stays readable in the Corezoid UI's process list.
+
 `params` — declare all input parameters the caller must pass. See `${CLAUDE_PLUGIN_ROOT}/docs/process/process-with-parameters.md`.
 
 ### Core rules
 
-- Node IDs must be unique 24-character hex strings: `^[0-9a-f]{24}$`. These are **temporary placeholders** for new nodes — on `push-process` Corezoid reassigns its own canonical IDs (and rewires references within the push). Run `pull-process` after pushing to get the canonical IDs before any further edits. See [Node ID Lifecycle](${CLAUDE_PLUGIN_ROOT}/docs/process/process-development-guide.md#node-id-lifecycle-server-assignment--stability-on-push).
+- Node IDs must be unique 24-character hex strings: `^[0-9a-f]{24}$`. These are **temporary placeholders** for new nodes — on `push-process` Corezoid reassigns its own canonical IDs (and rewires references within the push). Run `pull-process` after pushing to get the canonical IDs before any further edits.
 - Connect nodes only through the `go` field
 - Every node that can fail must have `err_node_id` — point it **directly at a Final Error node** (`obj_type: 2`) unless the error path needs logic (reply to caller, retry routing). Never create an Escalation node (`obj_type: 3`) that only contains a bare `go` — that is a passthrough anti-pattern flagged by `lint-process`
 - All constants (URLs, tokens, IDs) must be Corezoid variables — never hardcoded:
@@ -146,6 +220,8 @@ After a successful deploy, run a test task to verify the process behaves as expe
 Call MCP tool **`run-task`** with:
 - `process_path`: `<PROCESS_PATH>`
 - `data`: `{"param1": "value1"}`
+
+The project index refreshes automatically at the end of `push-process` — the MCP server appends a "Project index refreshed at ..." line to the deploy output. Do **not** call `build-project-index` separately; surface the appended line to the user so the new process is visibly in the index. If the line reads "Warning: project index build failed ...", tell the user but continue — deploy already succeeded.
 
 ---
 

--- a/plugins/corezoid/skills/corezoid-edit/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-edit/SKILL.md
@@ -22,8 +22,24 @@ You are a specialist in modifying Corezoid BPM processes using the `corezoid` MC
    > "Please specify the process — you can provide a file path (e.g. `123_payment.conv.json`), a process name, or a process ID."
 
    Do **not** call any MCP tools until the user provides an identifier.
-3. If the user gave a **name or ID** (not a file path), search the local working directory for the matching `.conv.json` file using the `find` or `grep` Bash tools (the project is already pulled locally).
-4. Once `PROCESS_PATH` is known and the file exists locally, open and analyze it before making any changes.
+3. If the user gave a **name, alias, or ID** (not a file path), call MCP tool **`describe-process`** with `identifier: "<user-value>"`. The tool resolves it against `.corezoid/project-map.json` and returns a JSON payload with:
+
+   - `path` — the file to open
+   - `calls_in_count` and `high_fan_in` (bool, true if > 5)
+   - `stale` (bool, true if the on-disk file's hash differs from the indexed hash)
+   - `candidates[]` if the identifier matches multiple processes
+
+   If `candidates[]` is non-empty, show the list to the user and ask which one — do not guess. If `index_missing: true`, fall back to `find`/`grep` in the working directory and note that blast-radius/staleness data is unavailable until the index is built (suggest running the `corezoid-index` skill).
+
+4. **Blast-radius / staleness — read from the tool's response, not from memory:**
+   - If `high_fan_in: true`, explicitly tell the user before making any changes: "This process is called by `<calls_in_count>` other processes in the project — edits will affect all of them." Then continue.
+   - If `stale: true`, tell the user: "The project index is out of date for this file — it may have been edited outside the plugin. I'll continue, but consider running the `corezoid-index` skill afterwards to refresh." Then continue.
+
+   These two flags come from `describe-process`, not from a separate MANDATORY check step you have to remember. If they aren't present in the response, they are simply false — no action needed.
+
+5. If the user gave a file path directly (e.g. `123_payment.conv.json`), you may skip `describe-process` — the path is enough for the edit itself. But if `.corezoid/project-map.json` exists, calling `describe-process` with `identifier: "123"` (from the filename prefix) is still recommended so you see the blast-radius / staleness data.
+
+6. Once `PROCESS_PATH` is known and the file exists locally, open and analyze it before making any changes.
 
 ---
 
@@ -41,11 +57,44 @@ Open and analyze `PROCESS_PATH` to understand the current structure and logic. P
 
 Apply changes to `PROCESS_PATH`.
 
+### Contract-compatibility rules (MANDATORY when `calls_in_count > 0`)
+
+The `describe-process` response from the identify step already carries `calls_in_count`. If it is **> 0**, existing processes in this project depend on the current input/output contract of this one, and only additive changes are allowed here:
+
+| Change | Additive? |
+|---|---|
+| Add a new **optional** param to `params[]` (not required, sensible default) | ✅ |
+| Add a new field to a reply-node's `extra`/`extra_type` (don't remove existing ones) | ✅ |
+| Add a new logic branch that doesn't remove any existing route | ✅ |
+| Change the internal implementation while preserving the input/output contract | ✅ |
+| Rename a param, remove a param, change a param's type | ❌ breaking |
+| Change a param from optional to required | ❌ breaking |
+| Remove or rename a field in a reply-node's `extra` | ❌ breaking |
+| Change reply-node `throw_exception` behaviour (from silent to throwing, or vice versa) | ❌ breaking |
+| Change the error-path node so a previously-successful branch now goes to Error / End-Error | ❌ breaking |
+
+If the requested change is **breaking** and `calls_in_count > 0`, do **not** apply it here. Instead:
+
+1. Route the change through `corezoid-create` — its Step 1a decision tree will fork a new process (last row of that table: breaking-diff + callers > 0 → FORK), leaving this one untouched for the existing callers.
+2. Alternatively, if the user explicitly wants the breaking change to land in place, log the request and ask for confirmation **in interactive mode** with the explicit list of affected `calls_in[]` conv_ids. In autonomous mode, refuse: emit a clear error line to the log — `breaking change refused: conv_id=<id> has <n> callers, route through corezoid-create for a fork instead` — and exit without touching the file. Silent breakage of N callers is worse than not making the edit.
+
+If `calls_in_count == 0`, breaking changes are safe — proceed to Core rules as usual. Still record the intent in the audit line (see below): a caller-less process today may not be caller-less tomorrow, and the audit trail is what tells the next agent whether a past change was safe by luck or by design.
+
+### Audit line in `description`
+
+Regardless of the change (additive or in-place breaking on a caller-less process), prepend a one-line audit entry to `root.description` using the same format as `corezoid-create` Step 1a-D. Example:
+
+```
+Decision (2026-07-02): extended conv_id=1877387 with optional param "incomeType" (additive, callers=3)
+```
+
+Keep the existing description content after the new audit line (older audit lines are history — do not delete them). This makes the process's history readable in-place and gives the next autonomous run a decision breadcrumb without needing to reconstruct anything from git.
+
 ### Core rules
 
 - Connect nodes only through the `go` field
 - Every node that can fail must have `err_node_id` — point it **directly at a Final Error node** (`obj_type: 2`) unless the error path needs logic (reply to caller, retry routing). Never create an Escalation node (`obj_type: 3`) that only contains a bare `go` — that is a passthrough anti-pattern flagged by `lint-process`
-- Node IDs must be unique 24-character hex strings: `^[0-9a-f]{24}$`. **Always `pull-process` before editing** and reference only canonical, server-assigned IDs — IDs you invented in a previous push were reassigned by the server and no longer exist. New nodes added now get placeholder IDs that the server will likewise reassign on push. Existing nodes' IDs are preserved. See [Node ID Lifecycle](${CLAUDE_PLUGIN_ROOT}/docs/process/process-development-guide.md#node-id-lifecycle-server-assignment--stability-on-push).
+- Node IDs must be unique 24-character hex strings: `^[0-9a-f]{24}$`. **Always `pull-process` before editing** and reference only canonical, server-assigned IDs — IDs you invented in a previous push were reassigned by the server and no longer exist. New nodes added now get placeholder IDs that the server will likewise reassign on push. Existing nodes' IDs are preserved.
 - Use descriptive node `title` values (e.g., "Call Payment Process", not "RPC")
 - Place new nodes below existing ones, incrementing `y` by 200–250px
 - Position error nodes to the right of their parent (`x + 300`)
@@ -93,6 +142,10 @@ If deployment fails, fix the reported errors and re-run `push-process` until it 
 After a successful deploy, notify the user:
 
 > "Changes have been deployed. Please **refresh the page** in Corezoid to see the updated process."
+
+The project index refreshes automatically as part of `push-process` — the MCP server's `handlePushProcess` appends a "Project index refreshed at ... — processes: N, edges: M" line to the deploy output. Do **not** call `build-project-index` separately after a push; that would be a redundant second rebuild. Just surface the appended line to the user so they see the fresh counts.
+
+If the appended line reads "Warning: project index build failed ...", tell the user but do not treat it as a rollback — the deploy itself succeeded, and the user can retry the rebuild via the `corezoid-index` skill.
 
 ---
 

--- a/plugins/corezoid/skills/corezoid-index/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-index/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: corezoid-index
+description: >
+  Build or refresh the persistent project index (`.corezoid/project-map.json`,
+  `QUERIES.md`, CLAUDE.md auto-block) for a pulled Corezoid project. Activate
+  when the user says "build project index", "regenerate index", "index
+  project", "update project map", "corezoid index", or asks a question that
+  needs cross-process knowledge — "does a process for X already exist", "who
+  calls process Y", "where is variable @Z used", "which processes hit this
+  API", "any cycles in the project" — and no index has been built yet. Also
+  activate when the user reports that `.corezoid/project-map.json` is out of
+  date or missing.
+---
+
+# Build / Refresh the Corezoid Project Index
+
+You are a specialist in building the persistent, on-disk index that lets
+Claude answer cross-process questions about a Corezoid project without
+grep-walking every `.conv.json` file each session.
+
+## What the index is
+
+Three files, all written into the **currently pulled project's** directory
+(never into the plugin itself):
+
+| File | Purpose | Regenerable |
+|---|---|---|
+| `.corezoid/project-map.json` | Structured graph: processes, edges (`api_rpc`/`api_copy`/`api_get_task`), aliases, env-var usage, external HTTP endpoints, DB instances, security hotspots, graph statistics. | Yes (rebuild anytime) |
+| `.corezoid/QUERIES.md` | `jq` command recipes for the 9 common questions an agent asks about a project. | Yes |
+| `CLAUDE.md` (auto-block) | Short summary between `<!-- corezoid-index:start -->` markers, loaded automatically into every Claude Code session in this project. | Yes (block only; content outside markers preserved) |
+| `.corezoid/index-config.json` | Per-project heuristic keyword lists (entry_point / suspicious_name) **and** the `config_references` allow-list (which config ref names to track in the diagram scan). Created with defaults on first run, **never overwritten** — hand-edit to override defaults for non-English project naming or to add/remove config ref names. | Created once, not on rebuild |
+
+## When this skill runs vs when automation runs
+
+- `corezoid-init` invokes `build-project-index` automatically at the end of a
+  fresh `pull-folder`.
+- `corezoid-edit` and `corezoid-create` rebuild the index automatically after
+  a successful `push-process`.
+- **This skill** is for everything else: a project pulled before automation
+  landed, a project edited outside the plugin, a user who explicitly asks to
+  refresh the map, or a question that needs the index and no index yet exists.
+
+## Step 1 — Verify environment
+
+Read `.env` in the current working directory (or up to the project root). If
+`COREZOID_STAGE_ID` is missing or empty, do **not** try to build the index —
+invoke the `corezoid-init` skill first. Same pattern as `corezoid-project-review`
+Step 0.1. The index needs a real pulled project on disk; without one, there
+is nothing meaningful to index.
+
+## Step 2 — Build (or refresh) the index
+
+Call MCP tool **`build-project-index`** with no arguments (or with
+`project_path` if the pulled project lives in a subdirectory). The tool:
+
+- Walks the project tree
+- Parses every `.conv.json`, `_ALIASES_.json`, `_ENV_VARS_.json`, and
+  `*.instance.json` if present (missing optional files are not an error)
+- Writes `.corezoid/project-map.json` and `.corezoid/QUERIES.md`
+- Updates the auto-generated block in `CLAUDE.md`
+- Creates `.corezoid/index-config.json` with defaults on first run only
+
+**Never** run `build-project-index` inside the plugin's own repository — it
+will find no `.conv.json` files and produce an empty, meaningless index.
+Always run it in the directory of a pulled Corezoid project.
+
+## Step 3 — Report a short summary
+
+The tool returns a concise multi-line summary. Show it to the user verbatim
+if the counts are interesting; otherwise a one-liner is enough. Aim for **≤ 10
+lines** of your own output. Do not restate the full contents of
+`project-map.json` — that defeats the whole point of having a queryable file.
+
+If any of these appear in the summary, call them out explicitly:
+
+- **Config references (> 0)** — mention how many configured refs are actively used and which local state-stores back them (via `local_conv_id`). The index stores structure (who reads which refs, which `.ref[X]` fields), **not values**. If you need the actual runtime config values before working with a process, call `list-node-tasks` on the state-store process identified by `local_conv_id` — see "Reading live config values" below.
+- **Security hotspots (> 0)** — mention that these list field NAMES and
+  locations only; no values ever leak. Suggest reviewing `.security_hotspots`.
+- **Cycles (> 0)** — flag as "risk to edit"; direct the user to
+  `.graph_stats.cycles`.
+- **Orphaned candidates (> 0)** — phrase as "no internal caller in this
+  project, verify before deletion"; never as "dead code".
+- **First-time CLAUDE.md creation** — the tool prints a one-line notice; do
+  not suppress it. This is intentional: the plugin is mutating a user file
+  for the first time in this project, and the user must know it happened.
+
+## Step 4 — Point at `QUERIES.md`
+
+Close by mentioning `.corezoid/QUERIES.md`. It documents the 9 most common
+questions (who calls X, what does X call, resolve alias, find env var usage,
+fuzzy title search, process card, risk overview, external APIs + secrets,
+manual rebuild) with the exact `jq` command each. Direct the user there for
+follow-up questions instead of re-loading the whole `project-map.json` into
+context.
+
+## Reading live config values
+
+The index records **structure** — which processes read which config, via which fields — but never stores the actual runtime values. Values are intentionally excluded: they change frequently, may contain secrets, and an index built days ago would serve stale data.
+
+To read current config values before working on a project:
+
+1. Look up the config's `local_conv_id` in `.config_references`:
+   ```
+   jq '.config_references["config"].local_conv_id' .corezoid/project-map.json
+   ```
+2. Find the api_callback node of that state-diagram:
+   ```
+   jq '.scheme.nodes[] | select(.condition.logics[]?.type == "api_callback") | .id' \
+     <path_to_state_diagram.conv.json>
+   ```
+3. Call `list-node-tasks(process_id=<local_conv_id>, node_id=<callback_node_id>)` to see the current task payload.
+
+This keeps live secrets out of any file that could be committed or cached.
+
+## Checking freshness without a full rebuild
+
+If the user just wants to know whether the existing index is up to date (for
+example after `git pull` on a shared project), call the tool with
+`mode="check"`. It runs a fast `size`/`mtime`/`hash` comparison — no rebuild
+— and returns the list of files that diverged, if any. Use this before
+recommending a full rebuild: a report of "up-to-date" saves the user a wait.
+
+## Key facts about the schema
+
+- `edges[]` is the single source of truth for the graph; `calls_out`,
+  `calls_in`, and `state_stores[].written_by` are derived from it.
+- Cross-process edges are only `api_rpc`, `api_copy`, `api_get_task`.
+  `api_callback` marks a receiver node but is not an edge.
+- Env var values are **never** stored. `env_vars[name].used_by` lists which
+  processes reference `{{env_var[@name]}}`; the value stays in Corezoid.
+- Secret detection reports `security_hotspots[]` with field names and
+  locations only, never values — the pattern matches both `.instance.json`
+  fields and hardcoded-looking values in diagram `api` nodes' `url`,
+  `extra`, and `extra_headers`.
+- State processes (`conv_type == "state"`) are excluded from
+  orphaned/entry_points classification — a state store with no incoming
+  writes is a legitimate read-only lookup, not a dead-code signal.
+
+## Reference: what the tool detects
+
+| Signal | Where it comes from |
+|---|---|
+| Process inventory + hashes | Every `<id>_<name>.conv.json` |
+| `api_rpc` / `api_copy` / `api_get_task` edges | `scheme.nodes[].condition.logics[]` |
+| External APIs | `url` field of `api`-type logics |
+| DB instance calls | `instance_id`/`instance_name` of `db_call` logics |
+| Env var usage | `{{env_var[@NAME]}}` regex over all string values in logics |
+| Alias resolution | `_ALIASES_.json` at project root |
+| Env var declarations | `_ENV_VARS_.json` at project root (values NOT read) |
+| Instance secrets | `.instance.json` `data.*` field names matching `pass\|password\|secret\|token\|apikey\|api_key\|private_key` |
+| Diagram-hardcoded secrets | Same regex against `extra`/`extra_headers` field names in `api` logics, with a heuristic filter on value shape to reduce noise |
+| Folder breadcrumbs | Walk up parents, read `<id>_<name>.folder.json` markers |
+| Config references (`config_references`) | Purely local scan for `{{conv[@ref]...}}` patterns matching the allow-list in `.corezoid/index-config.json` → `config_references.tasks`. For each configured ref that IS referenced by some diagram: records `used_by` (caller conv_ids), `read_fields` (the `.ref[X]` field names extracted from the diagram), and `local_conv_id` if the ref resolves to a local state-store via `_ALIASES_.json`. When the ref does resolve to a local state store, the reader info is also mirrored into the corresponding `state_stores[cid]` entry (`read_by`/`read_fields`) so writers and readers live side by side. Provider-agnostic: the actual config values may be stored anywhere (external state store, Simulator, another Corezoid stage) — the index only shows the local usage picture. |

--- a/plugins/corezoid/skills/corezoid-init/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-init/SKILL.md
@@ -84,6 +84,28 @@ Do not proceed until the tool returns successfully.
 
 ---
 
+## Step 3 — The project index is auto-built (no extra action)
+
+`pull-folder` itself rebuilds the project index at the end of a successful
+pull — you do **not** need to call `build-project-index` separately. The tool
+appends a short "Project index refreshed at ... — processes: N, edges: M"
+line to its output. Surface that line to the user verbatim so they see the
+new counts (and, on first creation, the notice about the CLAUDE.md
+auto-block).
+
+This is a code-level guarantee inside the MCP server, not a skill-prompt
+step to remember — see `handlePullFolder` in the plugin's `mcp-server/`. The
+same code-level auto-rebuild also runs at the end of `push-process`, so
+`corezoid-edit` and `corezoid-create` do not need to call
+`build-project-index` after deploy either.
+
+If the auto-rebuild line reads "Warning: project index build failed ..." (a
+locked-down filesystem, a partial pull, or similar), tell the user, but do
+**not** block init — the pull itself succeeded and the project is usable
+without an index. The user can retry by invoking the `corezoid-index` skill.
+
+---
+
 ## Exception: user provides values directly
 
 If the user explicitly pastes values, write them to `.env` and skip the corresponding prompts:

--- a/plugins/corezoid/skills/corezoid-project-review/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-project-review/SKILL.md
@@ -28,8 +28,12 @@ Read `.env` from the current working directory and check for `COREZOID_STAGE_ID`
 
 ### Step 0.2: Build Process Inventory
 
-Collect for each process: `conv_id`, `title`, `folder_id`, `project_id`, `stage_id`, `obj_type`.
-Store as `process_inventory[]`. Skip objects where `obj_type != conveyor` unless explicitly requested.
+**Prefer the index over full re-pull.** If `.corezoid/project-map.json` exists, use it as the process inventory — one file read gives you every `conv_id`, `title`, folder breadcrumb, node count, and status without any `pull-process` calls. This is the reason the index exists.
+
+- Call MCP tool **`build-project-index`** with `mode: "check"` first. If the report says "up-to-date", the index is safe to use. If any files diverged (`changed`/`added`/`removed`), call `build-project-index` with no arguments to refresh, then continue. If either tool errors, or the index doesn't exist, fall back to the legacy path: `pull-process` per known process to reconstruct the inventory.
+- Read `.corezoid/project-map.json`. `processes{}` is `process_inventory[]` in map form (conv_id keyed). Skip entries where `conv_type == "state"` unless explicitly requested — state stores are audited under Phase 2 alias/cross-process analysis instead of per-process audit.
+
+Store as `process_inventory[]`. Only fall back to `pull-process`-based inventory building when the index is unavailable or the fallback was requested explicitly.
 
 ### Step 0.3: Announce Scope
 
@@ -76,14 +80,26 @@ Requires all `process_reports[]` from Phase 1.
 
 ### Step 2.1: Dependency Graph
 
-Build a directed graph — nodes: all processes; edges: every `api_rpc` / `api_copy` call between them.
+**Prefer the index over reconstruction.** If `.corezoid/project-map.json` is available and fresh (from Step 0.2), take the dependency graph directly from it — no pass over `.conv.json` files is needed:
+
+- Edges → `.edges` (each element has `from`, `to`, `type`, optional `mode` for `api_copy` and `via_alias`; type is one of `api_rpc`, `api_copy`, `api_get_task`)
+- Fan-in / fan-out → `.graph_stats.fan_in` / `.graph_stats.fan_out` per conv_id
+- High fan-in / fan-out — `.graph_stats.high_fan_in` / `.graph_stats.high_fan_out` (thresholds > 5 / > 7)
+- Cycles → `.graph_stats.cycles` (each is a normalised list of conv_ids)
+- Orphaned candidates → `.graph_stats.orphaned` (each with `suspicious_name: bool`)
+- Entry points → `.graph_stats.entry_points`
+- External `conv_id` references → `.unresolved_targets` (conv_ids referenced but not in this project inventory)
+
+**Do not interpret an empty `state_stores[cid].written_by` as `orphaned`.** State stores (`conv_type == "state"`) are excluded from the orphaned heuristic by construction — a state store with no writers is a legitimate read-only lookup, not dead code. This is a deliberate design choice in the index; treat `state_stores` and `orphaned` as unrelated signals.
 
 Flag:
-- ⚠️ **Circular dependencies** — A calls B which calls A
-- ⚠️ **Orphaned processes** — never called and no direct external input
-- ⚠️ **High fan-in** — called by > 5 other processes (single point of failure)
-- ⚠️ **High fan-out** — calls > 7 other processes (coupling risk)
-- ℹ️ **External calls** — `conv_id` values pointing outside the project inventory
+- ⚠️ **Circular dependencies** — from `.graph_stats.cycles`
+- ⚠️ **Orphaned candidates** — from `.graph_stats.orphaned`; phrase as "no internal caller in this project, verify before deletion", never as "dead code"
+- ⚠️ **High fan-in** — from `.graph_stats.high_fan_in`; single point of failure
+- ⚠️ **High fan-out** — from `.graph_stats.high_fan_out`; coupling risk
+- ℹ️ **External calls** — from `.unresolved_targets`
+
+Fallback: if the index is unavailable (Step 0.2 already surfaced that), reconstruct the graph the legacy way — one `pull-process` per inventory entry, walk `api_rpc`/`api_copy`/`api_get_task` logics manually. Note that this is much slower than the indexed path; suggest running the `corezoid-index` skill afterwards so the next review is fast.
 
 ### Step 2.2: Duplicate Logic Across Processes
 
@@ -107,15 +123,25 @@ False-positive guard (same as per-process review):
 
 ### Step 2.4: Alias Consistency
 
+Use `.by_alias` from `.corezoid/project-map.json` as the resolved alias↔conv_id map instead of walking `_ALIASES_.json` and diagram references manually. Then cross-reference against `edges[]` and per-process `aliases[]`.
+
 Flag:
-- Same alias used with both `create` and `modify` in different processes → race condition risk
-- Alias defined in one process but used with numeric `conv_id` in another → inconsistency
-- Aliases referenced in processes but absent from project inventory → undocumented external dependency
+- Same alias used with both `create` and `modify` in different processes → race condition risk (scan `edges` for `api_copy` with the same `via_alias` and differing `mode`)
+- Alias defined in one process but used with numeric `conv_id` in another → inconsistency (compare `.by_alias` targets with numeric `conv_id` references in `edges`)
+- Aliases referenced in processes but absent from `.by_alias` → falls out naturally as entries in `.unresolved_targets`
 
 To fix alias issues found here (create missing aliases, rename, repoint, delete conflicts),
 use the `/corezoid-alias-manager` skill.
 
-### Step 2.5: Naming Consistency
+### Step 2.5: Environment variable usage
+
+Read `.env_vars` from `.corezoid/project-map.json` — a map of `var_name -> { description, used_by }`. Cross-check against `_ENV_VARS_.json` (if present).
+
+Flag:
+- Variables in `_ENV_VARS_.json` with empty `used_by` → potentially dead variable declaration (`env_var_unused`)
+- References in `used_by` for variables not declared in `_ENV_VARS_.json` → undeclared variable used, often a typo or a variable defined at workspace level but not tracked in this project's export (`env_var_undeclared`)
+
+### Step 2.6: Naming Consistency
 
 Flag:
 - Same vague name used widely (e.g. 10+ nodes named `"error"` across project) → recommend naming standard
@@ -145,6 +171,8 @@ Run final normalization after merging: remove duplicates, remove dynamic-express
 | `cross_process` | `shared_hardcode_value` | medium |
 | `cross_process` | `duplicate_logic` | low |
 | `cross_process` | `alias_conflict` | warning |
+| `cross_process` | `env_var_unused` | low |
+| `cross_process` | `env_var_undeclared` | warning |
 | `cross_process` | `naming_convention` | low |
 
 Cross-process finding example:
@@ -215,7 +243,8 @@ Cross-process finding example:
       "dependency": 0,
       "cycle": 0,
       "repeated_logic": 0,
-      "cross_process": 0
+      "cross_process": 0,
+      "env_var": 0
     }
   },
   "dependency_graph": {
@@ -251,10 +280,15 @@ Cross-process finding example:
 
 | Step | MCP call |
 |------|----------|
-| 0.1 List processes | `list folder filter:"conveyor" obj_id:<COREZOID_STAGE_ID>` |
-| 1 Pull process | `pull-process process_id:<conv_id>` |
+| 0.2 Freshness check (preferred first call) | `build-project-index mode:check` |
+| 0.2 Full rebuild if stale | `build-project-index` (no args) |
+| 0.2 Read process inventory (indexed path) | Read `.corezoid/project-map.json` → `.processes{}` |
+| 0.1 List processes (legacy fallback) | `list folder filter:"conveyor" obj_id:<COREZOID_STAGE_ID>` |
+| 1 Pull process (legacy fallback) | `pull-process process_id:<conv_id>` |
 | 1 Lint process | `lint-process process_path:<path>` |
-| 2.1 List & resolve aliases | `/corezoid-alias-manager` → "Workflow: List aliases" |
+| 2.1 Dependency graph (indexed path) | Read `.corezoid/project-map.json` → `.edges` / `.graph_stats` / `.unresolved_targets` |
+| 2.4 Alias consistency (indexed path) | Read `.corezoid/project-map.json` → `.by_alias`; then `/corezoid-alias-manager` for fixes |
+| 2.5 Env var usage (indexed path) | Read `.corezoid/project-map.json` → `.env_vars`; cross-check against `_ENV_VARS_.json` |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a persistent on-disk project index to the plugin so agents (and their future sessions) don't have to re-scan every `.conv.json` file from scratch each time they need to answer questions like "who calls process X", "where is variable @Y used", or "are there cycles in the project".

- **`build-project-index` MCP tool** — walks the pulled project, writes `.corezoid/project-map.json` with:
  - Cross-process call graph (`api_rpc` / `api_copy` / `api_get_task`) with alias resolution
  - Env-var usage (`{{env_var[@X]}}`) per process
  - Config-reference usage (`{{conv[@X].ref[Y]}}`) with optional Corezoid API fetch of state-store task contents (field-level secret masking via `index-config.json`)
  - External API inventory, security hotspots (hardcoded secrets in diagrams and `.instance.json`)
  - Graph stats: cycles (DFS), high fan-in/out, orphaned candidates, entry points
  - State-store reader/writer map
  - Auto-triggered after every `pull-folder` (full fetch) and `push-process` (fast path, preserves task contents)
  - `mode="check"` for staleness detection without rebuild

- **`describe-process` MCP tool** — resolves conv_id / alias / title fragment against the index in one call, returns path + `calls_in_count` + `high_fan_in` flag + per-file hash staleness. Consumed at the mandatory "Identify the Process" step of `corezoid-edit` to deliver blast-radius and staleness as *data* rather than a forgettable MANDATORY prompt.

- **`corezoid-index` skill** — manual entry point.

- **`corezoid-create` skill** — deterministic duplicate-avoidance decision tree (reuse / extend / fork / create-new) driven by title match, signature match, and `calls_in_count`. Works in autonomous mode.

- **`corezoid-edit` skill** — backward-compatibility rules when `calls_in_count > 0`; breaking changes (rename/remove param, type change, flip `throw_exception`) refused autonomously.

- **`corezoid-init` / `corezoid-project-review`** — use index for inventory and dependency-graph phases with per-hash freshness validation and legacy fallback.

## Technical notes

- All new code is in `index_*.go` files + `mcp_handlers_{index,describe}.go`; the only changes to existing handlers (`handlePullFolder`, `handlePushProcess`) are additive: they append the index-rebuild output to the existing success message and can never make `isError=true`.
- Atomic `WriteProjectMap` (temp+rename) prevents corrupt files on crash mid-write.
- `_ALIASES_.json` parser handles the real Corezoid export format (JSON array with `short_name`/`obj_to_id`) and the legacy flat-map shape.
- `breadcrumbCache` eliminates up to 1000 repeated `os.ReadDir` calls for 200-process projects.
- Secret masking tested end-to-end: values never appear in `project-map.json` even for arrays-of-primitives under secret-named keys.

## Test plan

- [ ] `cd plugins/corezoid/mcp-server && go test ./... -race` passes (only pre-existing `TestSkillPathsExist` failure in `corezoid-api-connector` unrelated to this PR)
- [ ] `go test -run TestIndex_SLA_200Processes` ≤ 500 ms on developer hardware
- [ ] `pull-folder` on a real project produces `.corezoid/project-map.json` with populated `config_references` (requires `~/.corezoid/simulator-credentials.json` — optional, skips gracefully if absent)
- [ ] `describe-process identifier=@some-alias` returns JSON with `found:true`, `calls_in_count`, `stale`
- [ ] `build-project-index mode=check` on unchanged project returns "Index freshness: up-to-date"
- [ ] `push-process` after editing a process rebuilds index automatically (verify `generated_at` timestamp updates)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)