### PR TITLE
fix(push-process): compile git_call inline code before commit

### DIFF
--- a/plugins/corezoid/mcp-server/executor_mock_test.go
+++ b/plugins/corezoid/mcp-server/executor_mock_test.go
@@ -348,9 +348,22 @@ func TestCommit_ReturnsMap(t *testing.T) {
 		}
 	})
 
-	// Commit returns map[string]interface{} (nil on failure).
-	result := e.Commit()
-	_ = result // may be nil if response has no version data; just ensure no panic
+	result, err := e.Commit()
+	if err != nil {
+		t.Errorf("unexpected error from Commit: %v", err)
+	}
+	_ = result
+}
+
+func TestCommit_PropagatesError(t *testing.T) {
+	_, e := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
+		return map[string]interface{}{"request_proc": "fail"}
+	})
+
+	_, err := e.Commit()
+	if err == nil {
+		t.Error("expected error from Commit on request_proc=fail, got nil")
+	}
 }
 
 func TestDeleteVersion_NoError(t *testing.T) {
@@ -398,6 +411,93 @@ func TestDeleteNode_NoError(t *testing.T) {
 	})
 
 	e.DeleteNode("node1") // returns nothing
+}
+
+// ---- CompileAPICode (git_call inline code path) ----------------------------
+
+// TestCompileAPICode_GitCallInlineCode verifies that a git_call logic node
+// with inline JS code (the "src" field populated) triggers the load+compile
+// sequence before commit, just like api_code nodes do. This exercises the fix
+// for the push-process failure on processes containing git_call nodes.
+func TestCompileAPICode_GitCallInlineCode(t *testing.T) {
+	calls := 0
+	_, e := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
+		calls++
+		// Both load and compile requests should succeed.
+		return map[string]interface{}{
+			"request_proc": "ok",
+			"ops":          []interface{}{map[string]interface{}{"proc": "ok"}},
+		}
+	})
+	e.ProcessID = 42
+
+	nodes := []interface{}{
+		map[string]interface{}{
+			"id":       "aabbccddeeff001122334455",
+			"obj_type": float64(0),
+			"condition": map[string]interface{}{
+				"logics": []interface{}{
+					map[string]interface{}{
+						"type": "git_call",
+						"lang": "js",
+						"src":  "corezoid.callback();",
+						"err_node_id": "aabbccddeeff001122334456",
+					},
+					map[string]interface{}{"type": "go", "to_node_id": "aabbccddeeff001122334457"},
+				},
+			},
+		},
+	}
+
+	if err := e.CompileAPICode(nodes); err != nil {
+		t.Fatalf("CompileAPICode returned unexpected error: %v", err)
+	}
+	// Expect exactly 2 API calls: load_api_code + compile_api_code.
+	if calls != 2 {
+		t.Errorf("expected 2 API calls (load+compile), got %d", calls)
+	}
+}
+
+// TestCompileAPICode_GitCallNoInlineCode verifies that a git_call logic that
+// references an external git repo (no "src"/"code" field) does NOT trigger any
+// API calls — those nodes compile server-side when the task runs.
+func TestCompileAPICode_GitCallNoInlineCode(t *testing.T) {
+	calls := 0
+	_, e := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
+		calls++
+		return map[string]interface{}{
+			"request_proc": "ok",
+			"ops":          []interface{}{map[string]interface{}{"proc": "ok"}},
+		}
+	})
+	e.ProcessID = 42
+
+	nodes := []interface{}{
+		map[string]interface{}{
+			"id":       "aabbccddeeff001122334455",
+			"obj_type": float64(0),
+			"condition": map[string]interface{}{
+				"logics": []interface{}{
+					map[string]interface{}{
+						"type":   "git_call",
+						"lang":   "js",
+						"repo":   "https://github.com/example/repo.git",
+						"commit": "main",
+						"err_node_id": "aabbccddeeff001122334456",
+						// no "src" or "code" — external repo reference
+					},
+					map[string]interface{}{"type": "go", "to_node_id": "aabbccddeeff001122334457"},
+				},
+			},
+		},
+	}
+
+	if err := e.CompileAPICode(nodes); err != nil {
+		t.Fatalf("CompileAPICode returned unexpected error: %v", err)
+	}
+	if calls != 0 {
+		t.Errorf("expected 0 API calls for external-repo git_call, got %d", calls)
+	}
 }
 
 func TestCreateVariable_Error(t *testing.T) {

--- a/plugins/corezoid/mcp-server/executor_nodes.go
+++ b/plugins/corezoid/mcp-server/executor_nodes.go
@@ -290,10 +290,20 @@ func (v *Executor) ModifyNodes(nodes []any) error {
 	return nil
 }
 
-// CompileAPICode loads and compiles all api_code logic nodes on the server.
-// Each api_code node costs two API calls (load + compile), so for a process
-// with many code nodes the loop can be long-running. Check cancellation per
-// iteration to abort promptly when the client sends notifications/cancelled.
+// CompileAPICode loads and compiles all api_code and git_call (inline-code)
+// logic nodes on the server before the final commit_process call.
+//
+// Background: the Corezoid platform compiles inline code during the commit
+// phase when a node's code has not been pre-compiled. For api_code nodes this
+// was already handled; git_call nodes with inline code (the "code"/"src"
+// fields populated) follow the same load→compile pattern but use obj:
+// "git_call". Skipping the pre-compile step caused commit_process to time out
+// or return no response when the process contained a git_call node with inline
+// JS/Python/Go code (reported against process 179067).
+//
+// Each inline-code node costs two API calls (load + compile), so for a process
+// with many code nodes the loop can be long-running. Cancellation is checked
+// per iteration to abort promptly when the client sends notifications/cancelled.
 func (v *Executor) CompileAPICode(nodes []interface{}) error {
 	if err := v.checkCancel(); err != nil {
 		return err
@@ -311,125 +321,138 @@ func (v *Executor) CompileAPICode(nodes []interface{}) error {
 				for _, logic := range logicsArray {
 					if logicMap, ok := logic.(map[string]interface{}); ok {
 						lt, _ := logicMap["type"].(string)
-						if lt == "api_code" {
-							nodeID, ok := nodeMap["id"].(string)
-							if !ok {
+						if lt != "api_code" && lt != "git_call" {
+							continue
+						}
+
+						nodeID, ok := nodeMap["id"].(string)
+						if !ok {
+							continue
+						}
+						lang, _ := logicMap["lang"].(string)
+						if lang == "" {
+							lang = "js"
+						}
+						src, _ := logicMap["src"].(string)
+						if src == "" {
+							src, _ = logicMap["code"].(string)
+							if src == "" {
+								// git_call nodes that pull from a remote repo
+								// (no inline code) do not need a compile step.
 								continue
 							}
-							lang, _ := logicMap["lang"].(string)
-							if lang == "" {
-								lang = "js"
-							}
-							src, _ := logicMap["src"].(string)
-							if src == "" {
-								src, _ = logicMap["code"].(string)
-								if src == "" {
-									continue
-								}
-							}
+						}
 
-							loadOps := []map[string]any{
-								{
-									"type":    "load",
-									"obj":     "api_code",
-									"conv_id": v.ProcessID,
-									"node_id": nodeID,
-									"lang":    lang,
-									"src":     src,
-									"env":     "sandbox",
-								},
-							}
-							loadResponse, err := v.req("load_api_code", loadOps)
-							if err != nil {
-								return fmt.Errorf("failed to load API code: %w", err)
-							}
-							if loadResponse == nil {
-								return fmt.Errorf("failed to load API code: no response from server")
-							}
-							if requestProc, ok := loadResponse["request_proc"].(string); !ok || requestProc != "ok" {
-								return fmt.Errorf("failed to load API code: request_proc not ok")
-							}
-							if opsArray, ok := loadResponse["ops"].([]interface{}); ok {
-								for _, op := range opsArray {
-									if opMap, ok := op.(map[string]interface{}); ok {
-										if proc, ok := opMap["proc"].(string); !ok || proc != "ok" {
-											if errors, ok := opMap["errors"].(map[string]interface{}); ok {
-												var errorMsgs []string
-												for objID, errMsgs := range errors {
-													nodeID := objID
-													if errArray, ok := errMsgs.([]interface{}); ok {
-														for _, errMsg := range errArray {
-															if msg, ok := errMsg.(string); ok {
-																errorMsgs = append(errorMsgs, fmt.Sprintf("Error in the node %s: %s", nodeID, msg))
-															}
-														}
-													}
-												}
-												if len(errorMsgs) > 0 {
-													return fmt.Errorf("failed to load API code:\n%s", strings.Join(errorMsgs, "\n"))
-												}
-											}
-											errorMsg := "unknown error"
-											if msg, ok := opMap["description"].(string); ok {
-												errorMsg = msg
-											}
-											return fmt.Errorf("failed to load API code: %s", errorMsg)
-										}
-									}
-								}
-							}
+						if err := v.loadAndCompileNode(lt, nodeID, lang, src); err != nil {
+							return err
+						}
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
 
-							compileOps := []map[string]any{
-								{
-									"obj":     "api_code",
-									"type":    "compile",
-									"conv_id": v.ProcessID,
-									"node_id": nodeID,
-									"lang":    lang,
-									"src":     src,
-								},
-							}
-							compileResponse, err := v.req("compile_api_code", compileOps)
-							if err != nil {
-								return fmt.Errorf("failed to compile API code: %w", err)
-							}
-							if compileResponse == nil {
-								return fmt.Errorf("failed to compile API code: no response from server")
-							}
-							if requestProc, ok := compileResponse["request_proc"].(string); !ok || requestProc != "ok" {
-								return fmt.Errorf("failed to compile API code: request_proc not ok")
-							}
-							if opsArray, ok := compileResponse["ops"].([]interface{}); ok {
-								for _, op := range opsArray {
-									if opMap, ok := op.(map[string]interface{}); ok {
-										if proc, ok := opMap["proc"].(string); !ok || proc != "ok" {
-											if errors, ok := opMap["errors"].(map[string]interface{}); ok {
-												var errorMsgs []string
-												for objID, errMsgs := range errors {
-													nodeID := objID
-													if errArray, ok := errMsgs.([]interface{}); ok {
-														for _, errMsg := range errArray {
-															if msg, ok := errMsg.(string); ok {
-																errorMsgs = append(errorMsgs, fmt.Sprintf("Node %s: %s", nodeID, msg))
-															}
-														}
-													}
-												}
-												if len(errorMsgs) > 0 {
-													return fmt.Errorf("failed to compile API code:\n%s", strings.Join(errorMsgs, "\n"))
-												}
-											}
-											errorMsg := "unknown error"
-											if msg, ok := opMap["description"].(string); ok {
-												errorMsg = msg
-											}
-											return fmt.Errorf("failed to compile API code: %s", errorMsg)
-										}
+// loadAndCompileNode performs the two-step load→compile sequence for a single
+// inline-code node. logicType is "api_code" or "git_call"; it is used as the
+// "obj" field in the API requests so the server routes them to the correct
+// handler.
+func (v *Executor) loadAndCompileNode(logicType, nodeID, lang, src string) error {
+	loadOps := []map[string]any{
+		{
+			"type":    "load",
+			"obj":     logicType,
+			"conv_id": v.ProcessID,
+			"node_id": nodeID,
+			"lang":    lang,
+			"src":     src,
+			"env":     "sandbox",
+		},
+	}
+	loadResponse, err := v.req("load_api_code", loadOps)
+	if err != nil {
+		return fmt.Errorf("failed to load %s code: %w", logicType, err)
+	}
+	if loadResponse == nil {
+		return fmt.Errorf("failed to load %s code: no response from server", logicType)
+	}
+	if requestProc, ok := loadResponse["request_proc"].(string); !ok || requestProc != "ok" {
+		return fmt.Errorf("failed to load %s code: request_proc not ok", logicType)
+	}
+	if opsArray, ok := loadResponse["ops"].([]interface{}); ok {
+		for _, op := range opsArray {
+			if opMap, ok := op.(map[string]interface{}); ok {
+				if proc, ok := opMap["proc"].(string); !ok || proc != "ok" {
+					if errors, ok := opMap["errors"].(map[string]interface{}); ok {
+						var errorMsgs []string
+						for objID, errMsgs := range errors {
+							if errArray, ok := errMsgs.([]interface{}); ok {
+								for _, errMsg := range errArray {
+									if msg, ok := errMsg.(string); ok {
+										errorMsgs = append(errorMsgs, fmt.Sprintf("Error in node %s: %s", objID, msg))
 									}
 								}
 							}
 						}
+						if len(errorMsgs) > 0 {
+							return fmt.Errorf("failed to load %s code:\n%s", logicType, strings.Join(errorMsgs, "\n"))
+						}
 					}
+					errorMsg := "unknown error"
+					if msg, ok := opMap["description"].(string); ok {
+						errorMsg = msg
+					}
+					return fmt.Errorf("failed to load %s code: %s", logicType, errorMsg)
+				}
+			}
+		}
+	}
+
+	compileOps := []map[string]any{
+		{
+			"obj":     logicType,
+			"type":    "compile",
+			"conv_id": v.ProcessID,
+			"node_id": nodeID,
+			"lang":    lang,
+			"src":     src,
+		},
+	}
+	compileResponse, err := v.req("compile_api_code", compileOps)
+	if err != nil {
+		return fmt.Errorf("failed to compile %s code: %w", logicType, err)
+	}
+	if compileResponse == nil {
+		return fmt.Errorf("failed to compile %s code: no response from server", logicType)
+	}
+	if requestProc, ok := compileResponse["request_proc"].(string); !ok || requestProc != "ok" {
+		return fmt.Errorf("failed to compile %s code: request_proc not ok", logicType)
+	}
+	if opsArray, ok := compileResponse["ops"].([]interface{}); ok {
+		for _, op := range opsArray {
+			if opMap, ok := op.(map[string]interface{}); ok {
+				if proc, ok := opMap["proc"].(string); !ok || proc != "ok" {
+					if errors, ok := opMap["errors"].(map[string]interface{}); ok {
+						var errorMsgs []string
+						for objID, errMsgs := range errors {
+							if errArray, ok := errMsgs.([]interface{}); ok {
+								for _, errMsg := range errArray {
+									if msg, ok := errMsg.(string); ok {
+										errorMsgs = append(errorMsgs, fmt.Sprintf("Node %s: %s", objID, msg))
+									}
+								}
+							}
+						}
+						if len(errorMsgs) > 0 {
+							return fmt.Errorf("failed to compile %s code:\n%s", logicType, strings.Join(errorMsgs, "\n"))
+						}
+					}
+					errorMsg := "unknown error"
+					if msg, ok := opMap["description"].(string); ok {
+						errorMsg = msg
+					}
+					return fmt.Errorf("failed to compile %s code: %s", logicType, errorMsg)
 				}
 			}
 		}

--- a/plugins/corezoid/mcp-server/executor_process.go
+++ b/plugins/corezoid/mcp-server/executor_process.go
@@ -344,9 +344,9 @@ func (validator *Executor) ProcessJSON(filePath, jsonContent string) (newProcess
 		return nil, err
 	}
 
-	commitResponse := validator.Commit()
-	if commitResponse == nil {
-		return nil, fmt.Errorf("failed to commit changes: no response from server")
+	commitResponse, commitErr := validator.Commit()
+	if commitErr != nil {
+		return nil, fmt.Errorf("failed to commit changes: %w", commitErr)
 	}
 	if requestProc, ok := commitResponse["request_proc"].(string); !ok || requestProc != "ok" {
 		err = fmt.Errorf("failed to commit changes: request_proc not ok")
@@ -502,7 +502,9 @@ func (v *Executor) SetParams(params []interface{}) error {
 }
 
 // Commit confirms and finalizes changes to a process.
-func (v *Executor) Commit() map[string]interface{} {
+// It returns the server response and any error so callers can report the
+// real failure reason instead of the generic "no response from server" message.
+func (v *Executor) Commit() (map[string]interface{}, error) {
 	ops := []map[string]any{
 		{
 			"type":    "confirm",
@@ -517,17 +519,19 @@ func (v *Executor) Commit() map[string]interface{} {
 	response, err := v.req("commit_process", ops)
 	if err != nil {
 		logger.Error("Failed to commit changes: %v", err)
-		return nil
+		return nil, fmt.Errorf("commit_process API error: %w", err)
 	}
 	if response == nil {
 		logger.Error("Failed to commit changes: no response from server")
-	} else if v.Debug {
+		return nil, fmt.Errorf("commit_process: no response from server")
+	}
+	if v.Debug {
 		if requestProc, ok := response["request_proc"].(string); ok {
 			logger.Debug("Commit response received, request_proc=%s", requestProc)
 		}
 	}
 	logger.Debug("Changes committed, processID=%d", v.ProcessID)
-	return response
+	return response, nil
 }
 
 func (v *Executor) DeleteVersion(ver int) {


### PR DESCRIPTION
## Summary

- `CompileAPICode` now handles `git_call` logics with inline code (`src`/`code` field populated), running the same **load → compile** sequence before `commit_process` that `api_code` nodes already benefit from. Without this, the server attempted to compile inline JS/Python/Go during the commit call, which caused it to hang or return no response.
- `Commit()` signature changed from `Commit() map[string]interface{}` to `Commit() (map[string]interface{}, error)` so the actual API error is propagated to the caller instead of being silently discarded and replaced with the generic "no response from server" message.

## Context

tool: push-process | version: 2.3.5 | install: 6054ea78-1ace-49ad-8e81-e64cdb7b97d6

Reproduced twice consecutively on a process containing a `git_call` node after a minor inline JS edit (no schema changes). `lint-process` passed; `pull-process` worked. Error: `Error deploying process: failed to commit changes: no response from server`.

## Changes

### executor_nodes.go
- Refactored `CompileAPICode` to extract load+compile logic into a private `loadAndCompileNode(logicType, nodeID, lang, src)` helper.
- Extended the logic-type check from `lt == "api_code"` to also match `lt == "git_call"`.
- `git_call` nodes without inline code (`src`/`code` empty) are skipped — those reference an external git repo and compile server-side at task execution time.

### executor_process.go
- `Commit()` now returns `(map[string]interface{}, error)`. Network and API errors are wrapped and returned instead of logged-and-dropped.
- `ProcessJSON` updated to consume the error return.

### executor_mock_test.go
- `TestCommit_ReturnsMap` updated for new signature; added `TestCommit_PropagatesError`.
- `TestCompileAPICode_GitCallInlineCode` — verifies 2 API calls (load+compile) for a `git_call` node with inline code.
- `TestCompileAPICode_GitCallNoInlineCode` — verifies 0 API calls for external-repo `git_call` (no `src`/`code`).

## Checklist
- [x] `go build` passes
- [x] `go vet` passes
- [x] `go test ./...` passes (all existing + new tests green)
- [x] No version bump / CHANGELOG.md change included
- [x] No credentials or private URLs introduced