### PR TITLE
fix(docs): fix TestSkillPathsExist, update README and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ This is a Claude Code plugin (`@corezoid/corezoid-ai-plugin`) that gives Claude 
 
 The repo has three layers:
 - **Go MCP server** (`plugins/corezoid/mcp-server/`) — 44 tools, compiled from Go source, started automatically via `.mcp.json`. Has a test suite (`go test ./...`) and CI.
-- **Skills** (`plugins/corezoid/skills/`) — 19 SKILL.md files that teach Claude platform conventions.
+- **Skills** (`plugins/corezoid/skills/`) — 18 SKILL.md files that teach Claude platform conventions.
 - **Documentation corpus** (`plugins/corezoid/docs/`) — 24 node types, process guides, JSON schemas, samples.
 
 ## Plugin Development Commands

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,17 +4,28 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Purpose
 
-This is a Claude Code plugin (`@corezoid/corezoid-ai-plugin`) that gives Claude the knowledge and tools to create, edit, and review [Corezoid](https://corezoid.com) BPM processes directly from the IDE. It is primarily a **documentation and workflow plugin** — there is no build step or test suite. The repo ships static `.md` files, JSON samples, and plugin manifests.
+This is a Claude Code plugin (`@corezoid/corezoid-ai-plugin`) that gives Claude the knowledge and tools to create, edit, and review [Corezoid](https://corezoid.com) BPM processes directly from the IDE.
+
+The repo has three layers:
+- **Go MCP server** (`plugins/corezoid/mcp-server/`) — 44 tools, compiled from Go source, started automatically via `.mcp.json`. Has a test suite (`go test ./...`) and CI.
+- **Skills** (`plugins/corezoid/skills/`) — 19 SKILL.md files that teach Claude platform conventions.
+- **Documentation corpus** (`plugins/corezoid/docs/`) — 24 node types, process guides, JSON schemas, samples.
 
 ## Plugin Development Commands
 
 ```bash
+# Build and test the MCP server
+cd plugins/corezoid/mcp-server && go build ./... && go test ./...
+
+# Run tests with race detector
+cd plugins/corezoid/mcp-server && go test -race ./...
+
 # Publish a new version (triggers GitHub Actions on tag push)
-git tag v1.x.x && git push origin v1.x.x
+git tag vX.Y.Z && git push origin vX.Y.Z
 
 # Install the plugin locally for testing
-npm install -g .
-claude plugin install @corezoid/corezoid-ai-plugin
+claude plugin marketplace add .
+claude plugin install corezoid@corezoid
 ```
 
 ## convctl MCP server (bundled in this plugin)

--- a/README.md
+++ b/README.md
@@ -16,9 +16,18 @@ The plugin bundles a Go MCP server that exposes Corezoid operations as MCP tools
 | `corezoid-edit`                | "edit", "modify", "update" a process     | Modifying existing `.conv.json` files             |
 | `corezoid-review`              | "review", "audit", "check" a process     | Analysis, dead code, best-practice violations     |
 | `corezoid-project-review`      | "review project", "audit folder"         | Cross-process audit of an entire folder           |
-| `corezoid-stage-scan`          | "scan stage", "check stage before merge", "why does the merge fail" | Offline pre-merge validation of exported stage `.zip`s: non-active/empty processes, broken node links, broken/inactive `conv_id` refs |
+| `corezoid-state-diagram-create`| "create a state diagram", "build a state machine" | State diagrams (`conv_type "state"`) from scratch |
+| `corezoid-state-diagram-edit`  | "edit a state diagram", "add a state"    | Modifying existing state diagrams                 |
+| `corezoid-stage-scan`          | "scan stage", "check stage before merge", "why does the merge fail" | Offline pre-merge validation of exported stage `.zip`s: non-active/empty processes, broken node links |
 | `corezoid-dashboard-manager`   | "create dashboard", "add chart", "visualize metrics" | Dashboards, charts, node metrics, real-time monitoring |
 | `corezoid-process-tech-writer` | "document", "write docs", "describe process" | Markdown docs + enriched JSON with node descriptions |
+| `corezoid-access`              | "share", "give access", "create group", "create api key" | Object sharing, user groups, API keys, invites    |
+| `corezoid-alias-manager`       | "alias", "short name", "rename alias"    | Create, list, modify, delete process aliases      |
+| `corezoid-variable-manager`    | "variable", "env var", "create variable" | Create, list, modify, delete environment variables |
+| `corezoid-api-connector`       | "call Corezoid API", "api/2/json", "api_secret_outer" | Processes that call the Corezoid public API       |
+| `corezoid-process-optimizer`   | "optimize", "reduce tacts", "improve"    | Merge nodes, clean data flow, add resilience      |
+| `corezoid-feedback`            | "report a bug", "this is broken", "send feedback" | Collect and submit bug reports / improvement requests |
+| `marketplace-publish-validation` | "publish to marketplace", "check before publish" | Pre-publication checklist for Corezoid marketplace |
 
 ## Design philosophy
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The plugin bundles a Go MCP server that exposes Corezoid operations as MCP tools
 | `corezoid-project-review`      | "review project", "audit folder"         | Cross-process audit of an entire folder           |
 | `corezoid-state-diagram-create`| "create a state diagram", "build a state machine" | State diagrams (`conv_type "state"`) from scratch |
 | `corezoid-state-diagram-edit`  | "edit a state diagram", "add a state"    | Modifying existing state diagrams                 |
-| `corezoid-stage-scan`          | "scan stage", "check stage before merge", "why does the merge fail" | Offline pre-merge validation of exported stage `.zip`s: non-active/empty processes, broken node links |
+| `corezoid-stage-scan`          | "scan stage", "check stage before merge", "why does the merge fail" | Offline pre-merge validation of exported stage `.zip`s: non-active/empty processes, broken node links, broken/inactive `conv_id` refs |
 | `corezoid-dashboard-manager`   | "create dashboard", "add chart", "visualize metrics" | Dashboards, charts, node metrics, real-time monitoring |
 | `corezoid-process-tech-writer` | "document", "write docs", "describe process" | Markdown docs + enriched JSON with node descriptions |
 | `corezoid-access`              | "share", "give access", "create group", "create api key" | Object sharing, user groups, API keys, invites    |

--- a/plugins/corezoid/docs/process/corezoid-api-integration.md
+++ b/plugins/corezoid/docs/process/corezoid-api-integration.md
@@ -1,0 +1,96 @@
+# Corezoid Public API Integration Pattern
+
+Reference for building Corezoid processes that call the Corezoid public API (`/api/2/json/`).
+
+## Key difference from external API connectors
+
+Corezoid's own API uses `api_secret_outer` for HMAC authentication — **never** a Code Node for SHA1 signing. The platform handles signing automatically when `api_secret_outer` is set.
+
+## Required input params
+
+| Name | Type | Description |
+|---|---|---|
+| `api_login` | string | API key login (from workspace settings) |
+| `api_secret` | string | API key secret (used in `api_secret_outer`) |
+| `workspaceId` | string | Workspace (company) ID |
+
+Add operation-specific params (`processId`, `nodeId`, `limit`, `offset`, etc.).
+
+## Process flow
+
+```
+Start → API Call → Reply Success → Final [obj_type:2]
+              │
+         (err)└──► Error Escalation [obj_type:3] ──► Error [obj_type:2]
+        (time)└──► Timeout Escalation [obj_type:3] ──► Timeout [obj_type:2]
+```
+
+No Code Node is needed — `api_secret_outer` handles all authentication.
+
+## API Call node
+
+```json
+{
+  "type": "api",
+  "api_secret_outer": "{{api_secret}}",
+  "method": "POST",
+  "url": "https://api.corezoid.com/api/2/json/{{api_login}}",
+  "format": "",
+  "extra": {
+    "ops": "[{\"type\":\"list\",\"obj\":\"node\",\"company_id\":\"{{workspaceId}}\",\"conv_id\":{{processId}},\"limit\":{{limit}},\"offset\":{{offset}}}]"
+  },
+  "extra_type": {
+    "ops": "array"
+  },
+  "extra_headers": { "content-type": "application/json; charset=utf-8" },
+  "send_sys": true,
+  "rfc_format": true,
+  "is_migrate": true,
+  "customize_response": false,
+  "response": { "body": "{{body}}", "header": "{{header}}" },
+  "response_type": { "body": "object", "header": "object" },
+  "version": 2,
+  "max_threads": 5,
+  "debug_info": false,
+  "cert_pem": "",
+  "err_node_id": "<error_escalation_node_id>"
+}
+```
+
+Add a 30-second timeout semaphor to the API Call node.
+
+## Critical rules
+
+- `api_secret_outer` handles all auth — never compute HMAC in a Code Node
+- `ops` value must be a **stringified JSON string** with type `"array"`
+- `format` must be `""` (empty string), not `"raw"`
+- `send_sys: true` is required
+- `customize_response: false` — use default `body`/`header` response mapping
+- `rfc_format: true` is required
+
+## Reply Success node
+
+```json
+{
+  "type": "api_rpc_reply",
+  "mode": "key_value",
+  "res_data": { "result": "success", "response": "{{ops[0]}}" },
+  "res_data_type": { "result": "string", "response": "object" },
+  "throw_exception": false
+}
+```
+
+## Sample
+
+See `samples/corezoid-api-node-list.conv.json` for a complete working example (Node List operation).
+
+## Available `ops` types
+
+Refer to [openapi.corezoid.com](https://openapi.corezoid.com) for the full list of operations and their field schemas. Common operations:
+
+| `obj` | `type` | Description |
+|---|---|---|
+| `node` | `list` | List nodes in a process |
+| `conv` | `list` | List processes in a folder |
+| `task` | `list` | List tasks in a node |
+| `company` | `list` | List workspaces |

--- a/plugins/corezoid/docs/process/corezoid-api-integration.md
+++ b/plugins/corezoid/docs/process/corezoid-api-integration.md
@@ -59,6 +59,8 @@ No Code Node is needed — `api_secret_outer` handles all authentication.
 
 Add a 30-second timeout semaphor to the API Call node.
 
+> **On-prem:** replace `api.corezoid.com` with your own API host (the value of `COREZOID_API_URL`).
+
 ## Critical rules
 
 - `api_secret_outer` handles all auth — never compute HMAC in a Code Node
@@ -74,7 +76,7 @@ Add a 30-second timeout semaphor to the API Call node.
 {
   "type": "api_rpc_reply",
   "mode": "key_value",
-  "res_data": { "result": "success", "response": "{{ops[0]}}" },
+  "res_data": { "result": "success", "response": "{{body.ops[0]}}" },
   "res_data_type": { "result": "string", "response": "object" },
   "throw_exception": false
 }

--- a/plugins/corezoid/mcp-server/tools_registry_test.go
+++ b/plugins/corezoid/mcp-server/tools_registry_test.go
@@ -76,6 +76,14 @@ func TestSkillPathsExist(t *testing.T) {
 		matches := re.FindAllSubmatch(data, -1)
 		for _, m := range matches {
 			relPath := string(m[1])
+			// Strip URL fragment (#anchor) — the test checks file existence,
+			// not whether a specific heading exists inside the file.
+			if idx := strings.Index(relPath, "#"); idx >= 0 {
+				relPath = relPath[:idx]
+			}
+			if relPath == "" {
+				continue
+			}
 			absPath := filepath.Join(pluginRoot, relPath)
 			if _, err := os.Stat(absPath); os.IsNotExist(err) {
 				t.Errorf("%s/SKILL.md: references non-existent path ${CLAUDE_PLUGIN_ROOT}/%s (resolved: %s)",


### PR DESCRIPTION
## Summary

- **TestSkillPathsExist now passes on main** — stripped URL fragments (`#anchor`) from path resolution before `os.Stat`; created missing `corezoid-api-integration.md` referenced by `corezoid-api-connector` skill
- **CLAUDE.md corrected** — removed false "no build step or test suite" claim; described the actual three-layer structure and added correct dev commands
- **README skills table** — expanded from 9 to 18 entries to reflect all current skills

## Changes

### `tools_registry_test.go`
The regex captured `docs/process/file.md#some-heading` as the full path. `os.Stat` on a path with `#fragment` always fails even when the file exists. One-line fix: strip everything from `#` before stat.

### `docs/process/corezoid-api-integration.md` (new file)
`corezoid-api-connector/SKILL.md` references this doc twice but it was never created. Added the full `api_secret_outer` integration pattern (the skill already describes the pattern; this doc provides the canonical reference it links to).

### `CLAUDE.md`
Before: *"it is primarily a documentation and workflow plugin — there is no build step or test suite"*
After: accurate description — Go MCP server (44 tools, test suite, CI), 19 skills, docs corpus. Updated dev commands to match how the repo actually works.

### `README.md`
Skills table: 9 rows → 18 rows. Added all skills present in `plugins/corezoid/skills/` that were missing from the table.

## Test plan

- [ ] `cd plugins/corezoid/mcp-server && go test ./...` — passes (all tests green including the previously failing `TestSkillPathsExist`)
- [ ] README skills table count matches `ls plugins/corezoid/skills/ | wc -l`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)