### PR TITLE
feat(copy-process): add copy-process MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ validation errors, and summarize what each process does.
 | `modify-folder`     | Rename a folder or update its description          |
 | `delete-folder`     | Move a folder to the recycle bin                   |
 | `delete-process`    | Move a process or state diagram to the recycle bin |
+| `copy-process`      | Duplicate a process or state diagram without loading JSON into context (equivalent to Corezoid UI "Duplicate") |
 | `create-alias`      | Create a short alias for a process                 |
 | `create-variable`   | Create a Corezoid environment variable             |
 | `create-dashboard`  | Create a new dashboard for visualizing node metrics |
@@ -283,7 +284,7 @@ Claude Code / Codex
         ├── Workspace     list-workspaces, list-stages, list-projects,
         │                 create-project, modify-project, delete-project, show-project
         ├── Processes     pull-process, pull-folder, push-process, lint-process
-        │                 create-process, create-folder, create-alias, create-variable
+        │                 create-process, copy-process, create-folder, create-alias, create-variable
         │                 show-folder, list-folders, modify-folder, delete-folder, delete-process
         ├── Tasks         run-task, list-node-tasks, list-task-history
         │                 modify-task, delete-task

--- a/plugins/corezoid/mcp-server/executor_process.go
+++ b/plugins/corezoid/mcp-server/executor_process.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -596,4 +597,96 @@ func (v *Executor) Share(userID, convID int) map[string]interface{} {
 		}
 	}
 	return response
+}
+
+// CopyProcess duplicates sourceProcessID into folderID under newTitle and
+// saves the copy as a .conv.json file in the resolved local directory.
+//
+// If newTitle is empty it defaults to the source title with " (Copy)" appended.
+// If folderID is 0 the copy is placed in the same folder as the source.
+//
+// Returns the new process ID and the path of the saved file.
+func (v *Executor) CopyProcess(sourceProcessID, folderID int, newTitle string) (int, string, error) {
+	// 1. Export the source process.
+	srcV := NewValidator(v.Ctx, sourceProcessID)
+	srcRaw, err := srcV.ExportProcess()
+	if err != nil {
+		return 0, "", fmt.Errorf("export source process %d: %w", sourceProcessID, err)
+	}
+	var srcMap map[string]interface{}
+	if arr, ok := srcRaw.([]interface{}); ok && len(arr) > 0 {
+		srcMap, _ = arr[0].(map[string]interface{})
+	} else {
+		srcMap, _ = srcRaw.(map[string]interface{})
+	}
+	if srcMap == nil {
+		return 0, "", fmt.Errorf("source process %d: empty or unexpected export format", sourceProcessID)
+	}
+
+	// 2. Resolve title — default to "<original title> (Copy)".
+	if newTitle == "" {
+		if t, _ := srcMap["title"].(string); t != "" {
+			newTitle = t + " (Copy)"
+		} else {
+			newTitle = fmt.Sprintf("%d (Copy)", sourceProcessID)
+		}
+	}
+
+	// 3. Resolve target folder — default to source's parent_id.
+	if folderID == 0 {
+		if pid, _ := srcMap["parent_id"].(float64); pid > 0 {
+			folderID = int(pid)
+		}
+	}
+
+	// 4. Determine conv type (process or state diagram).
+	convType := "process"
+	if ct, _ := srcMap["conv_type"].(string); ct != "" {
+		convType = ct
+	}
+
+	// 5. Create empty target process in the destination folder.
+	newID := v.CreateEmptyConv(folderID, newTitle, "", convType)
+	if newID == 0 {
+		return 0, "", fmt.Errorf("failed to create target %s '%s' in folder %d", convType, newTitle, folderID)
+	}
+	v.ProcessID = newID
+
+	// 6. Update the title in the source JSON before deploying.
+	srcMap["title"] = newTitle
+	srcJSON, err := json.MarshalIndent(srcMap, "", "  ")
+	if err != nil {
+		return 0, "", fmt.Errorf("marshal source process: %w", err)
+	}
+
+	// 7. Resolve local destination directory from the API folder hierarchy.
+	safeName := strings.ReplaceAll(newTitle, " ", "_")
+	fileName := fmt.Sprintf("%d_%s.conv.json", newID, safeName)
+	var dir string
+	if v.StageID != 0 && folderID != 0 {
+		if resolved, resolveErr := v.resolveFolderPathFromAPI(folderID); resolveErr == nil {
+			dir = resolved
+		} else {
+			logger.Warn("copy-process: could not resolve folder path for folder_id %d: %v", folderID, resolveErr)
+		}
+	}
+	if dir != "" {
+		if mkErr := os.MkdirAll(dir, 0755); mkErr != nil {
+			logger.Warn("copy-process: could not create directory %s: %v — saving to cwd", dir, mkErr)
+			dir = ""
+		}
+	}
+	finalPath := filepath.Join(dir, fileName)
+
+	// 8. Write source JSON to the destination file and deploy.
+	if err := os.WriteFile(finalPath, srcJSON, 0644); err != nil {
+		return 0, "", fmt.Errorf("write %s: %w", finalPath, err)
+	}
+
+	if _, err := v.ProcessJSON(finalPath, string(srcJSON)); err != nil {
+		os.Remove(finalPath) //nolint:errcheck
+		return 0, "", fmt.Errorf("deploy copy: %w", err)
+	}
+
+	return newID, finalPath, nil
 }

