### PR TITLE
fix(pull-process): clarify deployed-only version; fix draft-vs-committed warning

### DIFF
--- a/plugins/corezoid/mcp-server/mcp_handlers_process.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_process.go
@@ -90,7 +90,13 @@ func handlePullProcess(ctx context.Context, args map[string]interface{}) (string
 	if err := os.WriteFile(filePath, data, 0644); err != nil {
 		return fmt.Sprintf("Error writing file: %v", err), true
 	}
-	return fmt.Sprintf("Process %d saved to %s", processID, filePath), false
+	return fmt.Sprintf(
+		"Process %d saved to %s\n\n"+
+			"Note: this is the last *deployed* (committed) version. "+
+			"Auto-saved drafts from the Corezoid web editor are not included — "+
+			"only the state after the last Deploy button click in the UI is exported.",
+		processID, filePath,
+	), false
 }
 
 // handlePullFolder recursively downloads a folder (stage) and all its

--- a/plugins/corezoid/mcp-server/tools_registry.go
+++ b/plugins/corezoid/mcp-server/tools_registry.go
@@ -6,7 +6,7 @@ package main
 var toolRegistry = []mcpTool{
 	{
 		Name:        "pull-process",
-		Description: "Export a single Corezoid process definitions to a JSON file. The file is saved to the folder path matching its location in Corezoid (resolved from parent_id).",
+		Description: "Export the last committed (deployed) version of a single Corezoid process to a JSON file. Auto-saved drafts from the Corezoid web editor are not captured — only the state after the last Deploy button click is exported. The file is saved to the folder path matching its location in Corezoid (resolved from parent_id).",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{

--- a/plugins/corezoid/mcp-server/tools_registry_test.go
+++ b/plugins/corezoid/mcp-server/tools_registry_test.go
@@ -76,7 +76,13 @@ func TestSkillPathsExist(t *testing.T) {
 		matches := re.FindAllSubmatch(data, -1)
 		for _, m := range matches {
 			relPath := string(m[1])
-			absPath := filepath.Join(pluginRoot, relPath)
+			// Strip Markdown anchor fragments (#section-name) before checking
+			// file existence — the file itself is what must exist, not the anchor.
+			filePath := relPath
+			if idx := strings.IndexByte(filePath, '#'); idx >= 0 {
+				filePath = filePath[:idx]
+			}
+			absPath := filepath.Join(pluginRoot, filePath)
 			if _, err := os.Stat(absPath); os.IsNotExist(err) {
 				t.Errorf("%s/SKILL.md: references non-existent path ${CLAUDE_PLUGIN_ROOT}/%s (resolved: %s)",
 					entry.Name(), relPath, absPath)

--- a/plugins/corezoid/skills/corezoid-api-connector/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-api-connector/SKILL.md
@@ -14,7 +14,7 @@ description: >
 You are a specialist in building Corezoid processes that call the **Corezoid public API**.
 
 > **Always read the reference doc before generating any JSON:**
-> `${CLAUDE_PLUGIN_ROOT}/docs/process/corezoid-api-integration.md`
+> `${CLAUDE_PLUGIN_ROOT}/docs/nodes/api-call-node.md`
 
 ---
 
@@ -132,6 +132,6 @@ lint-process → fix errors → push-process → run-task (smoke test)
 
 | Resource         | Path                                                             |
 | ---------------- | ---------------------------------------------------------------- |
-| Full pattern doc | `${CLAUDE_PLUGIN_ROOT}/docs/process/corezoid-api-integration.md` |
+| Full pattern doc | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/api-call-node.md` |
 | Sample process   | `${CLAUDE_PLUGIN_ROOT}/samples/corezoid-api-node-list.conv.json` |
 | API reference    | https://openapi.corezoid.com                                     |

--- a/plugins/corezoid/skills/corezoid-edit/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-edit/SKILL.md
@@ -84,18 +84,25 @@ For complete JSON structures see `${CLAUDE_PLUGIN_ROOT}/docs/node-structures.md`
 
 ## Pre-Deploy Sync Check (MANDATORY)
 
+> ⚠️ **Version note**: `pull-process` always exports the **last deployed (committed) version** of a process. Auto-saved drafts from the Corezoid web editor are not captured — only changes that were explicitly deployed via the **Deploy** button in the UI are visible to `pull-process`.
+
 **Before calling `push-process`**, always ask the user:
 
 > "Вносили ли вы или кто-то ещё изменения в этот процесс через веб-интерфейс Corezoid после последнего pull? (да/нет)"
 
 - **If "no"** — proceed directly to Step 3 (Deploy).
-- **If "yes"**:
-  1. Note all edits you applied to `PROCESS_PATH` in the current session — you will need to re-apply them after pulling.
-  2. Extract the process ID from `PROCESS_PATH` (the numeric prefix, e.g. `115` from `115_payment.conv.json`).
-  3. Call `pull-process(process_id=<ID>)` to overwrite the local file with the latest server version (which includes the user's UI changes).
-  4. Re-apply your edits from the current session on top of the freshly-pulled file.
-  5. Confirm with the user: "Я загрузил актуальную версию с сервера — ваши правки из UI теперь в файле. Мои изменения переприменены. Готов к деплою — продолжаем?" Wait for confirmation before proceeding.
-  6. Proceed to Step 3 (Deploy) after the user confirms.
+- **If "yes"** — ask a follow-up before acting:
+  > "Были ли эти изменения задеплоены через кнопку **Deploy** в веб-интерфейсе, или они сохранены только как черновик (автосохранение)?"
+  - **If deployed (committed via Deploy button)**:
+    1. Note all edits you applied to `PROCESS_PATH` in the current session — you will need to re-apply them after pulling.
+    2. Extract the process ID from `PROCESS_PATH` (the numeric prefix, e.g. `115` from `115_payment.conv.json`).
+    3. Call `pull-process(process_id=<ID>)` to overwrite the local file with the latest deployed version.
+    4. Re-apply your edits from the current session on top of the freshly-pulled file.
+    5. Confirm with the user: "Я загрузил актуальную задеплоенную версию с сервера — ваши правки из UI теперь в файле. Мои изменения переприменены. Готов к деплою — продолжаем?" Wait for confirmation before proceeding.
+    6. Proceed to Step 3 (Deploy) after the user confirms.
+  - **If undeployed draft (auto-saved only, not yet deployed)**:
+    ⚠️ Warn the user: "Ваши правки в редакторе Corezoid сохранены как черновик, но ещё не задеплоены. `pull-process` не захватывает черновики — он видит только задеплоенную версию. Если мы задеплоим сейчас через Claude Code, ваши черновики из UI будут перезаписаны. Рекомендую сначала нажать **Deploy** в веб-интерфейсе Corezoid, затем выполнить pull снова. Как хотите поступить?"
+    Wait for the user's decision and follow their instruction.
 
 ---
 

--- a/plugins/corezoid/skills/corezoid-edit/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-edit/SKILL.md
@@ -82,6 +82,23 @@ For complete JSON structures see `${CLAUDE_PLUGIN_ROOT}/docs/node-structures.md`
 
 ---
 
+## Pre-Deploy Sync Check (MANDATORY)
+
+**Before calling `push-process`**, always ask the user:
+
+> "Вносили ли вы или кто-то ещё изменения в этот процесс через веб-интерфейс Corezoid после последнего pull? (да/нет)"
+
+- **If "no"** — proceed directly to Step 3 (Deploy).
+- **If "yes"**:
+  1. Note all edits you applied to `PROCESS_PATH` in the current session — you will need to re-apply them after pulling.
+  2. Extract the process ID from `PROCESS_PATH` (the numeric prefix, e.g. `115` from `115_payment.conv.json`).
+  3. Call `pull-process(process_id=<ID>)` to overwrite the local file with the latest server version (which includes the user's UI changes).
+  4. Re-apply your edits from the current session on top of the freshly-pulled file.
+  5. Confirm with the user: "Я загрузил актуальную версию с сервера — ваши правки из UI теперь в файле. Мои изменения переприменены. Готов к деплою — продолжаем?" Wait for confirmation before proceeding.
+  6. Proceed to Step 3 (Deploy) after the user confirms.
+
+---
+
 ## Step 3: Deploy the Changes
 
 **MANDATORY: Always run this step whenever any changes were made to the process file — even if there are open questions or the work is not fully complete. Without deploying, all changes are lost.**


### PR DESCRIPTION
## Summary

- `tools_registry.go` — updated `pull-process` description to explicitly state it exports the **last committed (deployed)** version; auto-saved web-editor drafts are not captured
- `mcp_handlers_process.go` — `handlePullProcess` success message now appends a note reminding Claude (and the user) that only the deployed state was received
- `corezoid-edit` SKILL.md — Pre-Deploy Sync Check now:
  - Opens with a ⚠️ version-note callout explaining `pull-process` only sees deployed versions
  - Splits the "yes, I edited in UI" branch into two sub-cases:
    - **Deployed via Deploy button** → pull + re-apply (existing flow, corrected label)
    - **Undeployed draft (auto-save only)** → warn user that pushing now will overwrite their draft; recommend deploying from the Corezoid UI first

Fixes the misleading wording from the previous commit ("which includes the user's UI changes") — that claim was false for undeployed drafts.

## Context

tool: pull-process | version: 2.3.5 | install: c2d96fc7-994a-483e-872d-22279b6525e3

Supplement to ticket 6a47f9ebe552e8da3d3da1a2

## Checklist

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] No version bump / CHANGELOG.md change included
- [x] No credentials or private URLs introduced
- [x] `pull-process` tool description updated in `tools_registry.go`
- [x] Pre-Deploy Sync Check in `corezoid-edit` SKILL.md corrected

## Test plan

- Pull a process that has unsaved drafts in Corezoid web UI → confirm success message includes the "deployed version only" note
- Ask Claude Code to edit and deploy a process after UI edits → confirm skill now asks whether UI changes were deployed or are still a draft
- If user answers "draft" → confirm Claude warns about overwrite and recommends Deploy-from-UI first