### PR TITLE
feat(mcp): add process snapshot support with auto-snapshot before push

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "corezoid",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "license": "MIT",
       "source": {
         "source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "corezoid",
       "source": "./plugins/corezoid",
       "description": "Corezoid BPM platform skills, MCP server, docs, and samples for Claude Code.",
-      "version": "2.7.0",
+      "version": "2.7.1",
       "author": {
         "name": "Corezoid",
         "email": "support@corezoid.com"

--- a/README.md
+++ b/README.md
@@ -248,6 +248,10 @@ validation errors, and summarize what each process does.
 | `find-principal`    | Resolve user / group / API-key name to obj_id      |
 | `invite-user`       | Invite an external email and share an object in one call |
 | `send-feedback`     | Submit feedback about plugin behavior (returns ticket id) |
+| `create-snapshot`   | Create a snapshot of the current server state of a process (auto-created before every push-process on existing processes) |
+| `list-snapshots`    | List all snapshots for a process with version, title, author and creation time |
+| `delete-snapshot`   | Delete a snapshot by its obj_id |
+| `get-snapshot`      | Get the node list of a specific snapshot for diff comparison |
 
 ## Feedback
 

--- a/plugins/corezoid/.codex-plugin/plugin.json
+++ b/plugins/corezoid/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "corezoid",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Corezoid BPM platform assistant. Exposes Corezoid operations as an MCP server and provides skills for creating, editing, reviewing, and deploying business processes.",
   "author": {
     "name": "Corezoid",

--- a/plugins/corezoid/mcp-server/executor_snapshots.go
+++ b/plugins/corezoid/mcp-server/executor_snapshots.go
@@ -1,0 +1,148 @@
+package main
+
+import "fmt"
+
+// Snapshot describes one snapshot entry returned by list-snapshots.
+type Snapshot struct {
+	ObjID      int    `json:"obj_id"`
+	Version    int    `json:"version"`
+	UserID     int    `json:"user_id"`
+	UserName   string `json:"user_name"`
+	CreateTime int64  `json:"create_time"`
+	Title      string `json:"title"`
+}
+
+// CreateSnapshot creates a snapshot of the process at its current server state.
+// Returns (obj_id, version, error).
+func (v *Executor) CreateSnapshot(convID, projectID, stageID int, title string) (int, int, error) {
+	ops := []map[string]any{
+		{
+			"type":       "create",
+			"obj":        "snapshot",
+			"conv_id":    convID,
+			"project_id": projectID,
+			"stage_id":   stageID,
+			"company_id": v.WorkspaceID,
+			"title":      title,
+		},
+	}
+	resp, err := v.req("json", ops)
+	if err != nil {
+		return 0, 0, fmt.Errorf("CreateSnapshot request failed: %w", err)
+	}
+	op, err := firstOp(resp)
+	if err != nil {
+		return 0, 0, fmt.Errorf("CreateSnapshot: %w", err)
+	}
+	objID, _ := op["obj_id"].(float64)
+	version, _ := op["version"].(float64)
+	return int(objID), int(version), nil
+}
+
+// ListSnapshots returns all snapshots for the given process.
+func (v *Executor) ListSnapshots(convID, projectID, stageID int) ([]Snapshot, error) {
+	ops := []map[string]any{
+		{
+			"type":       "list",
+			"obj":        "snapshots",
+			"conv_id":    convID,
+			"project_id": projectID,
+			"stage_id":   stageID,
+			"company_id": v.WorkspaceID,
+		},
+	}
+	resp, err := v.req("json", ops)
+	if err != nil {
+		return nil, fmt.Errorf("ListSnapshots request failed: %w", err)
+	}
+	op, err := firstOp(resp)
+	if err != nil {
+		return nil, fmt.Errorf("ListSnapshots: %w", err)
+	}
+
+	raw, _ := op["list"].([]any)
+	snapshots := make([]Snapshot, 0, len(raw))
+	for _, item := range raw {
+		m, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		s := Snapshot{}
+		if f, ok := m["obj_id"].(float64); ok {
+			s.ObjID = int(f)
+		}
+		if f, ok := m["version"].(float64); ok {
+			s.Version = int(f)
+		}
+		if f, ok := m["user_id"].(float64); ok {
+			s.UserID = int(f)
+		}
+		if str, ok := m["user_name"].(string); ok {
+			s.UserName = str
+		}
+		if f, ok := m["create_time"].(float64); ok {
+			s.CreateTime = int64(f)
+		}
+		if str, ok := m["title"].(string); ok {
+			s.Title = str
+		}
+		snapshots = append(snapshots, s)
+	}
+	return snapshots, nil
+}
+
+// DeleteSnapshot removes a snapshot by its obj_id.
+func (v *Executor) DeleteSnapshot(objID, convID, projectID, stageID int) error {
+	ops := []map[string]any{
+		{
+			"type":       "delete",
+			"obj":        "snapshot",
+			"obj_id":     objID,
+			"conv_id":    convID,
+			"project_id": projectID,
+			"stage_id":   stageID,
+			"company_id": v.WorkspaceID,
+		},
+	}
+	resp, err := v.req("json", ops)
+	if err != nil {
+		return fmt.Errorf("DeleteSnapshot request failed: %w", err)
+	}
+	if _, err := firstOp(resp); err != nil {
+		return fmt.Errorf("DeleteSnapshot: %w", err)
+	}
+	return nil
+}
+
+// GetSnapshot returns the node list of a specific snapshot.
+// The result is a raw slice of node maps for diff comparison.
+func (v *Executor) GetSnapshot(objID, convID, projectID, stageID int) ([]map[string]any, error) {
+	ops := []map[string]any{
+		{
+			"type":       "list",
+			"obj":        "snapshot",
+			"obj_id":     objID,
+			"conv_id":    convID,
+			"project_id": projectID,
+			"stage_id":   stageID,
+			"company_id": v.WorkspaceID,
+		},
+	}
+	resp, err := v.req("json", ops)
+	if err != nil {
+		return nil, fmt.Errorf("GetSnapshot request failed: %w", err)
+	}
+	op, err := firstOp(resp)
+	if err != nil {
+		return nil, fmt.Errorf("GetSnapshot: %w", err)
+	}
+
+	raw, _ := op["list"].([]any)
+	nodes := make([]map[string]any, 0, len(raw))
+	for _, item := range raw {
+		if m, ok := item.(map[string]any); ok {
+			nodes = append(nodes, m)
+		}
+	}
+	return nodes, nil
+}

--- a/plugins/corezoid/mcp-server/main.go
+++ b/plugins/corezoid/mcp-server/main.go
@@ -533,62 +533,68 @@ func fixStruct(dataBin string, inProcessID int) (string, []string) {
 	return string(dataRspBin), messages
 }
 
-// resolveAndCacheProjectID returns the project ID for the current stage.
+// resolveAndCacheProjectID returns the project ID for the current stage and an
+// optional user-visible notice when COREZOID_PROJECT_ID is written to .env for
+// the first time. The notice is non-empty only on the first API resolution.
 // Priority: in-memory cache → COREZOID_PROJECT_ID env var → API (ShowFolder).
-// On first API resolution it persists the value to .env and the process env.
 // Thread-safe: reads under RLock, writes under Lock.
-func resolveAndCacheProjectID(v *Executor) int {
+func resolveAndCacheProjectID(v *Executor) (int, string) {
 	// Fast path: cache hit (read lock only).
 	authStateMu.RLock()
 	id := cachedProjectID
 	authStateMu.RUnlock()
 	if id != 0 {
-		return id
+		return id, ""
 	}
 
 	// Try env var (no API call needed).
 	if s := os.Getenv("COREZOID_PROJECT_ID"); s != "" {
 		if parsed, err := strconv.Atoi(s); err == nil && parsed != 0 {
 			withAuthLock(func() { cachedProjectID = parsed })
-			return parsed
+			return parsed, ""
 		}
 	}
 
 	// Resolve via API — must not hold the lock during I/O.
 	if v.StageID == 0 {
-		return 0
+		return 0, ""
 	}
 	resolved := v.GetProjectIDByStageID(v.StageID)
 	if resolved == 0 {
-		return 0
+		return 0, ""
 	}
 	withAuthLock(func() { cachedProjectID = resolved })
 	os.Setenv("COREZOID_PROJECT_ID", strconv.Itoa(resolved))
-	appendToDotEnv("COREZOID_PROJECT_ID", strconv.Itoa(resolved))
-	return resolved
+	if written := appendToDotEnv("COREZOID_PROJECT_ID", strconv.Itoa(resolved)); written {
+		notice := fmt.Sprintf("(COREZOID_PROJECT_ID=%d saved to .env for future use)", resolved)
+		return resolved, notice
+	}
+	return resolved, ""
 }
 
 // appendToDotEnv appends key=value to the nearest .env file if the key is absent.
-func appendToDotEnv(key, value string) {
+// Returns true when the value was actually written (first time only).
+func appendToDotEnv(key, value string) bool {
 	envPath := findDotEnvPath()
 	if envPath == "" {
-		return
+		return false
 	}
 	data, _ := os.ReadFile(envPath)
 	// Skip if key already present.
 	for _, line := range strings.Split(string(data), "\n") {
 		if strings.HasPrefix(strings.TrimSpace(line), key+"=") {
-			return
+			return false
 		}
 	}
 	f, err := os.OpenFile(envPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		logger.Warn("[snapshot] could not update .env: %v", err)
-		return
+		return false
 	}
 	defer f.Close()
 	_, _ = fmt.Fprintf(f, "\n%s=%s\n", key, value)
 	logger.Info("[snapshot] wrote %s=%s to %s", key, value, envPath)
+	return true
 }
 
 // findDotEnvPath returns the path of the nearest .env file by walking up from cwd.

--- a/plugins/corezoid/mcp-server/main.go
+++ b/plugins/corezoid/mcp-server/main.go
@@ -160,7 +160,8 @@ func loadConfig() {
 	}
 	stageID, _ = strconv.Atoi(os.Getenv("COREZOID_STAGE_ID"))
 	insecureTLS = os.Getenv("COREZOID_INSECURE_TLS") != ""
-	cachedProjectID = 0 // reset on workspace switch so it is re-resolved
+	cachedProjectID = 0              // reset on workspace switch so it is re-resolved
+	os.Unsetenv("COREZOID_PROJECT_ID") // prevent stale process env from short-circuiting resolution
 }
 
 // runCLI executes a single MCP tool from the command line and exits.
@@ -574,7 +575,12 @@ func resolveAndCacheProjectID(v *Executor) (int, string) {
 
 // appendToDotEnv appends key=value to the nearest .env file if the key is absent.
 // Returns true when the value was actually written (first time only).
+// The read-check-write is serialised under authStateMu to prevent duplicate entries
+// from concurrent resolveAndCacheProjectID calls.
 func appendToDotEnv(key, value string) bool {
+	authStateMu.Lock()
+	defer authStateMu.Unlock()
+
 	envPath := findDotEnvPath()
 	if envPath == "" {
 		return false

--- a/plugins/corezoid/mcp-server/main.go
+++ b/plugins/corezoid/mcp-server/main.go
@@ -46,6 +46,9 @@ var debug bool
 var apigwURL string
 var stageID int
 var insecureTLS bool
+// cachedProjectID is written once (protected by authStateMu) and then read-only.
+// Reset to 0 on every loadConfig so a workspace switch gets a fresh value.
+var cachedProjectID int
 
 // authSnapshot returns a coherent snapshot of the auth-state globals taken
 // under the read lock. Callers that subsequently need to mutate state must
@@ -157,6 +160,7 @@ func loadConfig() {
 	}
 	stageID, _ = strconv.Atoi(os.Getenv("COREZOID_STAGE_ID"))
 	insecureTLS = os.Getenv("COREZOID_INSECURE_TLS") != ""
+	cachedProjectID = 0 // reset on workspace switch so it is re-resolved
 }
 
 // runCLI executes a single MCP tool from the command line and exits.
@@ -527,4 +531,101 @@ func fixStruct(dataBin string, inProcessID int) (string, []string) {
 		return dataBin, messages
 	}
 	return string(dataRspBin), messages
+}
+
+// resolveAndCacheProjectID returns the project ID for the current stage.
+// Priority: in-memory cache → COREZOID_PROJECT_ID env var → API (ShowFolder).
+// On first API resolution it persists the value to .env and the process env.
+// Thread-safe: reads under RLock, writes under Lock.
+func resolveAndCacheProjectID(v *Executor) int {
+	// Fast path: cache hit (read lock only).
+	authStateMu.RLock()
+	id := cachedProjectID
+	authStateMu.RUnlock()
+	if id != 0 {
+		return id
+	}
+
+	// Try env var (no API call needed).
+	if s := os.Getenv("COREZOID_PROJECT_ID"); s != "" {
+		if parsed, err := strconv.Atoi(s); err == nil && parsed != 0 {
+			withAuthLock(func() { cachedProjectID = parsed })
+			return parsed
+		}
+	}
+
+	// Resolve via API — must not hold the lock during I/O.
+	if v.StageID == 0 {
+		return 0
+	}
+	resolved := v.GetProjectIDByStageID(v.StageID)
+	if resolved == 0 {
+		return 0
+	}
+	withAuthLock(func() { cachedProjectID = resolved })
+	os.Setenv("COREZOID_PROJECT_ID", strconv.Itoa(resolved))
+	appendToDotEnv("COREZOID_PROJECT_ID", strconv.Itoa(resolved))
+	return resolved
+}
+
+// appendToDotEnv appends key=value to the nearest .env file if the key is absent.
+func appendToDotEnv(key, value string) {
+	envPath := findDotEnvPath()
+	if envPath == "" {
+		return
+	}
+	data, _ := os.ReadFile(envPath)
+	// Skip if key already present.
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), key+"=") {
+			return
+		}
+	}
+	f, err := os.OpenFile(envPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		logger.Warn("[snapshot] could not update .env: %v", err)
+		return
+	}
+	defer f.Close()
+	_, _ = fmt.Fprintf(f, "\n%s=%s\n", key, value)
+	logger.Info("[snapshot] wrote %s=%s to %s", key, value, envPath)
+}
+
+// findDotEnvPath returns the path of the nearest .env file by walking up from cwd.
+func findDotEnvPath() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return ""
+	}
+	dir := cwd
+	for {
+		candidate := filepath.Join(dir, ".env")
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate
+		}
+		if isProjectRoot(dir) {
+			// Create .env at project root if none exists yet.
+			return filepath.Join(dir, ".env")
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return filepath.Join(cwd, ".env")
+		}
+		dir = parent
+	}
+}
+
+// extractObjIDFromJSON returns the obj_id from a process JSON string.
+// Returns 0 if obj_id is null or missing (new / unsaved process).
+func extractObjIDFromJSON(jsonContent string) int {
+	var m map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonContent), &m); err != nil {
+		return 0
+	}
+	switch v := m["obj_id"].(type) {
+	case float64:
+		return int(v)
+	default:
+		return 0
+	}
 }

