### PR TITLE
fix(mcp): wire COREZOID_DEBUG to the Executor API trace (with secret redaction)

### DIFF
--- a/plugins/corezoid/mcp-server/executor_api.go
+++ b/plugins/corezoid/mcp-server/executor_api.go
@@ -50,7 +50,7 @@ func (v *Executor) req(method string, ops []map[string]any) (map[string]interfac
 
 	if v.Debug {
 		var prettyJSON bytes.Buffer
-		json.Indent(&prettyJSON, payloadJSON, "", "  ")
+		json.Indent(&prettyJSON, redactForLog(payloadJSON), "", "  ")
 		logger.Debug("API Request, method=%s, payload=%s", method, prettyJSON.String())
 	}
 
@@ -78,10 +78,10 @@ func (v *Executor) req(method string, ops []map[string]any) (map[string]interfac
 
 	if v.Debug {
 		var prettyJSON bytes.Buffer
-		if json.Indent(&prettyJSON, body, "", "  ") == nil {
+		if json.Indent(&prettyJSON, redactForLog(body), "", "  ") == nil {
 			logger.Debug("API Response, method=%s, status=%s, body=%s", method, resp.Status, prettyJSON.String())
 		} else {
-			logger.Debug("API Response, method=%s, status=%s, body=%s", method, resp.Status, string(body))
+			logger.Debug("API Response, method=%s, status=%s, body=(non-JSON, omitted)", method, resp.Status)
 		}
 	}
 

--- a/plugins/corezoid/mcp-server/log_redact.go
+++ b/plugins/corezoid/mcp-server/log_redact.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// redactForLog masks secret-bearing values in an API payload/response before
+// it is written to the debug log. The debug trace dumps full bodies, and two
+// flows carry live secrets: create_api_key responses return the API-key
+// secret in `logins[].key` (which CreateAPIKey deliberately writes only to a
+// 0600 file), and env-var ops carry the variable value — the variable-manager
+// skill explicitly directs tokens and API keys there. Debug logs are exactly
+// what users paste into bug reports, so the trace must never contain them.
+//
+// Redaction is field-based, not method-based: env-var values also travel
+// through the generic "json" method, so keying off the method name would
+// miss them.
+func redactForLog(data []byte) []byte {
+	var v interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		// Not JSON — don't risk dumping it raw.
+		return []byte(`"(non-JSON payload omitted from debug log)"`)
+	}
+	redactValue(v, false)
+	out, err := json.Marshal(v)
+	if err != nil {
+		return []byte(`"(payload could not be re-serialized for debug log)"`)
+	}
+	return out
+}
+
+// secretKeys are masked wherever they appear, at any nesting depth.
+var secretKeys = map[string]bool{
+	"key":          true, // create_api_key response: logins[].key
+	"api_key":      true,
+	"api_secret":   true,
+	"secret":       true,
+	"password":     true,
+	"token":        true,
+	"access_token": true,
+}
+
+// redactValue walks the decoded JSON. envVar is true inside an object that
+// declared itself an env_var op — there the `value` field is the secret.
+func redactValue(v interface{}, envVar bool) {
+	switch node := v.(type) {
+	case map[string]interface{}:
+		if obj, _ := node["obj"].(string); strings.EqualFold(obj, "env_var") {
+			envVar = true
+		}
+		for k, child := range node {
+			lk := strings.ToLower(k)
+			if (secretKeys[lk] || (envVar && lk == "value")) && child != nil {
+				// Over-redaction is the safe direction for a debug log.
+				node[k] = "***REDACTED***"
+				continue
+			}
+			redactValue(child, envVar)
+		}
+	case []interface{}:
+		for _, child := range node {
+			redactValue(child, envVar)
+		}
+	}
+}

--- a/plugins/corezoid/mcp-server/log_redact_test.go
+++ b/plugins/corezoid/mcp-server/log_redact_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedactForLog_APIKeySecret(t *testing.T) {
+	in := `{"ops":[{"proc":"ok","logins":[{"obj_id":1,"key":"SUPER-SECRET-KEY"}]}]}`
+	out := string(redactForLog([]byte(in)))
+	if strings.Contains(out, "SUPER-SECRET-KEY") {
+		t.Fatalf("api-key secret leaked into debug output: %s", out)
+	}
+	if !strings.Contains(out, "***REDACTED***") {
+		t.Errorf("expected redaction marker, got: %s", out)
+	}
+}
+
+func TestRedactForLog_EnvVarValue(t *testing.T) {
+	in := `{"ops":[{"type":"create","obj":"env_var","name":"payment-token","value":"tok-12345"}]}`
+	out := string(redactForLog([]byte(in)))
+	if strings.Contains(out, "tok-12345") {
+		t.Fatalf("env-var value leaked into debug output: %s", out)
+	}
+	if !strings.Contains(out, "payment-token") {
+		t.Errorf("non-secret name must survive redaction: %s", out)
+	}
+}
+
+func TestRedactForLog_OrdinaryValueSurvives(t *testing.T) {
+	// `value` outside an env_var op is ordinary data (set_param etc.) and must
+	// not be masked; ordinary fields must round-trip untouched.
+	in := `{"ops":[{"type":"create","obj":"task","data":{"value":"42","title":"hello"}}]}`
+	out := string(redactForLog([]byte(in)))
+	for _, want := range []string{`"42"`, "hello"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("ordinary field lost: want %s in %s", want, out)
+		}
+	}
+}
+
+func TestRedactForLog_NonJSON(t *testing.T) {
+	out := string(redactForLog([]byte("not json at all")))
+	if strings.Contains(out, "not json") {
+		t.Fatalf("raw non-JSON payload must not be echoed: %s", out)
+	}
+}

--- a/plugins/corezoid/mcp-server/main.go
+++ b/plugins/corezoid/mcp-server/main.go
@@ -44,7 +44,17 @@ var apiURL string
 var accountURL string
 var apiToken string
 var workspaceID string
-var debug bool
+
+// debug gates the Executor's detailed API request/response tracing (full
+// payload dumps via the `if v.Debug` guards). It shares the COREZOID_DEBUG
+// switch with logger.IsDebug — before this assignment the var was never set,
+// so the executor trace was unreachable dead code and API-level issues could
+// not be diagnosed at all.
+var debug = debugFromEnv()
+
+// debugFromEnv reports whether COREZOID_DEBUG requests the detailed trace.
+// Split out so tests can exercise the wiring with t.Setenv.
+func debugFromEnv() bool { return os.Getenv("COREZOID_DEBUG") != "" }
 var apigwURL string
 var stageID int
 var insecureTLS bool
@@ -161,6 +171,7 @@ func loadConfig() {
 		apigwURL = "https://api-apigw.corezoid.com"
 	}
 	stageID, _ = strconv.Atoi(os.Getenv("COREZOID_STAGE_ID"))
+	debug = debugFromEnv() // executor API trace; same switch as logger.IsDebug
 	insecureTLS = os.Getenv("COREZOID_INSECURE_TLS") != ""
 	cachedProjectID = 0              // reset on workspace switch so it is re-resolved
 	os.Unsetenv("COREZOID_PROJECT_ID") // prevent stale process env from short-circuiting resolution

--- a/plugins/corezoid/mcp-server/main_config_test.go
+++ b/plugins/corezoid/mcp-server/main_config_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"sync"
@@ -203,5 +204,24 @@ func TestLoadConfig_DefaultsApigwURL(t *testing.T) {
 
 	if apigwURL != "https://api-apigw.corezoid.com" {
 		t.Errorf("expected default apigwURL, got %q", apigwURL)
+	}
+}
+
+// TestDebugFlagFollowsEnv pins the COREZOID_DEBUG wiring for the Executor
+// trace end-to-end: the package-level `debug` var used to be declared and
+// never assigned, making every `if v.Debug` block unreachable dead code. The
+// assertion goes through loadConfig + NewValidator — the actual consumer
+// path — so reverting the assignment fails this test.
+func TestDebugFlagFollowsEnv(t *testing.T) {
+	t.Chdir(t.TempDir()) // keep loadConfig away from the repo .env
+	t.Setenv("COREZOID_DEBUG", "")
+	loadConfig()
+	if v := NewValidator(context.Background(), 0); v.Debug {
+		t.Fatal("empty COREZOID_DEBUG must not enable the executor trace")
+	}
+	t.Setenv("COREZOID_DEBUG", "1")
+	loadConfig()
+	if v := NewValidator(context.Background(), 0); !v.Debug {
+		t.Fatal("COREZOID_DEBUG=1 must enable the executor trace")
 	}
 }


### PR DESCRIPTION
**This does NOT turn debug logging on for anyone.** It makes the existing opt-in switch actually work: `var debug bool` in `main.go` was declared and **never assigned**, so the Executor's detailed API request/response trace (`if v.Debug { … }`) was unreachable dead code — `COREZOID_DEBUG=1` produced no API trace in either MCP or CLI mode, making server-side failures undiagnosable in the field. Default behavior (no env var) is unchanged: no trace.

`debug` now follows `COREZOID_DEBUG` — the same switch `logger.IsDebug` already uses — assigned in `loadConfig` so a workspace switch re-reads it. The test asserts through `loadConfig` + `NewValidator` (the real consumer path), so reverting the assignment fails it.

## Secret redaction (review finding)

Arming the previously dead trace would also have armed two secret leaks into `~/.corezoid/mcp.log` — exactly the file users paste into bug reports:

- `create_api_key` responses carry the API-key secret in `logins[].key` (which `CreateAPIKey` deliberately writes only to a 0600 file instead of chat output);
- env-var ops carry the variable value, and the variable-manager skill explicitly directs tokens/API keys into env vars.

Dumps are now redacted **field-based** before logging (`log_redact.go`): `key`, `api_key`, `secret`, `password`, `token`, … anywhere, plus `value` inside `env_var` ops (env-var traffic also flows through the generic `json` method, so method-name filtering would miss it). Non-JSON bodies are omitted rather than echoed. Over-redaction is the chosen failure direction. The Authorization header was already redacted (`Simulator ***`).

Live-verified: `COREZOID_DEBUG=1 convctl show-folder …` emits the trace (none before); 4 redaction tests + end-to-end wiring test; `go test -race` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)