### PR TITLE
fix(schema): allow null for node-level extra — the platform emits it

### DIFF
--- a/plugins/corezoid/mcp-server/json-schema/node.json
+++ b/plugins/corezoid/mcp-server/json-schema/node.json
@@ -39,8 +39,8 @@
       "description": "Y coordinate on canvas"
     },
     "extra": {
-      "type": "string",
-      "description": "UI settings in JSON string format"
+      "type": ["string", "null"],
+      "description": "UI settings in JSON string format. The platform itself emits null for some nodes (pull-process writes it verbatim), so null must round-trip."
     },
     "options": {
       "type": ["string", "null"],

--- a/plugins/corezoid/mcp-server/lint_test.go
+++ b/plugins/corezoid/mcp-server/lint_test.go
@@ -161,3 +161,36 @@ func TestFormatLintResult_Golden(t *testing.T) {
 		})
 	}
 }
+
+// TestLintProcess_NodeExtraNull verifies that a node-level "extra": null passes
+// schema validation. The platform itself emits null for some nodes, and
+// pull-process writes it verbatim — so the plugin must accept its own pull
+// output (previously: 'at /scheme/nodes/0/extra: got null, want string').
+func TestLintProcess_NodeExtraNull(t *testing.T) {
+	f, err := os.CreateTemp("", "extra-null-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	f.WriteString(`{
+		"obj_type": 1, "obj_id": 1, "conv_type": "process", "title": "extra-null", "status": "active",
+		"params": [], "ref_mask": true,
+		"scheme": {"web_settings": [[],[]], "nodes": [
+			{"id": "aaaa0001513aa075cf400001", "obj_type": 1, "title": "Start", "x": 0, "y": 0,
+			 "extra": null, "options": null,
+			 "condition": {"logics": [{"type": "go", "to_node_id": "aaaa0002513aa075cf400002"}], "semaphors": []}},
+			{"id": "aaaa0002513aa075cf400002", "obj_type": 2, "title": "Final", "x": 0, "y": 100,
+			 "extra": "{}", "options": null,
+			 "condition": {"logics": [], "semaphors": []}}
+		]}
+	}`)
+	f.Close()
+
+	result, err := lintProcess(f.Name())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.SchemaValid {
+		t.Errorf("extra:null must pass schema validation, got: %s", result.SchemaError)
+	}
+}


### PR DESCRIPTION
## Problem

The node schema declared `extra` as `type: string`, but the platform itself returns `"extra": null` for some nodes and `pull-process` writes that JSON verbatim. The plugin then **rejects its own pull output** on lint-process / push-process:

```
at /scheme/nodes/0/extra: got null, want string
```

Found in multiple real pulled `.conv.json` files (not a hand-crafted edge case).

## Fix

`extra` becomes `"type": ["string", "null"]` — mirroring `options`, which already allows null for exactly this reason. `ModifyNodes` handles the null safely (extra is only forwarded when it is a non-empty string), so the round-trip is clean.

Unit test: a process with `extra: null` passes schema validation.

## Verified live (dev)

- lint on a real pulled file with `extra: null`: **No issues found** (previously: schema fail)
- push of a process carrying `extra: null`: deploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)