--- a/plugins/corezoid/mcp-server/mcp_handlers.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers.go
@@ -38,6 +38,7 @@ var toolHandlers = map[string]toolHandler{
 	"delete-folder":        handleDeleteFolder,
 	"delete-process":       handleDeleteProcess,
 	"create-alias":         handleCreateAlias,
+	"copy-process":         handleCopyProcess,
 
 	// discovery
 	"list-workspaces": handleListWorkspaces,

--- a/plugins/corezoid/mcp-server/mcp_handlers_process.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_process.go
@@ -667,3 +667,34 @@ func handleCreateAlias(ctx context.Context, args map[string]interface{}) (string
 
 	return fmt.Sprintf("Alias '%s' created successfully, AliasID: %d", shortName, aliasID), false
 }
+
+// handleCopyProcess duplicates an existing process or state diagram without
+// loading its full JSON into the AI context. The copy is placed in the same
+// folder as the source unless folder_path is provided.
+func handleCopyProcess(ctx context.Context, args map[string]interface{}) (string, bool) {
+	sourceProcessID, err := intArg(args, "source_process_id")
+	if err != nil {
+		return "Error: " + err.Error(), true
+	}
+
+	// new_name is optional — CopyProcess defaults to "<title> (Copy)".
+	newName, _ := args["new_name"].(string)
+
+	// folder_path is optional — CopyProcess defaults to the source's parent folder.
+	folderID := 0
+	if _, hasPath := args["folder_path"]; hasPath {
+		folderPath := resolveDirPath(args, "folder_path")
+		folderID, err = resolveFolderIDFromDir(folderPath)
+		if err != nil {
+			return fmt.Sprintf("Error resolving destination folder: %v", err), true
+		}
+	}
+
+	v := NewValidator(ctx, 0)
+	newID, filePath, err := v.CopyProcess(sourceProcessID, folderID, newName)
+	if err != nil {
+		return fmt.Sprintf("Error copying process %d: %v", sourceProcessID, err), true
+	}
+
+	return fmt.Sprintf("Process %d copied (new ID: %d) → %s", sourceProcessID, newID, filePath), false
+}

--- a/plugins/corezoid/mcp-server/tools_registry.go
+++ b/plugins/corezoid/mcp-server/tools_registry.go
@@ -259,6 +259,28 @@ var toolRegistry = []mcpTool{
 		},
 	},
 	{
+		Name:        "copy-process",
+		Description: "Duplicate a Corezoid process or state diagram without loading its JSON into the AI context. Equivalent to the 'Duplicate' action in the Corezoid UI. Creates an independent copy with a new process ID and saves it as a .conv.json file.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"source_process_id": map[string]interface{}{
+					"type":        "integer",
+					"description": "ID of the process or state diagram to copy",
+				},
+				"new_name": map[string]interface{}{
+					"type":        "string",
+					"description": "Title for the copy. Omit to default to the original title with ' (Copy)' appended.",
+				},
+				"folder_path": map[string]interface{}{
+					"type":        "string",
+					"description": "Relative path to the destination folder directory. Omit to place the copy in the same folder as the source.",
+				},
+			},
+			"required": []string{"source_process_id"},
+		},
+	},
+	{
 		Name:        "list-workspaces",
 		Description: "Return the list of Corezoid workspaces (companies) available to the authenticated user.",
 		InputSchema: map[string]interface{}{


### PR DESCRIPTION
## Summary
- Adds `copy-process` MCP tool — duplicates a process or state diagram without loading its JSON into the AI context
- Equivalent to the "Duplicate" action in the Corezoid UI
- Supports optional `new_name` (defaults to `<title> (Copy)`) and optional `folder_path` (defaults to the source's parent folder)
- The copy is saved as a `.conv.json` file in the resolved local directory, ready for further editing

## Context
tool: create-process | version: 2.3.5 | install: 104e5afc

## Implementation
`copy-process(source_process_id, new_name?, folder_path?)` in the MCP server:
1. Exports the source process JSON server-side via the existing `ExportProcess` API
2. Creates an empty target process in the destination folder via `CreateEmptyConv`
3. Deploys the source scheme to the new process ID via `ProcessJSON`
4. Saves the result as `<newID>_<title>.conv.json` in the correct local directory

The AI context never sees the process JSON — context-cost is O(1) regardless of process size.

## Checklist
- [x] `make build` passes
- [x] `make vet` passes
- [x] `make test` passes (TestToolRegistryMatchesREADME, TestToolRegistryNoDuplicates, etc.)
- [x] README.md tools table updated
- [x] README.md architecture diagram updated
- [x] No version bump / CHANGELOG.md change included
- [x] No credentials or private URLs in any file

## Test plan
- Call `copy-process` with a valid `source_process_id` — verify a new `.conv.json` appears in the correct folder with a new process ID
- Call with `new_name` set — verify the copy uses that title
- Call with `folder_path` pointing to a different subfolder — verify placement
- Omit both optional args — verify default title `<original> (Copy)` and same-folder placement