### PR TITLE
fix(schema): allow object cast in go_if_const conditions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "corezoid",
       "source": "./plugins/corezoid",
       "description": "Corezoid BPM platform skills, MCP server, docs, and samples for Claude Code.",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "author": {
         "name": "Corezoid",
         "email": "support@corezoid.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.7.1]
+
+- Fix: `go_if_const` condition schema was missing `"object"` from the allowed `cast` enum, even though sibling schemas (`api`, `set_param`) already allow `object` for `extra_type` — caused `push-process` to reject processes with pre-existing, valid object-typed conditions.
+
 ## [2.7.0]
 
 - Feat: AWS Kiro support — the same plugin payload now installs on Kiro alongside Claude Code and Codex via a symmetric overlay (`plugins/corezoid/.kiro-plugin/plugin.json`, `plugins/corezoid/.mcp.kiro.json`, `plugins/corezoid/steering/corezoid.md`, and a root-level `POWER.md` distribution manifest for kiro.dev/powers).

--- a/plugins/corezoid/.claude-plugin/plugin.json
+++ b/plugins/corezoid/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "corezoid",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Corezoid AI Documentation and Templates — skills and MCP server for working with Corezoid BPM processes.",
   "author": {
     "name": "Corezoid",

--- a/plugins/corezoid/mcp-server/json-schema/logics/go_if_const.json
+++ b/plugins/corezoid/mcp-server/json-schema/logics/go_if_const.json
@@ -39,7 +39,7 @@
           },
           "cast": {
             "type": "string",
-            "enum": ["string", "number", "boolean", "array"],
+            "enum": ["string", "number", "boolean", "array", "object"],
             "description": "Data type to cast the parameter to for comparison"
           }
         }


### PR DESCRIPTION
## Summary
- `go_if_const` condition schema only allowed `string`/`number`/`boolean`/`array` for `cast`, while sibling schemas (`api`, `set_param`) already allow `object` for `extra_type`.
- This mismatch made `push-process` reject processes with pre-existing, valid object-typed conditions (e.g. `{{x}} not_eq \"{}\"`), even though the live Corezoid engine accepts them.

## Related issues / context
- Found while deploying a process (IN market) that had a long-standing `cast: \"object\"` condition created via the Corezoid UI — `push-process` blocked an unrelated fix until the condition was manually changed to `cast: \"string\"` in the UI.

## Test plan
- [x] Built the MCP server locally with this fix and confirmed `push-process` now succeeds on a live process containing a `go_if_const` condition with `\"cast\": \"object\"` (previously failed with `JSON schema validation failed`)
- [x] Confirmed existing `string`/`number`/`boolean`/`array` casts still validate unchanged

@MalishkinMV mind taking a look?

🤖 Generated with [Claude Code](https://claude.com/claude-code)