### PR TITLE
feat(skills): add corezoid-describe skill and description update rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The plugin bundles a Go MCP server that exposes Corezoid operations as MCP tools
 | `corezoid-variable-manager`    | "variable", "env var", "create variable" | Create, list, modify, delete environment variables |
 | `corezoid-api-connector`       | "call Corezoid API", "api/2/json", "api_secret_outer" | Processes that call the Corezoid public API       |
 | `corezoid-process-optimizer`   | "optimize", "reduce tacts", "improve"    | Merge nodes, clean data flow, add resilience      |
+| `corezoid-describe`            | "update description", "add description", "describe this process" | Set or refresh the description of a process, folder, or project |
 | `corezoid-feedback`            | "report a bug", "this is broken", "send feedback" | Collect and submit bug reports / improvement requests |
 | `marketplace-publish-validation` | "publish to marketplace", "check before publish" | Pre-publication checklist for Corezoid marketplace |
 

--- a/plugins/corezoid/skills/corezoid-create/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-create/SKILL.md
@@ -92,7 +92,7 @@ Produce a valid `.conv.json` file.
   "obj_id": null,
   "parent_id": null,
   "title": "Process Name",
-  "description": "",
+  "description": "<fill in — see rule below>",
   "status": "active",
   "params": [],
   "ref_mask": true,
@@ -103,6 +103,12 @@ Produce a valid `.conv.json` file.
   }
 }
 ```
+
+**`description`** — fill in immediately based on the requirements gathered in Step 1. Follow the Description Update Rule:
+- 1–2 sentences, starting with a verb (*Calls*, *Creates*, *Validates*, *Routes*, *Aggregates*)
+- Sentence 1: what the process does — verb + action + subject. Example: *"Calls the Stripe API to create a payment session and returns the checkout URL."*
+- Sentence 2 (optional): key inputs/outputs or notable behaviour. Example: *"Requires `amount` and `currency`; on error returns a structured error object."*
+- Under 200 characters, no *"This process…"* preamble
 
 `params` — declare all input parameters the caller must pass. See `${CLAUDE_PLUGIN_ROOT}/docs/process/process-with-parameters.md`.
 

--- a/plugins/corezoid/skills/corezoid-create/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-create/SKILL.md
@@ -92,7 +92,7 @@ Produce a valid `.conv.json` file.
   "obj_id": null,
   "parent_id": null,
   "title": "Process Name",
-  "description": "<fill in — see rule below>",
+  "description": "",
   "status": "active",
   "params": [],
   "ref_mask": true,
@@ -104,11 +104,7 @@ Produce a valid `.conv.json` file.
 }
 ```
 
-**`description`** — fill in immediately based on the requirements gathered in Step 1. Follow the Description Update Rule:
-- 1–2 sentences, starting with a verb (*Calls*, *Creates*, *Validates*, *Routes*, *Aggregates*)
-- Sentence 1: what the process does — verb + action + subject. Example: *"Calls the Stripe API to create a payment session and returns the checkout URL."*
-- Sentence 2 (optional): key inputs/outputs or notable behaviour. Example: *"Requires `amount` and `currency`; on error returns a structured error object."*
-- Under 200 characters, no *"This process…"* preamble
+Fill in `description` based on the requirements gathered in Step 1 (see Description Update Rule in `corezoid/SKILL.md`): 1–2 sentences starting with a verb, under 200 characters, no *"This process…"* preamble.
 
 `params` — declare all input parameters the caller must pass. See `${CLAUDE_PLUGIN_ROOT}/docs/process/process-with-parameters.md`.
 

--- a/plugins/corezoid/skills/corezoid-describe/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-describe/SKILL.md
@@ -34,8 +34,17 @@ If not clear, ask:
 3. Also consider any changes the user described in the conversation — they are the primary source of intent
 
 **For a folder:**
