### PR TITLE
fix(lint): lint matches the server contract — api required fields, reply literals, null extra

### DIFF
--- a/plugins/corezoid/docs/nodes/call-process-node.md
+++ b/plugins/corezoid/docs/nodes/call-process-node.md
@@ -207,6 +207,8 @@ If the count threshold is reached, the task is routed to an escalation node:
         "type": "api",
         "url": "https://api.example.com/data",
         "method": "POST",
+        "extra_headers": {},
+        "max_threads": 5,
         "content_type": "application/json",
         "err_node_id": "error_node_id"
       },

--- a/plugins/corezoid/docs/nodes/reply-to-process-node.md
+++ b/plugins/corezoid/docs/nodes/reply-to-process-node.md
@@ -15,6 +15,13 @@
    - Key-value pairs to be returned to the calling process.
    - Example: `"res_data": {"res": "{{res}}"}`
    - Validation: Must be a valid JSON object with properly formatted values.
+   - **Every value must be a string** — either a `"{{variable}}"` template or a plain
+     string literal. Literal non-string values (`[]`, `{}`, `0`, `true`, `null`) pass
+     JSON-schema validation but hang the server-side commit when the process is pushed
+     through the API (`push-process` fails with the opaque "no response from server").
+     To return an empty array / zero / etc., set it in an upstream Code node
+     (`data.links = []`) and reference it as `"{{links}}"` with the real type declared
+     in `res_data_type`. `lint-process` flags this pattern.
 2. **Response Data Type** (Object)
    - Specifies the data types of the returned values.
    - Example: `"res_data_type": {"res": "string"}`

