### PR TITLE
fix(manifests): sync codex/marketplace manifests to 2.7.1

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "corezoid",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "license": "MIT",
       "source": {
         "source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "corezoid",
       "source": "./plugins/corezoid",
       "description": "Corezoid BPM platform skills, MCP server, docs, and samples for Claude Code.",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "author": {
         "name": "Corezoid",
         "email": "support@corezoid.com"

--- a/plugins/corezoid/.codex-plugin/plugin.json
+++ b/plugins/corezoid/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "corezoid",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Corezoid BPM platform assistant. Exposes Corezoid operations as an MCP server and provides skills for creating, editing, reviewing, and deploying business processes.",
   "author": {
     "name": "Corezoid",


### PR DESCRIPTION
## Problem

`main` currently has **manifest version drift**: `plugins/corezoid/.claude-plugin/plugin.json` is at `2.7.1`, while `plugins/corezoid/.codex-plugin/plugin.json`, `.claude-plugin/marketplace.json` and `.agents/plugins/marketplace.json` stayed at `2.7.0` (came in with today's merges).

The **Validate JSON manifests** CI job compares all four and fails — and since PR checks run on the merge commit with `main`, it currently fails on **every open PR** regardless of its content (see #54, #55, #56 runs: `ERROR: version mismatch across manifests`).

## Fix

Bump the three lagging manifests to `2.7.1` — one version string per file, nothing else.

After this merges, re-running the manifest check on open PRs should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)