-1. List `.conv.json` files inside the folder (use `find` Bash tool)
-2. Read titles and existing descriptions of contained processes to understand the folder's scope
+1. Resolve `folder_id` using the priority order below (Step 2a)
+2. List `.conv.json` files inside the folder (use `find` Bash tool)
+3. Read titles and existing descriptions of contained processes to understand the folder's scope
+
+**Step 2a — Resolve folder_id (for folder targets):**
+
+Use the first available source in this order:
+1. **Explicit ID** — user provided a numeric folder ID → use it directly
+2. **Process context** — a `.conv.json` is known → read its `parent_id` field → that is the `folder_id`
+3. **Name search** — user provided only a folder name → call `list-folders(folder_id=0)` and find the matching entry by title
+4. **Not found** — name search returns no match → skip the folder description update silently (do not error)
 
 **For a project:**
 1. Call `list-projects` or `show-project` to get current metadata
@@ -84,6 +93,7 @@ Write 1–2 sentences describing the project's overall purpose and the main syst
 3. Confirm: *"Description updated and deployed."*
 
 **For a folder:**
+Use the `folder_id` resolved in Step 2a. If it was not resolved (source 4 — not found), skip this step.
 Call MCP tool **`modify-folder`** with `folder_id` and `description`.
 
 **For a project:**

--- a/plugins/corezoid/skills/corezoid-describe/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-describe/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: corezoid-describe
+description: >
+  Updates or creates the description of a Corezoid process, folder, or project
+  without touching its logic. Use when the user says "update description",
+  "add description", "describe this process", "set description for folder",
+  "describe folder", "обнови описание", "добавь описание", "опиши процесс",
+  "задай описание папки", or asks to document an object briefly.
+  Also use when editing/creating is complete and the user wants to separately
+  describe what was built.
+---
+
+# Update Process / Folder / Project Description
+
+You are a specialist in writing clear, factual descriptions for Corezoid objects.
+
+## Step 1: Identify the Object
+
+Determine what needs to be described:
+- **Process** — user provides a file path, process name, or process ID
+- **Folder** — user provides a folder name, folder ID, or path
+- **Project** — user provides a project name or project ID
+
+If not clear, ask:
+> "Which process, folder, or project should I describe? Provide a file path, name, or ID."
+
+---
+
+## Step 2: Read the Current State
+
+**For a process:**
+1. Open and read the `.conv.json` file
+2. Note: current `description` (if any), process title, node titles, logic types, external APIs called, declared `params`
+3. Also consider any changes the user described in the conversation — they are the primary source of intent
+
+**For a folder:**
+1. List `.conv.json` files inside the folder (use `find` Bash tool)
+2. Read titles and existing descriptions of contained processes to understand the folder's scope
+
+**For a project:**
+1. Call `list-projects` or `show-project` to get current metadata
+2. Inspect the top-level folder structure to understand what the project covers
+
+---
+
+## Step 3: Generate the Description
+
+### Process description
+
+Write 1–2 sentences:
+- **Sentence 1** — what the process does: verb + action + subject.
+  - *"Calls the Stripe API to create a payment session and returns the checkout URL."*
+  - *"Validates the incoming webhook signature and routes the event to the correct handler process."*
+  - *"Creates a new user record in the Simulator platform and returns the actor ID."*
+- **Sentence 2** (optional) — key inputs, outputs, or notable behaviour:
+  - *"Requires `amount` and `currency`; on error returns a structured error object."*
+
+Rules:
+- Start with a verb in third person: *Calls*, *Creates*, *Validates*, *Routes*, *Aggregates*, *Sends*, *Fetches*
+- Name the external service, Corezoid object type, or business action specifically
+- Do NOT write *"This process…"*, *"The purpose of this…"*, or *"This skill…"*
+- Keep under 200 characters
+- If the current description is already accurate and recent, say so — do not update for the sake of updating
+
+### Folder description
+
+Write 1 sentence: *"Contains [what kind of processes] for [what purpose/system]."*
+
+Examples:
+- *"Contains Stripe payment integration processes (checkout, refund, webhook handling)."*
+- *"Contains internal user management processes for the CRM project."*
+
+### Project description
+
+Write 1–2 sentences describing the project's overall purpose and the main systems or workflows it covers.
+
+---
+
+## Step 4: Apply the Description
+
+**For a process:**
+1. Update the `description` field at the root of the `.conv.json` file
+2. Call MCP tool **`push-process`** with `process_path`
+3. Confirm: *"Description updated and deployed."*
+
+**For a folder:**
+Call MCP tool **`modify-folder`** with `folder_id` and `description`.
+
+**For a project:**
+Call MCP tool **`modify-project`** with `company_id`, `project_id`, and `description`.
+
+---
+
+## Notes
+
+- If the user describes what changed (*"I just added a retry node"*), incorporate that context into the description
+- Never fabricate process behaviour not visible in the JSON or stated by the user
+- For processes that already have a good description, confirm with the user before overwriting

