### PR TITLE
fix(mcp): push-process reliability — surface commit errors, write file only after commit

### DIFF
--- a/plugins/corezoid/mcp-server/executor_gitcall_integration_test.go
+++ b/plugins/corezoid/mcp-server/executor_gitcall_integration_test.go
@@ -132,8 +132,8 @@ func deployAndRunGitCall(t *testing.T, v *Executor, conv int, ws, start, final s
 	}
 	t.Logf("[%s] build finished in %s", c.lang, time.Since(buildStart).Round(time.Second))
 
-	if resp := v.Commit(); resp == nil || gitCallFirstOp(resp)["proc"] == "error" {
-		t.Fatalf("[%s] commit rejected after build: %v", c.lang, resp)
+	if resp, err := v.Commit(); err != nil || resp == nil || gitCallFirstOp(resp)["proc"] == "error" {
+		t.Fatalf("[%s] commit rejected after build: %v (err: %v)", c.lang, resp, err)
 	}
 
 	ref := c.lang + "-it-" + strconv.FormatInt(time.Now().UnixNano(), 10)

--- a/plugins/corezoid/mcp-server/executor_mock_test.go
+++ b/plugins/corezoid/mcp-server/executor_mock_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -340,19 +341,6 @@ func TestSetParams_Error(t *testing.T) {
 	}
 }
 
-func TestCommit_ReturnsMap(t *testing.T) {
-	_, e := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
-		return map[string]interface{}{
-			"request_proc": "ok",
-			"ops":          []interface{}{map[string]interface{}{"proc": "ok"}},
-		}
-	})
-
-	// Commit returns map[string]interface{} (nil on failure).
-	result := e.Commit()
-	_ = result // may be nil if response has no version data; just ensure no panic
-}
-
 func TestDeleteVersion_NoError(t *testing.T) {
 	_, e := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
 		return map[string]interface{}{
@@ -429,5 +417,53 @@ func TestGetProjectIDByStageID_OK(t *testing.T) {
 	id := e.GetProjectIDByStageID(1)
 	if id != 999 {
 		t.Errorf("expected 999, got %d", id)
+	}
+}
+
+// ---- Commit ------------------------------------------------------------------
+
+// TestCommit_SurfacesServerError verifies that a server-side commit rejection
+// (e.g. a timer below the platform minimum, or an invalid api_rpc_reply shape)
+// reaches the caller as an error carrying the server's exact message — not a
+// silent nil that the push handler can only report as "no response from server".
+func TestCommit_SurfacesServerError(t *testing.T) {
+	_, e := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
+		return map[string]interface{}{
+			"request_proc": "ok",
+			"ops": []interface{}{map[string]interface{}{
+				"proc": "error",
+				"errors": map[string]interface{}{
+					"6a4fa136b677ac77708b234c": []interface{}{
+						"Key 'value'. 'Timer value 15 sec is less than minimum limit 30 sec'",
+					},
+				},
+			}},
+		}
+	})
+
+	resp, err := e.Commit()
+	if err == nil {
+		t.Fatalf("expected error from rejected commit, got nil (resp=%v)", resp)
+	}
+	if !strings.Contains(err.Error(), "Timer value 15 sec is less than minimum limit 30 sec") {
+		t.Errorf("server message lost, got: %v", err)
+	}
+}
+
+// TestCommit_OK verifies the happy path returns the response and no error.
+func TestCommit_OK(t *testing.T) {
+	_, e := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
+		return map[string]interface{}{
+			"request_proc": "ok",
+			"ops":          []interface{}{map[string]interface{}{"proc": "ok"}},
+		}
+	})
+
+	resp, err := e.Commit()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("expected non-nil response")
 	}
 }