--- a/plugins/corezoid/docs/process/algorithm-to-process-guide.md
+++ b/plugins/corezoid/docs/process/algorithm-to-process-guide.md
@@ -221,6 +221,8 @@ Implement the algorithm's core logic:
      {
        "type": "api",
        "method": "POST",
+       "max_threads": 5,
+       "extra_headers": {},
        "url": "https://api.example.com/validate",
        "extra": {
          "customer_id": "{{customer_id}}",

--- a/plugins/corezoid/docs/process/error-handling.md
+++ b/plugins/corezoid/docs/process/error-handling.md
@@ -220,6 +220,8 @@ Example:
 {
   "type": "api",
   "method": "GET",
+  "extra_headers": {},
+  "max_threads": 5,
   "url": "https://api.example.com",
   "extra": {},
   "extra_type": {},

--- a/plugins/corezoid/docs/variables-guide.md
+++ b/plugins/corezoid/docs/variables-guide.md
@@ -60,6 +60,8 @@ Use the syntax `{{env_var[@variable-name]}}` anywhere a value is expected.
   "type": "api",
   "url": "{{env_var[@payment-api-url]}}/charge",
   "method": "POST",
+  "extra_headers": {},
+  "max_threads": 5,
   "err_node_id": "<error_node_id>"
 }
 ```

--- a/plugins/corezoid/mcp-server/json-schema/logics/api.json
+++ b/plugins/corezoid/mcp-server/json-schema/logics/api.json
@@ -3,7 +3,7 @@
   "title": "API Logic Schema",
   "description": "Schema for the api logic type in Corezoid processes",
   "type": "object",
-  "required": ["type", "method", "url", "err_node_id"],
+  "required": ["type", "method", "url", "extra_headers", "max_threads", "err_node_id"],
   "additionalProperties": false,
   "properties": {
     "type": {

--- a/plugins/corezoid/mcp-server/json-schema/node.json
+++ b/plugins/corezoid/mcp-server/json-schema/node.json
@@ -39,8 +39,8 @@
       "description": "Y coordinate on canvas"
     },
     "extra": {
-      "type": "string",
-      "description": "UI settings in JSON string format"
+      "type": ["string", "null"],
+      "description": "UI settings in JSON string format. The platform itself emits null for some nodes (pull-process writes it verbatim), so null must round-trip."
     },
     "options": {
       "type": ["string", "null"],

--- a/plugins/corezoid/mcp-server/lint.go
+++ b/plugins/corezoid/mcp-server/lint.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 )
 
@@ -14,6 +15,7 @@ type LintResult struct {
 	UnusedSetParams          []UnusedSetParam
 	OrphanedNodes            []OrphanedNode
 	PassthroughEscalations   []PassthroughEscalation
+	LiteralReplyValues       []LiteralReplyValue
 	TotalNodes               int
 	ReachableCount           int
 	SchemaValid              bool
@@ -51,6 +53,19 @@ type PassthroughEscalation struct {
 	TargetID    string
 	TargetTitle string
 	Issue       string
+}
+
+// LiteralReplyValue represents an api_rpc_reply logic whose res_data (or extra)
+// contains literal non-string values ([], {}, 0, true, null). The commit service
+// hangs on serialising such values when the process is pushed through the API
+// ("no response from server"), even though the JSON schema accepts them — reply
+// parameters must be "{{variable}}" templates or plain strings, with the real
+// type declared in res_data_type.
+type LiteralReplyValue struct {
+	ID     string
+	Title  string
+	Fields []string
+	Issue  string
 }
 
 // processNode is the typed representation of a Corezoid node used throughout lint checks.
@@ -111,6 +126,7 @@ func lintProcess(filePath string) (*LintResult, error) {
 	result.NoopConditions, result.UnusedSetParams = findNoopNodes(typed)
 	result.OrphanedNodes, result.ReachableCount = findOrphanedNodes(typed)
 	result.PassthroughEscalations = findPassthroughEscalations(typed)
+	result.LiteralReplyValues = findLiteralReplyValues(typed)
 
 	schemaErr := ValidateJSONSchema(filePath, debug)
 	if schemaErr != nil {
@@ -305,6 +321,70 @@ func findPassthroughEscalations(nodes []processNode) []PassthroughEscalation {
 	return result
 }
 
+// findLiteralReplyValues detects api_rpc_reply logics whose res_data (or its
+// alternative spelling extra) carries literal non-string values. The Corezoid
+// commit service cannot serialise them when the change comes through the API:
+// the commit request gets no reply and push-process fails with the opaque
+// "no response from server" — while both the JSON schema and the UI editor
+// accept the very same scheme. Catching it in lint turns a dead-end hang into
+// an actionable message.
+//
+// Only non-string values are flagged. Literal strings ("success", "API call
+// error") are fine — the platform serialises them the same way as templates.
+func findLiteralReplyValues(nodes []processNode) []LiteralReplyValue {
+	var result []LiteralReplyValue
+	for _, n := range nodes {
+		for _, lg := range n.logics {
+			if t, _ := lg["type"].(string); t != "api_rpc_reply" {
+				continue
+			}
+			var fields []string
+			for _, dataKey := range []string{"res_data", "extra"} {
+				data, _ := lg[dataKey].(map[string]interface{})
+				keys := make([]string, 0, len(data))
+				for k := range data {
+					keys = append(keys, k)
+				}
+				sort.Strings(keys)
+				for _, k := range keys {
+					if _, isString := data[k].(string); !isString {
+						fields = append(fields, fmt.Sprintf("%s.%s = %s", dataKey, k, describeLiteral(data[k])))
+					}
+				}
+			}
+			if len(fields) == 0 {
+				continue
+			}
+			displayTitle := n.title
+			if displayTitle == "" {
+				displayTitle = "(untitled)"
+			}
+			result = append(result, LiteralReplyValue{
+				ID:     n.id,
+				Title:  displayTitle,
+				Fields: fields,
+				Issue: fmt.Sprintf(
+					"api_rpc_reply has literal non-string values (%s) — pushing this scheme hangs the server commit (\"no response from server\"). Set the value in an upstream api_code/set_param node and reference it as \"{{variable}}\" with the real type in res_data_type",
+					strings.Join(fields, ", ")),
+			})
+		}
+	}
+	return result
+}
+
+// describeLiteral renders a res_data value for the lint message ([], {}, 0, true, null).
+func describeLiteral(v interface{}) string {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return fmt.Sprintf("%v", v)
+	}
+	s := string(b)
+	if len(s) > 40 {
+		s = s[:37] + "..."
+	}
+	return s
+}
+
 // findOrphanedNodes does a BFS from the Start node and returns unreachable nodes
 func findOrphanedNodes(nodes []processNode) ([]OrphanedNode, int) {
 	typeLabels := map[float64]string{0: "standard", 1: "start", 2: "final", 3: "escalation"}
@@ -434,6 +514,15 @@ func FormatLintResult(result *LintResult) string {
 		}
 	}
 
+	if len(result.LiteralReplyValues) > 0 {
+		hasIssues = true
+		sb.WriteString(fmt.Sprintf("\n=== API_RPC_REPLY LITERAL VALUES (%d) ===\n", len(result.LiteralReplyValues)))
+		for _, lr := range result.LiteralReplyValues {
+			sb.WriteString(fmt.Sprintf("  [%s] %s\n", lr.ID, lr.Title))
+			sb.WriteString(fmt.Sprintf("  Issue: %s\n", lr.Issue))
+		}
+	}
+
 	if !hasIssues {
 		sb.WriteString("\nNo issues found.")
 	} else {
@@ -441,7 +530,7 @@ func FormatLintResult(result *LintResult) string {
 		if !result.SchemaValid {
 			schemaIssues = 1
 		}
-		total := len(result.NoopConditions) + len(result.UnusedSetParams) + len(result.OrphanedNodes) + len(result.PassthroughEscalations) + schemaIssues
+		total := len(result.NoopConditions) + len(result.UnusedSetParams) + len(result.OrphanedNodes) + len(result.PassthroughEscalations) + len(result.LiteralReplyValues) + schemaIssues
 		sb.WriteString(fmt.Sprintf("\nTotal issues: %d\n", total))
 	}
 

--- a/plugins/corezoid/mcp-server/lint_api_contract_test.go
+++ b/plugins/corezoid/mcp-server/lint_api_contract_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// apiContractProcess builds a minimal process with one api-logic node. The
+// fields argument is merged into the api logic on top of the schema-required
+// base, letting tests drop or add server-mandatory keys.
+func apiContractProcess(t *testing.T, extraFields map[string]interface{}) string {
+	t.Helper()
+	api := map[string]interface{}{
+		"type":        "api",
+		"method":      "POST",
+		"url":         "https://example.com/hook",
+		"err_node_id": "bbccddaabbccddaabbcc0003",
+	}
+	for k, v := range extraFields {
+		api[k] = v
+	}
+	proc := map[string]interface{}{
+		"obj_type": 1, "obj_id": 0, "title": "api contract", "params": []interface{}{},
+		"status": "active", "ref_mask": true, "conv_type": "process",
+		"scheme": map[string]interface{}{
+			"web_settings": []interface{}{[]interface{}{}, []interface{}{}},
+			"nodes": []interface{}{
+				map[string]interface{}{
+					"id": "bbccddaabbccddaabbcc0001", "obj_type": 1, "title": "Start",
+					"x": 0, "y": 0, "extra": `{"modeForm":"collapse","icon":""}`, "options": nil,
+					"condition": map[string]interface{}{
+						"logics":    []interface{}{map[string]interface{}{"type": "go", "to_node_id": "bbccddaabbccddaabbcc0002"}},
+						"semaphors": []interface{}{},
+					},
+				},
+				map[string]interface{}{
+					"id": "bbccddaabbccddaabbcc0002", "obj_type": 0, "title": "Call API",
+					"x": 200, "y": 200, "extra": `{"modeForm":"expand","icon":""}`, "options": nil,
+					"condition": map[string]interface{}{
+						"logics": []interface{}{
+							api,
+							map[string]interface{}{"type": "go", "to_node_id": "bbccddaabbccddaabbcc0004"},
+						},
+						"semaphors": []interface{}{},
+					},
+				},
+				map[string]interface{}{
+					"id": "bbccddaabbccddaabbcc0003", "obj_type": 2, "title": "Error",
+					"x": 500, "y": 200, "extra": `{"modeForm":"collapse","icon":"error"}`, "options": nil,
+					"condition": map[string]interface{}{"logics": []interface{}{}, "semaphors": []interface{}{}},
+				},
+				map[string]interface{}{
+					"id": "bbccddaabbccddaabbcc0004", "obj_type": 2, "title": "Final",
+					"x": 200, "y": 500, "extra": `{"modeForm":"collapse","icon":"success"}`, "options": nil,
+					"condition": map[string]interface{}{"logics": []interface{}{}, "semaphors": []interface{}{}},
+				},
+			},
+		},
+	}
+	data, err := json.Marshal(proc)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "api_contract.conv.json")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// The server rejects a commit whose api logic lacks extra_headers or
+// max_threads ("Key 'extra_headers' is required"). Lint must catch that
+// BEFORE push — a green lint followed by a failed commit is the exact
+// false-confidence this schema addition removes.
+func TestLintProcess_APIMissingServerMandatoryFields(t *testing.T) {
+	path := apiContractProcess(t, nil) // no extra_headers, no max_threads
+	result, err := lintProcess(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.SchemaError == "" {
+		t.Fatal("expected a schema error for api logic without extra_headers/max_threads")
+	}
+	for _, key := range []string{"extra_headers", "max_threads"} {
+		if !strings.Contains(result.SchemaError, key) {
+			t.Errorf("schema error must mention %q, got:\n%s", key, result.SchemaError)
+		}
+	}
+}
+
+func TestLintProcess_APIWithServerMandatoryFieldsPasses(t *testing.T) {
+	path := apiContractProcess(t, map[string]interface{}{
+		"extra_headers": map[string]interface{}{"content-type": "application/json"},
+		"max_threads":   5,
+	})
+	result, err := lintProcess(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.SchemaError != "" {
+		t.Errorf("expected no schema error, got:\n%s", result.SchemaError)
+	}
+}

--- a/plugins/corezoid/mcp-server/lint_test.go
+++ b/plugins/corezoid/mcp-server/lint_test.go
@@ -212,3 +212,36 @@ func TestFormatLintResult_Golden(t *testing.T) {
 		})
 	}
 }
+
+// TestLintProcess_NodeExtraNull verifies that a node-level "extra": null passes
+// schema validation. The platform itself emits null for some nodes, and
+// pull-process writes it verbatim — so the plugin must accept its own pull
+// output (previously: 'at /scheme/nodes/0/extra: got null, want string').
+func TestLintProcess_NodeExtraNull(t *testing.T) {
+	f, err := os.CreateTemp("", "extra-null-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	f.WriteString(`{
+		"obj_type": 1, "obj_id": 1, "conv_type": "process", "title": "extra-null", "status": "active",
+		"params": [], "ref_mask": true,
+		"scheme": {"web_settings": [[],[]], "nodes": [
+			{"id": "aaaa0001513aa075cf400001", "obj_type": 1, "title": "Start", "x": 0, "y": 0,
+			 "extra": null, "options": null,
+			 "condition": {"logics": [{"type": "go", "to_node_id": "aaaa0002513aa075cf400002"}], "semaphors": []}},
+			{"id": "aaaa0002513aa075cf400002", "obj_type": 2, "title": "Final", "x": 0, "y": 100,
+			 "extra": "{}", "options": null,
+			 "condition": {"logics": [], "semaphors": []}}
+		]}
+	}`)
+	f.Close()
+
+	result, err := lintProcess(f.Name())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.SchemaValid {
+		t.Errorf("extra:null must pass schema validation, got: %s", result.SchemaError)
+	}
+}

--- a/plugins/corezoid/mcp-server/lint_test.go
+++ b/plugins/corezoid/mcp-server/lint_test.go
@@ -67,6 +67,56 @@ func TestLintProcess_PassthroughEscalation(t *testing.T) {
 	}
 }
 
+// TestLintProcess_LiteralReplyValues verifies detection of literal non-string
+// values in api_rpc_reply res_data — the scheme shape that hangs the server
+// commit ("no response from server") when pushed through the API.
+func TestLintProcess_LiteralReplyValues(t *testing.T) {
+	result, err := lintProcess("samples/reply_literal_values.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The fixture has two offending reply nodes: one via res_data, one via the
+	// alternative extra/extra_type spelling (both are accepted by the platform
+	// schema and both hang the commit the same way).
+	if len(result.LiteralReplyValues) != 2 {
+		t.Fatalf("expected 2 literal reply findings, got %d: %+v", len(result.LiteralReplyValues), result.LiteralReplyValues)
+	}
+	lr := result.LiteralReplyValues[0]
+	if lr.Title != "Reply literals" {
+		t.Errorf("expected node title 'Reply literals', got %q", lr.Title)
+	}
+	// links=[] and chars=0 are literals; note is a plain string and must not be flagged.
+	if len(lr.Fields) != 2 {
+		t.Errorf("expected 2 flagged fields, got %d: %v", len(lr.Fields), lr.Fields)
+	}
+	for _, f := range lr.Fields {
+		if strings.Contains(f, "note") {
+			t.Errorf("plain string value 'note' must not be flagged, got %v", lr.Fields)
+		}
+	}
+
+	// Second node uses extra/extra_type: meta={} is a literal, status is a string.
+	le := result.LiteralReplyValues[1]
+	if le.Title != "Reply extra literal" {
+		t.Errorf("expected node title 'Reply extra literal', got %q", le.Title)
+	}
+	if len(le.Fields) != 1 || !strings.Contains(le.Fields[0], "extra.meta") {
+		t.Errorf("expected exactly [extra.meta ...] flagged, got %v", le.Fields)
+	}
+}
+
+// TestLintProcess_LiteralReplyValues_CleanReply verifies that api_rpc_reply
+// with only strings/templates in res_data reports nothing.
+func TestLintProcess_LiteralReplyValues_CleanReply(t *testing.T) {
+	result, err := lintProcess("samples/valid_process.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.LiteralReplyValues) != 0 {
+		t.Errorf("expected 0 literal reply findings, got %d: %+v", len(result.LiteralReplyValues), result.LiteralReplyValues)
+	}
+}
+
 // TestLintProcess_MalformedJSON verifies graceful error on invalid JSON.
 func TestLintProcess_MalformedJSON(t *testing.T) {
 	f, err := os.CreateTemp("", "bad-*.json")
@@ -129,6 +179,7 @@ func TestFormatLintResult_Golden(t *testing.T) {
 		{"clean", "samples/valid_process.json", "testdata/golden/lint_clean.txt"},
 		{"orphaned", "samples/orphaned_node.json", "testdata/golden/lint_orphaned.txt"},
 		{"noop", "samples/noop_condition.json", "testdata/golden/lint_noop.txt"},
+		{"reply_literals", "samples/reply_literal_values.json", "testdata/golden/lint_reply_literals.txt"},
 	}
 
 	for _, tc := range cases {

--- a/plugins/corezoid/mcp-server/samples/multi_action_logics.json
+++ b/plugins/corezoid/mcp-server/samples/multi_action_logics.json
@@ -26,7 +26,8 @@
           "logics": [
             {
               "type": "set_param",
-              "params": [{"name": "x", "value": "1", "type": "string"}],
+              "extra": {"x": "1"},
+              "extra_type": {"x": "string"},
               "err_node_id": "ddaabbccddaabbccddaa0003"
             },
             {

--- a/plugins/corezoid/mcp-server/samples/reply_literal_values.json
+++ b/plugins/corezoid/mcp-server/samples/reply_literal_values.json
@@ -1,0 +1,117 @@
+{
+  "conv_type": "process",
+  "description": "Lint fixture: api_rpc_reply with literal non-string res_data values ([], 0) — such a scheme hangs the server commit when pushed",
+  "obj_id": 1,
+  "obj_type": 1,
+  "params": [],
+  "ref_mask": true,
+  "scheme": {
+    "nodes": [
+      {
+        "id": "bbbb0001513aa075cf400001",
+        "obj_type": 1,
+        "condition": {
+          "logics": [
+            {
+              "type": "go",
+              "to_node_id": "bbbb0002513aa075cf400002"
+            }
+          ],
+          "semaphors": []
+        },
+        "title": "Start",
+        "description": "",
+        "x": 600,
+        "y": 100,
+        "extra": "{\"icon\":\"\",\"modeForm\":\"collapse\"}",
+        "options": "{\"direct_url\":true,\"type_auth\":\"no_auth\"}"
+      },
+      {
+        "id": "bbbb0002513aa075cf400002",
+        "obj_type": 0,
+        "condition": {
+          "logics": [
+            {
+              "type": "api_rpc_reply",
+              "mode": "key_value",
+              "res_data": {
+                "links": [],
+                "chars": 0,
+                "note": "plain strings are fine"
+              },
+              "res_data_type": {
+                "links": "array",
+                "chars": "number",
+                "note": "string"
+              },
+              "throw_exception": false
+            },
+            {
+              "type": "go",
+              "to_node_id": "bbbb0004513aa075cf400004"
+            }
+          ],
+          "semaphors": []
+        },
+        "title": "Reply literals",
+        "description": "",
+        "x": 600,
+        "y": 300,
+        "extra": "{\"modeForm\":\"expand\",\"icon\":\"\"}",
+        "options": null
+      },
+      {
+        "id": "bbbb0004513aa075cf400004",
+        "obj_type": 0,
+        "condition": {
+          "logics": [
+            {
+              "type": "api_rpc_reply",
+              "extra": {
+                "meta": {},
+                "status": "success"
+              },
+              "extra_type": {
+                "meta": "object",
+                "status": "string"
+              },
+              "throw_exception": false
+            },
+            {
+              "type": "go",
+              "to_node_id": "bbbb0003513aa075cf400003"
+            }
+          ],
+          "semaphors": []
+        },
+        "title": "Reply extra literal",
+        "description": "",
+        "x": 600,
+        "y": 400,
+        "extra": "{\"modeForm\":\"expand\",\"icon\":\"\"}",
+        "options": null
+      },
+      {
+        "id": "bbbb0003513aa075cf400003",
+        "obj_type": 2,
+        "condition": {
+          "logics": [],
+          "semaphors": []
+        },
+        "title": "Final",
+        "description": "",
+        "x": 600,
+        "y": 500,
+        "extra": "{\"modeForm\":\"collapse\",\"icon\":\"success\"}",
+        "options": "{\"save_task\":true}"
+      }
+    ],
+    "web_settings": [
+      [],
+      []
+    ]
+  },
+  "status": "active",
+  "title": "reply-literal-values",
+  "uuid": "4395ca9a-6041-43a3-b1fe-8cda363a6d9a"
+}

--- a/plugins/corezoid/mcp-server/testdata/golden/lint_reply_literals.txt
+++ b/plugins/corezoid/mcp-server/testdata/golden/lint_reply_literals.txt
@@ -1,0 +1,10 @@
+Lint results for: reply-literal-values
+Total nodes: 4
+
+=== API_RPC_REPLY LITERAL VALUES (2) ===
+  [bbbb0002513aa075cf400002] Reply literals
+  Issue: api_rpc_reply has literal non-string values (res_data.chars = 0, res_data.links = []) — pushing this scheme hangs the server commit ("no response from server"). Set the value in an upstream api_code/set_param node and reference it as "{{variable}}" with the real type in res_data_type
+  [bbbb0004513aa075cf400004] Reply extra literal
+  Issue: api_rpc_reply has literal non-string values (extra.meta = {}) — pushing this scheme hangs the server commit ("no response from server"). Set the value in an upstream api_code/set_param node and reference it as "{{variable}}" with the real type in res_data_type
+
+Total issues: 2

--- a/plugins/corezoid/mcp-server/tools_registry.go
+++ b/plugins/corezoid/mcp-server/tools_registry.go
@@ -74,7 +74,7 @@ var toolRegistry = []mcpTool{
 	},
 	{
 		Name:        "lint-process",
-		Description: "Validate process structure. Reports orphaned nodes, noop conditions, and unused set_params.",
+		Description: "Validate process structure. Reports orphaned nodes, noop conditions, unused set_params, passthrough escalations, and literal non-string values in api_rpc_reply res_data (a scheme shape that hangs the server commit on push).",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{

--- a/plugins/corezoid/samples/delay-retry-pattern.json
+++ b/plugins/corezoid/samples/delay-retry-pattern.json
@@ -43,6 +43,8 @@
               "url": "{{url}}",
               "method": "GET",
               "content_type": "application/json",
+              "extra_headers": {},
+              "max_threads": 5,
               "err_node_id": "aabc000000000000000000003",
               "extra": {},
               "extra_type": {}

--- a/plugins/corezoid/samples/error-handling.json
+++ b/plugins/corezoid/samples/error-handling.json
@@ -53,7 +53,7 @@
                 {
                   "param": "amount",
                   "const": "0",
-                  "fun": "<=",
+                  "fun": "less_or_eq",
                   "cast": "number"
                 }
               ]
@@ -78,6 +78,8 @@
               "url": "{{env_var[@payment-api-url]}}/charge",
               "method": "POST",
               "content_type": "application/json",
+              "extra_headers": {},
+              "max_threads": 5,
               "extra": {
                 "order_id": "{{order_id}}",
                 "amount": "{{amount}}"

--- a/plugins/corezoid/skills/corezoid-variable-manager/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-variable-manager/SKILL.md
@@ -66,6 +66,8 @@ is expected.
   "type": "api",
   "url": "{{env_var[@payment-api-url]}}/charge",
   "method": "POST",
+  "extra_headers": {},
+  "max_threads": 5,
   "err_node_id": "<error_node_id>"
 }
 ```
@@ -76,6 +78,8 @@ is expected.
   "type": "api",
   "url": "{{env_var[@payment-api-url]}}/charge",
   "method": "POST",
+  "extra_headers": {},
+  "max_threads": 5,
   "extra": { "Authorization": "Bearer {{env_var[@payment-api-token]}}" },
   "extra_type": { "Authorization": "string" },
   "err_node_id": "<error_node_id>"


### PR DESCRIPTION
Bundles three small schema/lint fixes with one theme: **what lint accepts must match what the server actually accepts and emits**. Folded per review plan; supersedes #54 and #60.

## 1. api schema: `extra_headers` + `max_threads` are required (was #66)

The server rejects a commit whose api logic lacks them — verified live: `Key 'extra_headers' is required`, then `Key 'max_threads' is required` (sandbox project 685225). Lint passing while the push is doomed is exactly the false confidence this removes. Sample survey: all 4028 production api logics reviewed carry both keys.

Also brings every bundled sample up to the schema it ships with: `multi_action_logics.json` (set_param dialect), `delay-retry-pattern.json`, `error-handling.json` (+ its pre-existing `"fun": "<="` → `less_or_eq` dialect fix). All samples now pass `lint-process`.

## 2. lint flags literal non-string values in `api_rpc_reply` `res_data` (was #54)

Pushing `res_data.chars = 0` / `res_data.links = []` hangs the server commit ("no response from server"). Lint now points at the exact node with the fix recipe. Golden test included.

## 3. schema allows `null` for node-level `extra` (was #60)

The platform itself emits `"extra": null` on pull; lint must not reject the server's own output. Verified live: a process with `extra: null` on every node lints clean with this branch and fails without it.

## Tests

`go build`, `go test` green on the combined branch; live lint runs for all three behaviors above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)