--- a/plugins/corezoid/skills/corezoid-edit/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-edit/SKILL.md
@@ -82,7 +82,23 @@ For complete JSON structures see `${CLAUDE_PLUGIN_ROOT}/docs/node-structures.md`
 
 ---
 
-## Step 3: Deploy the Changes
+## Step 3: Update the Description
+
+Before deploying, update the root-level `description` field in `PROCESS_PATH` to reflect the process's current behaviour after your edits.
+
+Follow the **Description Update Rule** from the `corezoid` skill:
+- 1–2 sentences, starting with a verb (*Calls*, *Creates*, *Validates*, *Routes*, *Aggregates*)
+- Sentence 1: what the process does — verb + action + subject
+- Sentence 2 (optional): key inputs/outputs or notable behaviour
+- Under 200 characters, no *"This process…"* preamble
+
+Write the updated `description` directly into the JSON file. This costs nothing extra — the description rides the same `push-process` call.
+
+If the parent folder was structurally affected (process added, removed, or renamed), also call MCP tool **`modify-folder`** with a one-sentence `description` of what the folder contains.
+
+---
+
+## Step 4: Deploy the Changes
 
 **MANDATORY: Always run this step whenever any changes were made to the process file — even if there are open questions or the work is not fully complete. Without deploying, all changes are lost.**
 

--- a/plugins/corezoid/skills/corezoid-edit/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-edit/SKILL.md
@@ -86,6 +86,8 @@ For complete JSON structures see `${CLAUDE_PLUGIN_ROOT}/docs/node-structures.md`
 
 Before deploying, update the root-level `description` field in `PROCESS_PATH` to reflect the process's current behaviour after your edits.
 
+**Guard — preserve existing descriptions when appropriate:** if the process already has a non-empty description and your edits did not change the overall purpose (e.g. you fixed a bug, adjusted a timeout, or rewired an error path without altering what the process fundamentally does), preserve the existing description rather than replacing it.
+
 Follow the **Description Update Rule** from the `corezoid` skill:
 - 1–2 sentences, starting with a verb (*Calls*, *Creates*, *Validates*, *Routes*, *Aggregates*)
 - Sentence 1: what the process does — verb + action + subject

--- a/plugins/corezoid/skills/corezoid/SKILL.md
+++ b/plugins/corezoid/skills/corezoid/SKILL.md
@@ -131,6 +131,7 @@ For domain-specific workflows use the specialized skills:
 - `/corezoid-variable-manager` — creating, listing, modifying, deleting variables (visible/secret, raw/json)
 - `/corezoid-process-optimizer` — reduce tacts (merge nodes), clean data flow, fill names, add semaphors
 - `/corezoid-api-connector` — build processes that call the Corezoid public API (`/api/2/json/`) using `api_secret_outer`
+- `/corezoid-describe` — update or create the description of a process, folder, or project without editing its logic
 
 ## Reference Documents
 
@@ -154,6 +155,42 @@ Use the `Read` tool to load these files when you need deeper detail:
 | `${CLAUDE_PLUGIN_ROOT}/docs/state-diagrams/state-diagram-node-structures.md` | JSON schemas for nodes inside a state diagram |
 | `${CLAUDE_PLUGIN_ROOT}/docs/state-diagrams/state-diagram-process-interaction.md` | How driver processes read / create / modify state tasks |
 | `${CLAUDE_PLUGIN_ROOT}/docs/variables-guide.md` | Variable naming rules, creation workflow, usage examples |