--- a/plugins/corezoid/mcp-server/mcp_handlers.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers.go
@@ -84,6 +84,12 @@ var toolHandlers = map[string]toolHandler{
 
 	// feedback
 	"send-feedback": handleSendFeedback,
+
+	// process snapshots
+	"create-snapshot": handleCreateSnapshot,
+	"list-snapshots":  handleListSnapshots,
+	"delete-snapshot": handleDeleteSnapshot,
+	"get-snapshot":    handleGetSnapshot,
 }
 
 // noAuthTools don't need any credentials. lint runs entirely on local files;

--- a/plugins/corezoid/mcp-server/mcp_handlers_process.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_process.go
@@ -188,13 +188,16 @@ func handlePushProcess(ctx context.Context, args map[string]interface{}) (string
 			title := fmt.Sprintf("pre-push %s %s", name, time.Now().UTC().Format("2006-01-02 15:04"))
 			if snapObjID, snapVer, snapErr := v.CreateSnapshot(existingObjID, projectID, v.StageID, title); snapErr != nil {
 				logger.Warn("[snapshot] auto-snapshot failed, continuing: %v", snapErr)
+				snapshotNote = fmt.Sprintf("Warning: auto-snapshot failed (%v).", snapErr)
 			} else {
 				logger.Info("[snapshot] created version %d (obj_id=%d) for process %d", snapVer, snapObjID, existingObjID)
 				snapshotNote = fmt.Sprintf("Snapshot created before push (version %d, obj_id=%d).", snapVer, snapObjID)
 			}
-			if envNotice != "" {
+			if envNotice != "" && snapshotNote != "" {
 				snapshotNote += " " + envNotice
 			}
+		} else {
+			snapshotNote = "Warning: auto-snapshot skipped (project_id unresolved)."
 		}
 	}
 