--- a/plugins/corezoid/mcp-server/executor_process.go
+++ b/plugins/corezoid/mcp-server/executor_process.go
@@ -186,8 +186,11 @@ func (v *Executor) ExportProcess() (any, error) {
 // Cancellation is checked at the top and between major API-heavy steps so a
 // client-side cancel doesn't have to wait for the entire deploy to finish.
 func (validator *Executor) ProcessJSON(filePath, jsonContent string) (newProcessData map[string]interface{}, err error) {
+	// committed flips to true once Commit succeeds: from that point a failure
+	// (e.g. updating the local file) must NOT drop the just-committed version.
+	committed := false
 	defer func() {
-		if err != nil {
+		if err != nil && !committed {
 			if validator != nil {
 				validator.DeleteVersion(validator.Version)
 			}
@@ -310,10 +313,11 @@ func (validator *Executor) ProcessJSON(filePath, jsonContent string) (newProcess
 		jsonContent = strings.Replace(jsonContent, "\""+inID+"\"", "\""+extInfo.ServerID+"\"", -1)
 	}
 	if changed {
-		err = os.WriteFile(filePath, []byte(jsonContent), 0644)
-		if err != nil {
-			return nil, fmt.Errorf("failed to write file: %v", err)
-		}
+		// Re-parse the id-remapped scheme in memory now, but hold off writing
+		// it to disk until the commit succeeds. Writing here left the local
+		// file pointing at server node IDs of a draft that the deferred
+		// DeleteVersion removes whenever any later step (modify, compile,
+		// commit) fails — a silent desync between the file and the server.
 		err = json.Unmarshal([]byte(jsonContent), &newProcessData)
 		if err != nil {
 			logger.Error("Failed to parse1 JSON: %v", err)
@@ -400,6 +404,17 @@ func (validator *Executor) ProcessJSON(filePath, jsonContent string) (newProcess
 		}
 		if len(errorMsgs) > 0 {
 			err = fmt.Errorf("failed to commit changes: %s", strings.Join(errorMsgs, "\n"))
+			return nil, err
+		}
+	}
+
+	committed = true
+
+	// The deploy is committed — now it is safe to sync the local file to the
+	// server's canonical node IDs.
+	if changed {
+		if werr := os.WriteFile(filePath, []byte(jsonContent), 0644); werr != nil {
+			err = fmt.Errorf("process deployed, but failed to update the local file with server node IDs: %v", werr)
 			return nil, err
 		}
 	}

--- a/plugins/corezoid/mcp-server/executor_process.go
+++ b/plugins/corezoid/mcp-server/executor_process.go
@@ -338,9 +338,10 @@ func (validator *Executor) ProcessJSON(filePath, jsonContent string) (newProcess
 		return nil, err
 	}
 
+	// CompileAPICode already prefixes its errors with "failed to compile API
+	// code:" — wrapping again produced a doubled prefix in the tool output.
 	err = validator.CompileAPICode(nodes)
 	if err != nil {
-		err = fmt.Errorf("failed to compile API code: %v", err)
 		return nil, err
 	}
 
@@ -351,7 +352,10 @@ func (validator *Executor) ProcessJSON(filePath, jsonContent string) (newProcess
 		return nil, fmt.Errorf("failed to build git_call node(s): %v", err)
 	}
 
-	commitResponse := validator.Commit()
+	commitResponse, err := validator.Commit()
+	if err != nil {
+		return nil, fmt.Errorf("failed to commit changes: %v", err)
+	}
 	if commitResponse == nil {
 		return nil, fmt.Errorf("failed to commit changes: no response from server")
 	}
@@ -508,8 +512,15 @@ func (v *Executor) SetParams(params []interface{}) error {
 	return nil
 }
 
-// Commit confirms and finalizes changes to a process.
-func (v *Executor) Commit() map[string]interface{} {
+// Commit confirms and finalizes changes to a process. The server rejects a
+// commit with a precise, actionable reason (schema-shape violations, timer
+// minimums, invalid set_param pairs, …) delivered through the op error that
+// v.req converts into a Go error — so that error is returned to the caller
+// verbatim instead of being demoted to a log line. Earlier versions logged it
+// and returned nil, which the caller could only report as the opaque
+// "no response from server", turning every server-side rejection into a
+// dead-end mystery.
+func (v *Executor) Commit() (map[string]interface{}, error) {
 	ops := []map[string]any{
 		{
 			"type":    "confirm",
@@ -524,17 +535,21 @@ func (v *Executor) Commit() map[string]interface{} {
 	response, err := v.req("commit_process", ops)
 	if err != nil {
 		logger.Error("Failed to commit changes: %v", err)
-		return nil
+		return nil, err
 	}
 	if response == nil {
+		// A (nil, nil) from req would otherwise fall through to the success
+		// debug line below — a false "Changes committed" in the log.
 		logger.Error("Failed to commit changes: no response from server")
-	} else if v.Debug {
+		return nil, fmt.Errorf("no response from server")
+	}
+	if v.Debug {
 		if requestProc, ok := response["request_proc"].(string); ok {
 			logger.Debug("Commit response received, request_proc=%s", requestProc)
 		}
 	}
 	logger.Debug("Changes committed, processID=%d", v.ProcessID)
-	return response
+	return response, nil
 }
 
 func (v *Executor) DeleteVersion(ver int) {


### PR DESCRIPTION
Combines two push-process reliability fixes that tell one story — a failed push must not lie and must not corrupt local state. The two changes touch the same code (`ProcessJSON` / `Commit`) and conflicted as separate PRs; folded together per review plan. Supersedes #59.

## 1. Surface the server's commit rejection (was: "no response from server")

When `commit_process` fails, the server replies with a precise, actionable reason (schema-shape violation, "Timer value 15 sec is less than minimum limit 30 sec", "Key 'extra_headers' is required", …). `Commit()` logged that to `~/.corezoid/mcp.log` and returned `nil`, so the user saw only:

```
Error deploying process: failed to commit changes: no response from server
```

`Commit()` now returns `(response, error)` and the handler surfaces the real reason.

## 2. Write server node IDs to the local file only after a successful commit

`ProcessJSON` rewrote the local file with server-assigned node IDs *before* modify/compile/commit. Any later failure triggered the deferred `DeleteVersion`, which dropped those very nodes server-side — leaving the local file pointing at node IDs that no longer exist. Retries then operated on a poisoned file (field-observed as the unrecoverable `err_node_id … does not exist` loop). The write now happens only after `committed = true`.

## Live verification (sandbox project 685225, dev stage 685226)

Pushed a process whose api logic lacks `extra_headers` (server rejects the commit):

- Before: `failed to commit changes: no response from server`, file rewritten with server IDs of the rolled-back draft.
- After: `failed to commit changes: API op error: Node …: Key 'extra_headers' is required`, and the local file keeps all 7 local node IDs (0 server IDs written).

## Tests

`go build`, `go test`, `go test -race` — green on the combined branch (`TestCommit_SurfacesServerError`, `TestCommit_OK`, writeback tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)