### PR TITLE
fix(mcp): accept absolute paths that resolve inside the project root

### DIFF
--- a/plugins/corezoid/mcp-server/mcp_utils.go
+++ b/plugins/corezoid/mcp-server/mcp_utils.go
@@ -9,35 +9,72 @@ import (
 	"strings"
 )
 
-// confineToWorkdir is a lexical guard against path-traversal in LLM-supplied
-// path arguments. It rejects absolute paths and any relative path whose
-// cleaned form starts with ".." (i.e. escapes the working directory).
+// confineToWorkdir is a guard against path-traversal in LLM-supplied path
+// arguments. Relative paths are checked lexically (the cleaned form must not
+// start with ".."). Absolute paths are accepted only when they resolve inside
+// the working directory, in which case they are rewritten to the equivalent
+// relative path.
 //
 // Threat model: a prompt-injected LLM might call lint-process with
 // process_path="../../etc/passwd" or pull-folder writing to ~/.ssh/. Handlers
 // run with the user's full file permissions, so anything the path argument
 // says, the OS will do. This check is defence-in-depth: it blocks the
-// path-traversal escape without restricting legitimate relative paths inside
-// the workspace.
+// path-traversal escape without restricting legitimate paths inside the
+// workspace.
 //
-// Design note: absolute paths are rejected outright rather than allowed-if-
-// under-cwd. The "under-cwd" form invites subtle symlink edge cases (on
-// macOS in particular, /var/folders/... and /private/var/folders/... are the
-// same directory via symlink, breaking lexical Rel comparison) and the MCP
-// server always runs with cwd set to the project root via COREZOID_WORK_DIR,
-// so legitimate paths are naturally relative.
+// Design note: the absolute-path comparison resolves symlinks on both sides
+// (filepath.EvalSymlinks) before filepath.Rel. A purely lexical comparison is
+// unsound — on macOS /var/folders/... and /private/var/folders/... are the
+// same directory via symlink — which is why earlier versions rejected
+// absolute paths outright. Resolving both sides removes that failure mode
+// while keeping the guarantee: a path that escapes cwd is still rejected.
+// Callers (IDE agents in particular) routinely produce absolute paths for
+// files they just read or wrote inside the project; forcing them to guess the
+// project-relative spelling caused a needless error/retry loop.
 func confineToWorkdir(p string) (string, error) {
 	if p == "" {
 		return p, nil
 	}
 	if filepath.IsAbs(p) {
-		return "", fmt.Errorf("absolute paths are not allowed (received %q); pass a path relative to the project root", p)
+		rel, err := relativeToCwd(p)
+		if err != nil {
+			return "", fmt.Errorf("absolute path %q is not inside the working directory; pass a path relative to the project root (%v)", p, err)
+		}
+		return rel, nil
 	}
 	clean := filepath.Clean(p)
 	if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
 		return "", fmt.Errorf("path %q escapes working directory", p)
 	}
 	return p, nil
+}
+
+// relativeToCwd converts an absolute path to its cwd-relative form, resolving
+// symlinks on both sides so the comparison holds on macOS (/var → /private/var)
+// and similar layouts. The path's parent directory must exist — EvalSymlinks
+// needs a real directory — but the file itself may not (write targets).
+// Returns an error when the path lies outside the working directory.
+func relativeToCwd(p string) (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine working directory: %v", err)
+	}
+	cwdReal, err := filepath.EvalSymlinks(cwd)
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve working directory: %v", err)
+	}
+	dirReal, err := filepath.EvalSymlinks(filepath.Dir(p))
+	if err != nil {
+		return "", fmt.Errorf("cannot resolve path: %v", err)
+	}
+	rel, err := filepath.Rel(cwdReal, filepath.Join(dirReal, filepath.Base(p)))
+	if err != nil {
+		return "", fmt.Errorf("cannot relativize path: %v", err)
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("path resolves outside the working directory")
+	}
+	return rel, nil
 }
 
 // resolveFolderIDFromDir looks for a file matching <id>_<name>.folder.json or

--- a/plugins/corezoid/mcp-server/mcp_utils_test.go
+++ b/plugins/corezoid/mcp-server/mcp_utils_test.go
@@ -232,17 +232,47 @@ func TestConfineToWorkdir_Allows(t *testing.T) {
 	}
 }
 