--- a/plugins/corezoid/mcp-server/mcp_handlers_process.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_process.go
@@ -105,7 +105,7 @@ func handlePullFolder(ctx context.Context, args map[string]interface{}) (string,
 
 	// Pre-warm project_id cache so push-process never needs an extra API call.
 	// folderID is the stage; its parent is the project.
-	resolveAndCacheProjectID(v)
+	_, _ = resolveAndCacheProjectID(v)
 
 	if err := downloadStageRecursively(v, folderID, "."); err != nil {
 		return fmt.Sprintf("Error fetching folder: %v", err), true
@@ -181,14 +181,19 @@ func handlePushProcess(ctx context.Context, args map[string]interface{}) (string
 
 	// Auto-snapshot: if process already exists on server (obj_id != null/0),
 	// capture current server state before overwriting. Never blocks on failure.
+	var snapshotNote string
 	if existingObjID := extractObjIDFromJSON(jsonContent); existingObjID != 0 {
-		if projectID := resolveAndCacheProjectID(v); projectID != 0 && v.StageID != 0 {
+		if projectID, envNotice := resolveAndCacheProjectID(v); projectID != 0 && v.StageID != 0 {
 			name := extractProcessNameFromPath(filePath)
-			title := fmt.Sprintf("pre-push %s %s", name, time.Now().UTC().Format("2006-01-02"))
+			title := fmt.Sprintf("pre-push %s %s", name, time.Now().UTC().Format("2006-01-02 15:04"))
 			if snapObjID, snapVer, snapErr := v.CreateSnapshot(existingObjID, projectID, v.StageID, title); snapErr != nil {
 				logger.Warn("[snapshot] auto-snapshot failed, continuing: %v", snapErr)
 			} else {
 				logger.Info("[snapshot] created version %d (obj_id=%d) for process %d", snapVer, snapObjID, existingObjID)
+				snapshotNote = fmt.Sprintf("Snapshot created before push (version %d, obj_id=%d).", snapVer, snapObjID)
+			}
+			if envNotice != "" {
+				snapshotNote += " " + envNotice
 			}
 		}
 	}
@@ -198,6 +203,9 @@ func handlePushProcess(ctx context.Context, args map[string]interface{}) (string
 	}
 
 	result := fmt.Sprintf("Process deployed successfully, ProcessID: %d", procID)
+	if snapshotNote != "" {
+		result += "\n" + snapshotNote
+	}
 	// Surface the git_call container build log so the user sees what the build
 	// service reported (progress + result), not just silence on success.
 	if len(v.gitCallBuildLog) > 0 {

--- a/plugins/corezoid/mcp-server/mcp_handlers_process.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_process.go
@@ -102,6 +102,11 @@ func handlePullFolder(ctx context.Context, args map[string]interface{}) (string,
 	}
 
 	v := NewValidator(ctx, 0)
+
+	// Pre-warm project_id cache so push-process never needs an extra API call.
+	// folderID is the stage; its parent is the project.
+	resolveAndCacheProjectID(v)
+
 	if err := downloadStageRecursively(v, folderID, "."); err != nil {
 		return fmt.Sprintf("Error fetching folder: %v", err), true
 	}
@@ -172,6 +177,20 @@ func handlePushProcess(ctx context.Context, args map[string]interface{}) (string
 
 	if err := v.BeforeValidation(jsonContent, nil); err != nil {
 		return fmt.Sprintf("Validation failed: %v", err), true
+	}
+
+	// Auto-snapshot: if process already exists on server (obj_id != null/0),
+	// capture current server state before overwriting. Never blocks on failure.
+	if existingObjID := extractObjIDFromJSON(jsonContent); existingObjID != 0 {
+		if projectID := resolveAndCacheProjectID(v); projectID != 0 && v.StageID != 0 {
+			name := extractProcessNameFromPath(filePath)
+			title := fmt.Sprintf("pre-push %s %s", name, time.Now().UTC().Format("2006-01-02"))
+			if snapObjID, snapVer, snapErr := v.CreateSnapshot(existingObjID, projectID, v.StageID, title); snapErr != nil {
+				logger.Warn("[snapshot] auto-snapshot failed, continuing: %v", snapErr)
+			} else {
+				logger.Info("[snapshot] created version %d (obj_id=%d) for process %d", snapVer, snapObjID, existingObjID)
+			}
+		}
 	}
 
 	if _, err := v.ProcessJSON(filePath, jsonContent); err != nil {

--- a/plugins/corezoid/mcp-server/mcp_handlers_snapshots.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_snapshots.go
@@ -28,7 +28,7 @@ func handleCreateSnapshot(ctx context.Context, args map[string]interface{}) (str
 	}
 
 	v := NewValidator(ctx, procID)
-	projectID := resolveAndCacheProjectID(v)
+	projectID, envNotice := resolveAndCacheProjectID(v)
 	if projectID == 0 {
 		return "Error: could not resolve project_id. Set COREZOID_PROJECT_ID in .env or ensure COREZOID_STAGE_ID is configured.", true
 	}
@@ -38,7 +38,11 @@ func handleCreateSnapshot(ctx context.Context, args map[string]interface{}) (str
 		return fmt.Sprintf("Error creating snapshot: %v", err), true
 	}
 
-	return fmt.Sprintf("Snapshot created: version %d (obj_id=%d) — %q", version, objID, title), false
+	result := fmt.Sprintf("Snapshot created: version %d (obj_id=%d) — %q", version, objID, title)
+	if envNotice != "" {
+		result += " " + envNotice
+	}
+	return result, false
 }
 
 // handleListSnapshots returns all snapshots for the given process.
@@ -54,7 +58,7 @@ func handleListSnapshots(ctx context.Context, args map[string]interface{}) (stri
 	}
 
 	v := NewValidator(ctx, procID)
-	projectID := resolveAndCacheProjectID(v)
+	projectID, _ := resolveAndCacheProjectID(v)
 	if projectID == 0 {
 		return "Error: could not resolve project_id.", true
 	}
@@ -90,7 +94,7 @@ func handleDeleteSnapshot(ctx context.Context, args map[string]interface{}) (str
 	}
 
 	v := NewValidator(ctx, procID)
-	projectID := resolveAndCacheProjectID(v)
+	projectID, _ := resolveAndCacheProjectID(v)
 	if projectID == 0 {
 		return "Error: could not resolve project_id.", true
 	}
@@ -120,7 +124,7 @@ func handleGetSnapshot(ctx context.Context, args map[string]interface{}) (string
 	}
 
 	v := NewValidator(ctx, procID)
-	projectID := resolveAndCacheProjectID(v)
+	projectID, _ := resolveAndCacheProjectID(v)
 	if projectID == 0 {
 		return "Error: could not resolve project_id.", true
 	}

--- a/plugins/corezoid/mcp-server/mcp_handlers_snapshots.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_snapshots.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// handleCreateSnapshot manually creates a snapshot for the given process.
+func handleCreateSnapshot(ctx context.Context, args map[string]interface{}) (string, bool) {
+	filePath, err := resolveProcessPath(args, "process_path")
+	if err != nil {
+		return "Error: " + err.Error(), true
+	}
+
+	procID, errMsg := extractProcessIDFromPath(filePath)
+	if errMsg != "" {
+		return errMsg, true
+	}
+
+	title, _ := args["title"].(string)
+	if title == "" {
+		name := extractProcessNameFromPath(filePath)
+		title = fmt.Sprintf("manual snapshot %s %s", name, time.Now().UTC().Format("2006-01-02 15:04"))
+	}
+
+	v := NewValidator(ctx, procID)
+	projectID := resolveAndCacheProjectID(v)
+	if projectID == 0 {
+		return "Error: could not resolve project_id. Set COREZOID_PROJECT_ID in .env or ensure COREZOID_STAGE_ID is configured.", true
+	}
+
+	objID, version, err := v.CreateSnapshot(procID, projectID, v.StageID, title)
+	if err != nil {
+		return fmt.Sprintf("Error creating snapshot: %v", err), true
+	}
+
+	return fmt.Sprintf("Snapshot created: version %d (obj_id=%d) — %q", version, objID, title), false
+}
+
+// handleListSnapshots returns all snapshots for the given process.
+func handleListSnapshots(ctx context.Context, args map[string]interface{}) (string, bool) {
+	filePath, err := resolveProcessPath(args, "process_path")
+	if err != nil {
+		return "Error: " + err.Error(), true
+	}
+
+	procID, errMsg := extractProcessIDFromPath(filePath)
+	if errMsg != "" {
+		return errMsg, true
+	}
+
+	v := NewValidator(ctx, procID)
+	projectID := resolveAndCacheProjectID(v)
+	if projectID == 0 {
+		return "Error: could not resolve project_id.", true
+	}
+
+	snapshots, err := v.ListSnapshots(procID, projectID, v.StageID)
+	if err != nil {
+		return fmt.Sprintf("Error listing snapshots: %v", err), true
+	}
+
+	if len(snapshots) == 0 {
+		return "No snapshots found for this process.", false
+	}
+
+	b, _ := json.MarshalIndent(snapshots, "", "  ")
+	return string(b), false
+}
+
+// handleDeleteSnapshot removes a snapshot by obj_id.
+func handleDeleteSnapshot(ctx context.Context, args map[string]interface{}) (string, bool) {
+	filePath, err := resolveProcessPath(args, "process_path")
+	if err != nil {
+		return "Error: " + err.Error(), true
+	}
+
+	procID, errMsg := extractProcessIDFromPath(filePath)
+	if errMsg != "" {
+		return errMsg, true
+	}
+
+	objID, err := intArg(args, "snapshot_id")
+	if err != nil {
+		return "Error: " + err.Error(), true
+	}
+
+	v := NewValidator(ctx, procID)
+	projectID := resolveAndCacheProjectID(v)
+	if projectID == 0 {
+		return "Error: could not resolve project_id.", true
+	}
+
+	if err := v.DeleteSnapshot(objID, procID, projectID, v.StageID); err != nil {
+		return fmt.Sprintf("Error deleting snapshot: %v", err), true
+	}
+
+	return fmt.Sprintf("Snapshot %d deleted.", objID), false
+}
+
+// handleGetSnapshot returns the nodes of a specific snapshot for diff comparison.
+func handleGetSnapshot(ctx context.Context, args map[string]interface{}) (string, bool) {
+	filePath, err := resolveProcessPath(args, "process_path")
+	if err != nil {
+		return "Error: " + err.Error(), true
+	}
+
+	procID, errMsg := extractProcessIDFromPath(filePath)
+	if errMsg != "" {
+		return errMsg, true
+	}
+
+	objID, err := intArg(args, "snapshot_id")
+	if err != nil {
+		return "Error: " + err.Error(), true
+	}
+
+	v := NewValidator(ctx, procID)
+	projectID := resolveAndCacheProjectID(v)
+	if projectID == 0 {
+		return "Error: could not resolve project_id.", true
+	}
+
+	nodes, err := v.GetSnapshot(objID, procID, projectID, v.StageID)
+	if err != nil {
+		return fmt.Sprintf("Error getting snapshot: %v", err), true
+	}
+
+	b, _ := json.MarshalIndent(nodes, "", "  ")
+	return string(b), false
+}
+
+// extractProcessNameFromPath returns the human-readable name from a conv.json filename.
+// "379055_Escalation.conv.json" → "Escalation"
+func extractProcessNameFromPath(filePath string) string {
+	base := filepath.Base(filePath)
+	name := strings.TrimSuffix(base, ".conv.json")
+	if idx := strings.Index(name, "_"); idx >= 0 {
+		name = name[idx+1:]
+	}
+	return name
+}

--- a/plugins/corezoid/mcp-server/snapshot_helpers_test.go
+++ b/plugins/corezoid/mcp-server/snapshot_helpers_test.go
@@ -113,9 +113,12 @@ func TestResolveAndCacheProjectID_FromEnv(t *testing.T) {
 
 	// v with StageID=0 — API path must not be reached.
 	v := &Executor{}
-	got := resolveAndCacheProjectID(v)
+	got, notice := resolveAndCacheProjectID(v)
 	if got != 188280 {
 		t.Errorf("expected 188280 from env, got %d", got)
+	}
+	if notice != "" {
+		t.Errorf("expected no notice from env path, got %q", notice)
 	}
 	if cachedProjectID != 188280 {
 		t.Errorf("expected cachedProjectID=188280, got %d", cachedProjectID)
@@ -128,8 +131,11 @@ func TestResolveAndCacheProjectID_FromCache(t *testing.T) {
 	defer func() { cachedProjectID = orig }()
 
 	v := &Executor{} // StageID=0, would fail API call
-	got := resolveAndCacheProjectID(v)
+	got, notice := resolveAndCacheProjectID(v)
 	if got != 42000 {
 		t.Errorf("expected cached value 42000, got %d", got)
+	}
+	if notice != "" {
+		t.Errorf("expected no notice from cache path, got %q", notice)
 	}
 }

--- a/plugins/corezoid/mcp-server/snapshot_helpers_test.go
+++ b/plugins/corezoid/mcp-server/snapshot_helpers_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- extractObjIDFromJSON ---
+
+func TestExtractObjIDFromJSON_ExistingProcess(t *testing.T) {
+	json := `{"obj_type":1,"obj_id":379055,"title":"Escalation"}`
+	if got := extractObjIDFromJSON(json); got != 379055 {
+		t.Errorf("expected 379055, got %d", got)
+	}
+}
+
+func TestExtractObjIDFromJSON_NewProcess(t *testing.T) {
+	json := `{"obj_type":1,"obj_id":null,"title":"New"}`
+	if got := extractObjIDFromJSON(json); got != 0 {
+		t.Errorf("expected 0 for null obj_id, got %d", got)
+	}
+}
+
+func TestExtractObjIDFromJSON_MissingField(t *testing.T) {
+	json := `{"obj_type":1,"title":"No ID field"}`
+	if got := extractObjIDFromJSON(json); got != 0 {
+		t.Errorf("expected 0 for missing obj_id, got %d", got)
+	}
+}
+
+func TestExtractObjIDFromJSON_InvalidJSON(t *testing.T) {
+	if got := extractObjIDFromJSON("not json"); got != 0 {
+		t.Errorf("expected 0 for invalid JSON, got %d", got)
+	}
+}
+
+// --- extractProcessNameFromPath ---
+
+func TestExtractProcessNameFromPath_Normal(t *testing.T) {
+	got := extractProcessNameFromPath("./folder/379055_Escalation.conv.json")
+	if got != "Escalation" {
+		t.Errorf("expected Escalation, got %q", got)
+	}
+}
+
+func TestExtractProcessNameFromPath_UnderscoreInName(t *testing.T) {
+	got := extractProcessNameFromPath("188291_Business_Process.conv.json")
+	if got != "Business_Process" {
+		t.Errorf("expected Business_Process, got %q", got)
+	}
+}
+
+func TestExtractProcessNameFromPath_NoUnderscore(t *testing.T) {
+	got := extractProcessNameFromPath("12345.conv.json")
+	if got != "12345" {
+		t.Errorf("expected 12345, got %q", got)
+	}
+}
+
+// --- appendToDotEnv ---
+
+func TestAppendToDotEnv_WritesNewKey(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	os.WriteFile(envPath, []byte("WORKSPACE_ID=abc\n"), 0644)
+
+	// Make findDotEnvPath find our temp file by changing cwd.
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+	os.Chdir(dir)
+
+	appendToDotEnv("COREZOID_PROJECT_ID", "12345")
+
+	data, _ := os.ReadFile(envPath)
+	if !strings.Contains(string(data), "COREZOID_PROJECT_ID=12345") {
+		t.Errorf("expected COREZOID_PROJECT_ID=12345 in .env, got:\n%s", data)
+	}
+}
+
+func TestAppendToDotEnv_DoesNotDuplicate(t *testing.T) {
+	dir := t.TempDir()
+	envPath := filepath.Join(dir, ".env")
+	os.WriteFile(envPath, []byte("COREZOID_PROJECT_ID=99999\n"), 0644)
+
+	orig, _ := os.Getwd()
+	defer os.Chdir(orig)
+	os.Chdir(dir)
+
+	appendToDotEnv("COREZOID_PROJECT_ID", "11111")
+
+	data, _ := os.ReadFile(envPath)
+	count := strings.Count(string(data), "COREZOID_PROJECT_ID")
+	if count != 1 {
+		t.Errorf("expected key to appear once, got %d times:\n%s", count, data)
+	}
+	if strings.Contains(string(data), "11111") {
+		t.Error("existing value should not be overwritten")
+	}
+}
+
+// --- resolveAndCacheProjectID: env var path ---
+
+func TestResolveAndCacheProjectID_FromEnv(t *testing.T) {
+	// Reset global state.
+	orig := cachedProjectID
+	cachedProjectID = 0
+	defer func() { cachedProjectID = orig }()
+
+	os.Setenv("COREZOID_PROJECT_ID", "188280")
+	defer os.Unsetenv("COREZOID_PROJECT_ID")
+
+	// v with StageID=0 — API path must not be reached.
+	v := &Executor{}
+	got := resolveAndCacheProjectID(v)
+	if got != 188280 {
+		t.Errorf("expected 188280 from env, got %d", got)
+	}
+	if cachedProjectID != 188280 {
+		t.Errorf("expected cachedProjectID=188280, got %d", cachedProjectID)
+	}
+}
+
+func TestResolveAndCacheProjectID_FromCache(t *testing.T) {
+	orig := cachedProjectID
+	cachedProjectID = 42000
+	defer func() { cachedProjectID = orig }()
+
+	v := &Executor{} // StageID=0, would fail API call
+	got := resolveAndCacheProjectID(v)
+	if got != 42000 {
+		t.Errorf("expected cached value 42000, got %d", got)
+	}
+}

--- a/plugins/corezoid/mcp-server/tools_registry.go
+++ b/plugins/corezoid/mcp-server/tools_registry.go
@@ -1070,4 +1070,72 @@ var toolRegistry = []mcpTool{
 			"required": []string{"problem"},
 		},
 	},
+	{
+		Name:        "create-snapshot",
+		Description: "Create a snapshot of the current server state of a process before making changes. Useful as a manual checkpoint before experiments. Auto-snapshot is also created automatically before every push-process on existing processes.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"process_path": map[string]interface{}{
+					"type":        "string",
+					"description": "Path to the .conv.json file.",
+				},
+				"title": map[string]interface{}{
+					"type":        "string",
+					"description": "Optional snapshot title. Defaults to 'manual snapshot <ProcessName> <datetime>'.",
+				},
+			},
+			"required": []string{"process_path"},
+		},
+	},
+	{
+		Name:        "list-snapshots",
+		Description: "List all snapshots for a process. Returns version, title, author and creation time for each snapshot.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"process_path": map[string]interface{}{
+					"type":        "string",
+					"description": "Path to the .conv.json file.",
+				},
+			},
+			"required": []string{"process_path"},
+		},
+	},
+	{
+		Name:        "delete-snapshot",
+		Description: "Delete a snapshot by its obj_id. Use list-snapshots to find the snapshot_id.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"process_path": map[string]interface{}{
+					"type":        "string",
+					"description": "Path to the .conv.json file.",
+				},
+				"snapshot_id": map[string]interface{}{
+					"type":        "integer",
+					"description": "The obj_id of the snapshot to delete (from list-snapshots).",
+				},
+			},
+			"required": []string{"process_path", "snapshot_id"},
+		},
+	},
+	{
+		Name:        "get-snapshot",
+		Description: "Get the node list of a specific snapshot for diff comparison against the current process state. Returns all nodes as they existed at snapshot time.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"process_path": map[string]interface{}{
+					"type":        "string",
+					"description": "Path to the .conv.json file.",
+				},
+				"snapshot_id": map[string]interface{}{
+					"type":        "integer",
+					"description": "The obj_id of the snapshot to retrieve (from list-snapshots).",
+				},
+			},
+			"required": []string{"process_path", "snapshot_id"},
+		},
+	},
 }

