### PR TITLE
fix(mcp): write server node IDs to the local file only after a successful commit

### DIFF
--- a/plugins/corezoid/mcp-server/executor_process.go
+++ b/plugins/corezoid/mcp-server/executor_process.go
@@ -186,8 +186,11 @@ func (v *Executor) ExportProcess() (any, error) {
 // Cancellation is checked at the top and between major API-heavy steps so a
 // client-side cancel doesn't have to wait for the entire deploy to finish.
 func (validator *Executor) ProcessJSON(filePath, jsonContent string) (newProcessData map[string]interface{}, err error) {
+	// committed flips to true once Commit succeeds: from that point a failure
+	// (e.g. updating the local file) must NOT drop the just-committed version.
+	committed := false
 	defer func() {
-		if err != nil {
+		if err != nil && !committed {
 			if validator != nil {
 				validator.DeleteVersion(validator.Version)
 			}
@@ -310,10 +313,11 @@ func (validator *Executor) ProcessJSON(filePath, jsonContent string) (newProcess
 		jsonContent = strings.Replace(jsonContent, "\""+inID+"\"", "\""+extInfo.ServerID+"\"", -1)
 	}
 	if changed {
-		err = os.WriteFile(filePath, []byte(jsonContent), 0644)
-		if err != nil {
-			return nil, fmt.Errorf("failed to write file: %v", err)
-		}
+		// Re-parse the id-remapped scheme in memory now, but hold off writing
+		// it to disk until the commit succeeds. Writing here left the local
+		// file pointing at server node IDs of a draft that the deferred
+		// DeleteVersion removes whenever any later step (modify, compile,
+		// commit) fails — a silent desync between the file and the server.
 		err = json.Unmarshal([]byte(jsonContent), &newProcessData)
 		if err != nil {
 			logger.Error("Failed to parse1 JSON: %v", err)
@@ -396,6 +400,17 @@ func (validator *Executor) ProcessJSON(filePath, jsonContent string) (newProcess
 		}
 		if len(errorMsgs) > 0 {
 			err = fmt.Errorf("failed to commit changes: %s", strings.Join(errorMsgs, "\n"))
+			return nil, err
+		}
+	}
+
+	committed = true
+
+	// The deploy is committed — now it is safe to sync the local file to the
+	// server's canonical node IDs.
+	if changed {
+		if werr := os.WriteFile(filePath, []byte(jsonContent), 0644); werr != nil {
+			err = fmt.Errorf("process deployed, but failed to update the local file with server node IDs: %v", werr)
 			return nil, err
 		}
 	}


### PR DESCRIPTION
## Problem

`push-process` rewrote the local `.conv.json` with the server's regenerated node IDs right after `CreateNodesFromJSON` — before modify/compile/commit. When any later step failed, the deferred `DeleteVersion` dropped the draft those IDs belonged to, leaving the local file **silently pointing at node IDs that no longer exist anywhere**. The user discovers the desync only on the next confusing push. (Reproduced live: a push failing at commit still rewrote all node IDs in the file.)

## Fix

- the id-remapped scheme is still re-parsed **in memory** at the same point (ModifyNodes needs it); only the `os.WriteFile` moves to after a successful `Commit`
- new `committed` guard: a post-commit failure (e.g. the file write itself) no longer triggers the deferred `DeleteVersion` of an already-committed version
- a post-commit write failure reports `process deployed, but failed to update the local file …` instead of masquerading as a deploy failure

## Verified live (dev, process 1882225)

- failing push (timer below platform minimum): file keeps its original node IDs byte-for-byte (before the fix: IDs regenerated despite the failure)
- successful push with fresh local IDs: file rewritten with server IDs exactly as before the change

`go build` / `go vet` / `go test ./...` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)