-func TestConfineToWorkdir_RejectsAllAbsolute(t *testing.T) {
-	// Absolute paths are rejected unconditionally — even those that point
-	// inside cwd — to dodge symlink edge cases (macOS /var → /private/var).
+func TestConfineToWorkdir_AllowsAbsoluteInsideCwd(t *testing.T) {
+	// Absolute paths pointing inside cwd are accepted and rewritten to the
+	// relative form. On macOS t.TempDir() lives under /var/folders/... which
+	// is a symlink to /private/var/folders/... — exactly the case that made a
+	// lexical comparison unsound — so this test exercises the EvalSymlinks
+	// resolution for real.
 	dir := t.TempDir()
 	orig, _ := os.Getwd()
 	os.Chdir(dir)                        //nolint:errcheck
 	t.Cleanup(func() { os.Chdir(orig) }) //nolint:errcheck
 
-	abs := filepath.Join(dir, "ok.conv.json")
-	if _, err := confineToWorkdir(abs); err == nil {
-		t.Error("expected absolute path to be rejected, got nil error")
+	if err := os.MkdirAll(filepath.Join(dir, "sub"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	cases := map[string]string{
+		filepath.Join(dir, "ok.conv.json"):          "ok.conv.json",
+		filepath.Join(dir, "sub", "in.conv.json"):   filepath.Join("sub", "in.conv.json"),
+	}
+	for abs, want := range cases {
+		got, err := confineToWorkdir(abs)
+		if err != nil {
+			t.Errorf("confineToWorkdir(%q) = err %v, want nil", abs, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("confineToWorkdir(%q) = %q, want %q", abs, got, want)
+		}
+	}
+}
+
+func TestConfineToWorkdir_RejectsAbsoluteOutsideCwd(t *testing.T) {
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(dir)                        //nolint:errcheck
+	t.Cleanup(func() { os.Chdir(orig) }) //nolint:errcheck
+
+	outside := t.TempDir() // sibling temp dir — exists, but not under cwd
+	for _, abs := range []string{filepath.Join(outside, "x.conv.json"), "/etc/passwd"} {
+		if _, err := confineToWorkdir(abs); err == nil {
+			t.Errorf("confineToWorkdir(%q) = nil, want error", abs)
+		}
 	}
 }
 

--- a/plugins/corezoid/mcp-server/tools_registry.go
+++ b/plugins/corezoid/mcp-server/tools_registry.go
@@ -60,13 +60,13 @@ var toolRegistry = []mcpTool{
 	},
 	{
 		Name:        "push-process",
-		Description: "Validate and deploy a process file to Corezoid.",
+		Description: "Validate and deploy a process file to Corezoid. Note: the server regenerates node IDs on every push and the local file is rewritten in place with the server's canonical scheme — reference nodes by title when iterating, and re-read the file after a push instead of reusing old node IDs.",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
 				"process_path": map[string]interface{}{
 					"type":        "string",
-					"description": "Relative path to the process JSON file.",
+					"description": "Path to the process JSON file, relative to the project root (absolute paths are accepted when they point inside the project).",
 				},
 			},
 			"required": []string{"process_path"},


### PR DESCRIPTION
## Problem

Agents (IDE tooling especially) routinely pass **absolute paths** for files they just read or wrote inside the project. `confineToWorkdir` rejected every absolute path outright, producing a two-step error dance on push-process/lint-process/run-task:

1. omit the path → `multiple .conv.json files found in current directory — pass process_path explicitly`
2. pass the absolute path the agent has at hand → `absolute paths are not allowed`
3. only the third attempt (manually relativised path) works

## Why it was rejected before, and why this is safe

The blanket rejection existed to dodge symlink edge cases in a lexical under-cwd comparison — on macOS `/var/folders/...` and `/private/var/folders/...` are the same directory via symlink, and `filepath.Rel` on unresolved paths lies about containment (the design note in the code documented exactly this).

This PR resolves symlinks on **both** sides with `filepath.EvalSymlinks` before `filepath.Rel`, which removes that failure mode instead of working around it:

- absolute path **inside** the project → accepted, rewritten to the equivalent relative path
- absolute path **outside** the project (including via symlink) → still rejected
- relative traversal (`../..`) → still rejected, unchanged

The path-traversal threat model (prompt-injected `process_path="../../etc/passwd"`) keeps the same guarantees.

## Also included

`push-process` tool description now documents that the server **regenerates node IDs on every push** and the local file is rewritten in place with the canonical scheme — so agents stop reusing stale node IDs and don't need a re-pull.

## Testing

- new tests: absolute-inside-cwd accepted (`t.TempDir()` lives under the real macOS `/var` symlink, so the EvalSymlinks path is exercised for real), absolute-outside-cwd rejected; existing traversal tests unchanged and green
- `go test ./...` green
- verified live: `lint-process process_path=/Users/.../684494_mcp-plugin-test/1880458_mcp-test-async.json` works; `process_path=/etc/hosts` → "absolute path is not inside the working directory"

🤖 Generated with [Claude Code](https://claude.com/claude-code)