--- a/plugins/corezoid/skills/corezoid-edit/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-edit/SKILL.md
@@ -108,6 +108,8 @@ Deploy the modified process by calling MCP tool **`push-process`** with `process
 
 If deployment fails, fix the reported errors and re-run `push-process` until it succeeds. Do not skip this step or postpone it — changes exist only in memory until pushed.
 
+> **Auto-snapshot:** if the process already existed on the server (`obj_id` ≠ null), `push-process` automatically creates a snapshot of the current server state before deploying your changes. No action needed — this is transparent. The snapshot appears in the Corezoid UI and can be managed with `list-snapshots` / `get-snapshot` / `delete-snapshot`.
+
 After a successful deploy, notify the user:
 
 > "Changes have been deployed. Please **refresh the page** in Corezoid to see the updated process."

--- a/plugins/corezoid/skills/corezoid/SKILL.md
+++ b/plugins/corezoid/skills/corezoid/SKILL.md
@@ -49,6 +49,10 @@ You have access to the Corezoid API via the `corezoid` MCP server.
 | `list-api-keys` | List API keys in the workspace |
 | `find-principal` | Resolve user / group / API-key name → obj_id (call before share-object) |
 | `invite-user` | Invite an external email AND share an object in one call |
+| `create-snapshot` | Create a snapshot of a process (auto-created before every push-process on existing processes) |
+| `list-snapshots` | List all snapshots for a process |
+| `delete-snapshot` | Delete a snapshot by snapshot_id |
+| `get-snapshot` | Get snapshot node list for diff comparison against current process |
 
 ## Platform Architecture
 


### PR DESCRIPTION
## Summary

- **Auto-snapshot before push**: `push-process` automatically creates a snapshot of the current server state before deploying changes to an existing process (`obj_id != null`). New processes are skipped. Never blocks on failure.
- **4 new MCP tools** for manual snapshot management: `create-snapshot`, `list-snapshots`, `delete-snapshot`, `get-snapshot`
- **`project_id` resolution**: resolved lazily via `GetProjectIDByStageID`, cached in memory + persisted to `.env` as `COREZOID_PROJECT_ID`. Pre-warmed during `pull-folder` so no extra API call on first push.
- **Thread-safe**: `cachedProjectID` protected by `authStateMu` (RLock reads, Lock writes); reset on `loadConfig()` so workspace switches get a fresh value.

## New files

| File | Purpose |
|---|---|
| `executor_snapshots.go` | Executor methods: CreateSnapshot, ListSnapshots, DeleteSnapshot, GetSnapshot |
| `mcp_handlers_snapshots.go` | 4 MCP tool handlers + `extractProcessNameFromPath` helper |
| `snapshot_helpers_test.go` | 10 unit tests for pure helper functions |

## Test plan

- [ ] Edit an existing process and run `push-process` — verify snapshot appears in Corezoid UI (version increments on each push)
- [ ] Create a new process and run `push-process` — verify no snapshot is created (`obj_id == null` fast path)
- [ ] Run `push-process` on environment without snapshot support — verify warning in log, push succeeds
- [ ] Call `list-snapshots` on a process after several pushes — verify all versions returned
- [ ] Call `get-snapshot` with a snapshot_id — verify node list returned for diff comparison
- [ ] Call `delete-snapshot` — verify snapshot removed from `list-snapshots`
- [ ] Set `COREZOID_PROJECT_ID` in `.env` before first push — verify no `ShowFolder` API call made
- [ ] Switch workspace (re-login) — verify `cachedProjectID` reset and re-resolved correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)