+
+## Description Update Rule
+
+After any successful change to a process, folder, or project, always set or refresh its description.
+
+### Process description
+
+The `description` field lives at the root of `.conv.json`.  
+**Update it in the same edit cycle, before `push-process`** — no second push needed.
+
+Write 1–2 sentences:
+- Sentence 1: what the process does — verb + action + subject.  
+  Example: *"Calls the Stripe API to create a payment session and returns the checkout URL."*
+- Sentence 2 (optional): key inputs/outputs or notable behaviour.  
+  Example: *"Requires `amount` and `currency`; on error returns a structured error object."*
+
+Rules:
+- Start with a verb in the third person: *Calls*, *Creates*, *Validates*, *Routes*, *Aggregates*
+- Name the external service, Corezoid object type, or business action specifically
+- Do not write *"This process…"* or *"The purpose of this…"*
+- Keep under 200 characters
+
+### Folder description
+
+Call MCP tool **`modify-folder`** with `description` after any structural change to the folder (new process added, process removed, folder renamed).
+
+Write 1 sentence: *"Contains [what kind of processes] for [what purpose/system]."*  
+Example: *"Contains Stripe payment integration processes (checkout, refund, webhook handling)."*
+
+### Project description
+
+Call MCP tool **`modify-project`** with `description` after any change that affects the project scope.
+
+Write 1–2 sentences describing what the project does as a whole.
+
+---
 
 ## Tips
 

--- a/plugins/corezoid/skills/corezoid/SKILL.md
+++ b/plugins/corezoid/skills/corezoid/SKILL.md
@@ -158,37 +158,12 @@ Use the `Read` tool to load these files when you need deeper detail:
 
 ## Description Update Rule
 
-After any successful change to a process, folder, or project, always set or refresh its description.
+After any successful change to a process, folder, or project, always set or refresh its description. Full authoring rules are in `/corezoid-describe`.
 
-### Process description
-
-The `description` field lives at the root of `.conv.json`.  
-**Update it in the same edit cycle, before `push-process`** — no second push needed.
-
-Write 1–2 sentences:
-- Sentence 1: what the process does — verb + action + subject.  
-  Example: *"Calls the Stripe API to create a payment session and returns the checkout URL."*
-- Sentence 2 (optional): key inputs/outputs or notable behaviour.  
-  Example: *"Requires `amount` and `currency`; on error returns a structured error object."*
-
-Rules:
-- Start with a verb in the third person: *Calls*, *Creates*, *Validates*, *Routes*, *Aggregates*
-- Name the external service, Corezoid object type, or business action specifically
-- Do not write *"This process…"* or *"The purpose of this…"*
-- Keep under 200 characters
-
-### Folder description
-
-Call MCP tool **`modify-folder`** with `description` after any structural change to the folder (new process added, process removed, folder renamed).
-
-Write 1 sentence: *"Contains [what kind of processes] for [what purpose/system]."*  
-Example: *"Contains Stripe payment integration processes (checkout, refund, webhook handling)."*
-
-### Project description
-
-Call MCP tool **`modify-project`** with `description` after any change that affects the project scope.
-
-Write 1–2 sentences describing what the project does as a whole.
+Summary:
+- **Process** — update `description` in `.conv.json` root **before** `push-process` (no second push needed). 1–2 sentences, start with a verb (*Calls*, *Creates*, *Validates*…), under 200 characters, no *"This process…"*
+- **Folder** — call `modify-folder` with `description` if the folder was structurally changed. Resolve `folder_id` from the process's parent or by name via `list-folders`; if unresolvable, skip.
+- **Project** — call `modify-project` with `description` if project scope changed.
 
 ---
 


### PR DESCRIPTION
## Summary

- New `corezoid-describe` skill — updates process/folder/project descriptions without touching logic; activated by "update description", "add description", "describe this process", "set description for folder"
- `Description Update Rule` added to `corezoid/SKILL.md` as single source of truth for how to generate descriptions (process, folder, project)
- `corezoid-edit`: new Step 3 "Update the Description" before `push-process` — description rides the same push, no extra call needed
- `corezoid-create`: `description` field in root JSON template is now required and filled from Step 1 requirements

## Test plan

- [ ] Invoke `/corezoid-describe` on an existing process — verify it reads JSON, generates 1–2 sentence description, pushes
- [ ] Edit a process via `/corezoid-edit` — verify Step 3 appears and description is updated before push
- [ ] Create a process via `/corezoid-create` — verify `description` field is non-empty in the generated JSON
- [ ] Invoke `/corezoid-describe` on a folder — verify `modify-folder` is called with description

🤖 Generated with [Claude Code](https://claude.com/claude-code)