### PR TITLE
feat(auth): add API key (login+secret) auth as Simulator token fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,10 @@ validation errors, and summarize what each process does.
 | `find-principal`    | Resolve user / group / API-key name to obj_id      |
 | `invite-user`       | Invite an external email and share an object in one call |
 | `send-feedback`     | Submit feedback about plugin behavior (returns ticket id) |
+| `git-pull-context`  | Pull CLAUDE.md + `_ext/` from the Corezoid git mirror for the current stage |
+| `git-push-context`  | Commit and push local `_ext/` changes to the git mirror |
+| `read-context-file` | Read a file from `_ext/` of the current stage |
+| `update-context-file` | Write or append content to a file in `_ext/docs/` |
 
 ## Feedback
 

--- a/plugins/corezoid/mcp-server/executor.go
+++ b/plugins/corezoid/mcp-server/executor.go
@@ -53,10 +53,11 @@ func NewValidator(ctx context.Context, inProcessID int) *Executor {
 		ctx = context.Background()
 	}
 	apiURLv, tokenv, workspaceIDv, _, stageIDv := authSnapshot()
+	snapAPILogin, snapAPISecret := apiKeySnapshot()
 	v := &Executor{
 		Ctx:         ctx,
-		APILogin:    "",
-		APISecret:   "",
+		APILogin:    snapAPILogin,
+		APISecret:   snapAPISecret,
 		APIUrl:      apiURLv,
 		Token:       tokenv,
 		WorkspaceID: workspaceIDv,

--- a/plugins/corezoid/mcp-server/executor_api.go
+++ b/plugins/corezoid/mcp-server/executor_api.go
@@ -3,7 +3,9 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/sha1" //nolint:gosec
 	"crypto/tls"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -56,16 +58,19 @@ func (v *Executor) req(method string, ops []map[string]any) (map[string]interfac
 
 	path := "json"
 	if method == "export_process" {
+		// Always use /api/2/download for exports — it returns a download_url.
+		// fetchDownload handles both auth modes:
+		//   Simulator: Authorization: Simulator <token> header
+		//   API key:   GET {url}/{login}/{ts}/{sig} (URL-embedded signature)
 		path = "download"
 	}
-	authURL := fmt.Sprintf("%s/api/2/%s", v.APIUrl, path)
 
 	if v.Debug {
-		logger.Debug("Request URL, url=%s", authURL)
+		logger.Debug("Request baseURL=%s path=%s", v.APIUrl, path)
 	}
 
 	client := newHTTPClient()
-	resp, body, err := doWithRetry(v.Ctx, client, "POST", authURL, payloadJSON, v.Token, v.Debug)
+	resp, body, err := doWithRetry(v.Ctx, client, "POST", v.APIUrl, path, payloadJSON, v.Token, v.APILogin, v.APISecret, v.Debug)
 	if err != nil {
 		return nil, err
 	}
@@ -107,17 +112,30 @@ func newHTTPClient() *http.Client {
 	}
 }
 
+// apiKeySign computes the Corezoid API key request signature:
+// hex(sha1(timestamp + apiSecret + body + apiSecret))
+func apiKeySign(secret, timestamp, body string) string {
+	h := sha1.New() //nolint:gosec
+	h.Write([]byte(timestamp + secret + body + secret))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
 // doWithRetry sends an authenticated request and retries transient 429/503
 // responses with exponential backoff and jitter. Non-retriable statuses (and
 // non-network errors) are returned to the caller after the first attempt;
 // retrying e.g. a 4xx auth failure would just delay the user-visible error.
 //
+// Authentication mode:
+//   - If token != "": Simulator bearer token. URL = baseURL/api/2/path, header Authorization: Simulator <token>.
+//   - If token == "" and apiLogin+apiSecret != "": API key HMAC-SHA1. URL = baseURL/api/2/path/apiLogin/ts/sig, no auth header.
+//
 // The response body is rebuilt from `payloadJSON` on each attempt, so the body
 // must be idempotent — which it is, since Corezoid's JSON-RPC ops are.
+// For API key mode the timestamp+signature are recomputed fresh on each retry.
 //
 // Returns the final response and the already-read body. Caller owns resp.Body
 // and must close it.
-func doWithRetry(ctx context.Context, client *http.Client, method, url string, payloadJSON []byte, token string, debug bool) (*http.Response, []byte, error) {
+func doWithRetry(ctx context.Context, client *http.Client, method, baseURL, path string, payloadJSON []byte, token, apiLoginArg, apiSecretArg string, debug bool) (*http.Response, []byte, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -129,18 +147,35 @@ func doWithRetry(ctx context.Context, client *http.Client, method, url string, p
 		if err := ctx.Err(); err != nil {
 			return nil, nil, err
 		}
-		req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(payloadJSON))
+
+		// Build per-attempt URL. For API key auth, recompute timestamp+signature
+		// on every retry so the signature is never stale.
+		var reqURL string
+		if token != "" {
+			reqURL = fmt.Sprintf("%s/api/2/%s", baseURL, path)
+		} else {
+			ts := strconv.FormatInt(time.Now().Unix(), 10)
+			sig := apiKeySign(apiSecretArg, ts, string(payloadJSON))
+			reqURL = fmt.Sprintf("%s/api/2/%s/%s/%s/%s", baseURL, path, apiLoginArg, ts, sig)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, method, reqURL, bytes.NewReader(payloadJSON))
 		if err != nil {
 			// NewRequest fails only on programmer error (bad method/URL),
 			// not on transient I/O — no point retrying.
 			return nil, nil, err
 		}
 		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Authorization", fmt.Sprintf("Simulator %s", token))
+		if token != "" {
+			req.Header.Set("Authorization", fmt.Sprintf("Simulator %s", token))
+		}
 		if debug && attempt == 1 {
-			safeHeaders := req.Header.Clone()
-			safeHeaders.Set("Authorization", "Simulator ***")
-			logger.Debug("Header: %v", safeHeaders)
+			logger.Debug("Request URL: %s", reqURL)
+			if token != "" {
+				safeHeaders := req.Header.Clone()
+				safeHeaders.Set("Authorization", "Simulator ***")
+				logger.Debug("Header: %v", safeHeaders)
+			}
 		}
 
 		resp, err := client.Do(req)

--- a/plugins/corezoid/mcp-server/executor_api_test.go
+++ b/plugins/corezoid/mcp-server/executor_api_test.go
@@ -160,7 +160,7 @@ func TestDoWithRetry_RetriesOn503ThenSucceeds(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	resp, body, err := doWithRetry(context.Background(), srv.Client(), "POST", srv.URL, []byte(`{}`), "tkn", false)
+	resp, body, err := doWithRetry(context.Background(), srv.Client(), "POST", srv.URL, "json", []byte(`{}`), "tkn", "", "", false)
 	if err != nil {
 		t.Fatalf("expected success after retries, got %v", err)
 	}
@@ -190,7 +190,7 @@ func TestDoWithRetry_RetriesOn429(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	resp, _, err := doWithRetry(context.Background(), srv.Client(), "POST", srv.URL, []byte(`{}`), "tkn", false)
+	resp, _, err := doWithRetry(context.Background(), srv.Client(), "POST", srv.URL, "json", []byte(`{}`), "tkn", "", "", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestDoWithRetry_DoesNotRetry4xx(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	resp, _, err := doWithRetry(context.Background(), srv.Client(), "POST", srv.URL, []byte(`{}`), "tkn", false)
+	resp, _, err := doWithRetry(context.Background(), srv.Client(), "POST", srv.URL, "json", []byte(`{}`), "tkn", "", "", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -233,7 +233,7 @@ func TestDoWithRetry_GivesUpAfterMaxAttempts(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	resp, _, err := doWithRetry(context.Background(), srv.Client(), "POST", srv.URL, []byte(`{}`), "tkn", false)
+	resp, _, err := doWithRetry(context.Background(), srv.Client(), "POST", srv.URL, "json", []byte(`{}`), "tkn", "", "", false)
 	if err == nil {
 		if resp != nil {
 			resp.Body.Close()
@@ -264,7 +264,7 @@ func TestDoWithRetry_CancelDuringBackoff(t *testing.T) {
 		cancel()
 	}()
 
-	_, _, err := doWithRetry(ctx, srv.Client(), "POST", srv.URL, []byte(`{}`), "tkn", false)
+	_, _, err := doWithRetry(ctx, srv.Client(), "POST", srv.URL, "json", []byte(`{}`), "tkn", "", "", false)
 	if err == nil {
 		t.Fatal("expected context.Canceled error, got nil")
 	}
@@ -274,6 +274,27 @@ func TestDoWithRetry_CancelDuringBackoff(t *testing.T) {
 	// We allow either 1 or 2 attempts before cancel races in.
 	if got := atomic.LoadInt32(&calls); got > 2 {
 		t.Errorf("cancel should stop retries quickly, got %d attempts", got)
+	}
+}
+
+// ---- apiKeySign -------------------------------------------------------------
+
+func TestAPIKeySign_KnownValue(t *testing.T) {
+	// Verify the HMAC-SHA1 formula: hex(sha1(ts + secret + body + secret))
+	// Expected value cross-checked independently:
+	//   python3 -c "import hashlib; print(hashlib.sha1(b'1700000000mysecret{}mysecret').hexdigest())"
+	const want = "8c5cd99f9cfa598f65e6b3fae56cc859cecd5ee6"
+	got := apiKeySign("mysecret", "1700000000", "{}")
+	if got != want {
+		t.Errorf("apiKeySign formula mismatch:\n  got  %q\n  want %q", got, want)
+	}
+	// Different secret must produce a different signature.
+	if got2 := apiKeySign("othersecret", "1700000000", "{}"); got == got2 {
+		t.Error("different secrets should produce different signatures")
+	}
+	// Different timestamp must produce a different signature.
+	if got3 := apiKeySign("mysecret", "1700000001", "{}"); got == got3 {
+		t.Error("different timestamps should produce different signatures")
 	}
 }
 

--- a/plugins/corezoid/mcp-server/executor_process.go
+++ b/plugins/corezoid/mcp-server/executor_process.go
@@ -6,15 +6,70 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
 
+// fetchDownload downloads the content at downloadURL and returns the raw bytes.
+//
+// Auth strategy:
+//   - Simulator token → Authorization: Simulator <token> header, URL unchanged.
+//   - API key (no token) → URL extended with /{API_LOGIN}/{TIMESTAMP}/{SIGNATURE}.
+//     Signature uses empty body: hex(sha1(ts + secret + "" + secret)).
+//     This is the documented Corezoid pattern for authenticating file downloads
+//     with an API key.
+//
+// HTTP status is checked: any 4xx/5xx is returned as an error with the first
+// 256 bytes of the response body for diagnosis.
+func (v *Executor) fetchDownload(downloadURL string) ([]byte, error) {
+	var reqURL string
+	if v.Token != "" {
+		reqURL = downloadURL
+	} else {
+		ts := strconv.FormatInt(time.Now().Unix(), 10)
+		sig := apiKeySign(v.APISecret, ts, "")
+		reqURL = fmt.Sprintf("%s/%s/%s/%s", downloadURL, v.APILogin, ts, sig)
+	}
+
+	req, err := http.NewRequestWithContext(v.Ctx, "GET", reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build download request: %w", err)
+	}
+	if v.Token != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Simulator %s", v.Token))
+	}
+
+	resp, err := newHTTPClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read download response: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		snippet := body
+		if len(snippet) > 256 {
+			snippet = snippet[:256]
+		}
+		return nil, fmt.Errorf("download failed with HTTP %d: %s", resp.StatusCode, snippet)
+	}
+	return body, nil
+}
+
 // PullZip exports a process or folder as a ZIP archive and returns the raw bytes.
 func (v *Executor) PullZip(id int, objType string) ([]byte, error) {
+	// /api/2/download (Simulator) accepts type="download".
+	// /api/2/json (API key) only accepts type="create" — "download" returns "undefined request".
+	opType := "create"
+	if v.Token != "" {
+		opType = "download"
+	}
 	ops := []map[string]any{
 		{
-			"type":       "create",
+			"type":       opType,
 			"obj":        "obj_scheme",
 			"obj_id":     id,
 			"company_id": v.WorkspaceID,
@@ -39,95 +94,25 @@ func (v *Executor) PullZip(id int, objType string) ([]byte, error) {
 	if !ok {
 		return nil, fmt.Errorf("failed to export process: unexpected ops format")
 	}
-	downloadURL1, ok := firstOp["download_url"].(string)
-	if !ok || downloadURL1 == "" {
+	downloadURL, ok := firstOp["download_url"].(string)
+	if !ok || downloadURL == "" {
 		return nil, fmt.Errorf("failed to export process: no download_url in response")
 	}
-
-	req, err := http.NewRequest("GET", downloadURL1, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	if v.Token != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Simulator %s", v.Token))
-	}
-	resp, err := newHTTPClient().Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to download process: %v", err)
-	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read process: %v", err)
-	}
-	return body, nil
-}
-
-// PullFolder exports all processes in a folder as a JSON array.
-func (v *Executor) PullFolder(id int, objType string) ([]any, error) {
-	ops := []map[string]any{
-		{
-			"type":       "create",
-			"obj":        "obj_scheme",
-			"obj_id":     id,
-			"company_id": v.WorkspaceID,
-			"obj_type":   objType,
-			"with_alias": true,
-			"async":      false,
-			"format":     "json",
-		},
-	}
-	response, err := v.req("export_process", ops)
-	if err != nil {
-		return nil, fmt.Errorf("failed to export process: %w", err)
-	}
-	if response["request_proc"] != "ok" {
-		return nil, fmt.Errorf("failed to export process: %v", response)
-	}
-	ops1, ok := response["ops"].([]any)
-	if !ok || len(ops1) == 0 {
-		return nil, fmt.Errorf("failed to export process: no ops in response")
-	}
-	firstOp, ok := ops1[0].(map[string]any)
-	if !ok {
-		return nil, fmt.Errorf("failed to export process: unexpected ops format")
-	}
-	downloadURL1, ok := firstOp["download_url"].(string)
-	if !ok || downloadURL1 == "" {
-		return nil, fmt.Errorf("failed to export process: no download_url in response")
-	}
-
-	req, err := http.NewRequest("GET", downloadURL1, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	if v.Token != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Simulator %s", v.Token))
-	}
-	resp, err := newHTTPClient().Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to download process: %v", err)
-	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read process: %v", err)
-	}
-	var processes []any
-	err = json.Unmarshal(body, &processes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal process: %v", err)
-	}
-	return processes, nil
+	return v.fetchDownload(downloadURL)
 }
 
 // ExportProcess downloads the current process definition as parsed JSON.
+// Both Simulator and API key modes use /api/2/download and follow the download_url.
+// fetchDownload handles auth: Simulator uses an Authorization header; API key
+// appends /{login}/{ts}/{sig} to the URL.
 func (v *Executor) ExportProcess() (any, error) {
+	opType := "create"
+	if v.Token != "" {
+		opType = "download"
+	}
 	ops := []map[string]any{
 		{
-			"type":       "create",
+			"type":       opType,
 			"obj":        "obj_scheme",
 			"obj_id":     v.ProcessID,
 			"company_id": v.WorkspaceID,
@@ -144,6 +129,8 @@ func (v *Executor) ExportProcess() (any, error) {
 	if response["request_proc"] != "ok" {
 		return nil, fmt.Errorf("failed to export process: %v", response)
 	}
+
+	// Follow download_url.
 	ops1, ok := response["ops"].([]any)
 	if !ok || len(ops1) == 0 {
 		return nil, fmt.Errorf("failed to export process: no ops in response")
@@ -152,32 +139,17 @@ func (v *Executor) ExportProcess() (any, error) {
 	if !ok {
 		return nil, fmt.Errorf("failed to export process: unexpected ops format")
 	}
-	downloadURL1, ok := firstOp["download_url"].(string)
-	if !ok || downloadURL1 == "" {
+	downloadURL, ok := firstOp["download_url"].(string)
+	if !ok || downloadURL == "" {
 		return nil, fmt.Errorf("failed to export process: no download_url in response")
 	}
-
-	req, err := http.NewRequest("GET", downloadURL1, nil)
+	body, err := v.fetchDownload(downloadURL)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Content-Type", "application/json")
-	if v.Token != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Simulator %s", v.Token))
-	}
-	resp, err := newHTTPClient().Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to download process: %v", err)
-	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read process: %v", err)
-	}
 	var process []any
-	err = json.Unmarshal(body, &process)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal process: %v", err)
+	if err = json.Unmarshal(body, &process); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal process: %w", err)
 	}
 	return process, nil
 }

--- a/plugins/corezoid/mcp-server/git-sync.go
+++ b/plugins/corezoid/mcp-server/git-sync.go
@@ -1,0 +1,289 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// GitSyncConfig holds all parameters needed for git mirror operations.
+// All fields except StagePath come from env vars (see loadGitSyncConfig).
+// StagePath is set at call time from the resolved project/stage names.
+type GitSyncConfig struct {
+	LoginID   string // COREZOID_LOGIN — API key login_id (numeric string)
+	Secret    string // COREZOID_SECRET — API key secret
+	CompanyID string // WORKSPACE_ID   — company UUID or iXXXXX
+	BaseURL   string // COREZOID_API_URL
+	WorkDir   string // base dir; .git-context/ is created here
+	StagePath string // "projects/<id>_<Name>/stages/<id>_<Name>" — set per-request
+}
+
+// IsConfigured returns true when all required fields are present.
+// Missing credentials → all git operations are silently skipped.
+func (c *GitSyncConfig) IsConfigured() bool {
+	return c.LoginID != "" && c.Secret != "" && c.CompanyID != "" && c.BaseURL != ""
+}
+
+// RepoURL builds the authenticated HTTPS clone URL.
+// url.UserPassword is used so that special characters in the secret
+// (@ : / #) are correctly percent-encoded in the userinfo component.
+func (c *GitSyncConfig) RepoURL() string {
+	u, err := url.Parse(c.BaseURL)
+	if err != nil || u.Host == "" {
+		return ""
+	}
+	repoURL := &url.URL{
+		Scheme: "https",
+		User:   url.UserPassword(c.LoginID, c.Secret),
+		Host:   u.Host,
+		Path:   "/corezoid-dev/c-" + c.CompanyID + ".git",
+	}
+	return repoURL.String()
+}
+
+// gitContextDir returns the local path where the sparse clone is kept.
+func (c *GitSyncConfig) gitContextDir() string {
+	base := c.WorkDir
+	if base == "" {
+		base, _ = os.Getwd()
+	}
+	return filepath.Join(base, ".git-context")
+}
+
+// gitRun executes a git command in dir with a timeout.
+// Returns combined stdout+stderr and any error.
+// Credential-bearing URLs in args are redacted in error messages.
+func gitRun(dir string, timeout time.Duration, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(out), fmt.Errorf("git %s: %w\n%s", strings.Join(redactGitArgs(args), " "), err, out)
+	}
+	return string(out), nil
+}
+
+// redactGitArgs returns a copy of args with any https://user:pass@host URL
+// replaced by its redacted form (password → "xxxxx").
+func redactGitArgs(args []string) []string {
+	out := make([]string, len(args))
+	for i, a := range args {
+		if u, err := url.Parse(a); err == nil && u.User != nil {
+			out[i] = u.Redacted()
+		} else {
+			out[i] = a
+		}
+	}
+	return out
+}
+
+// buildSparsePaths returns the cone-mode directory list for sparse checkout.
+// Cone mode automatically includes top-level files of all ancestor directories,
+// so CLAUDE.md at workspace/project/stage level is included for free.
+func buildSparsePaths(cfg GitSyncConfig) []string {
+	// Root _ext/ is always included.
+	paths := []string{"_ext"}
+
+	if cfg.StagePath == "" {
+		return paths
+	}
+	// StagePath = "projects/<id>_<Name>/stages/<id>_<Name>"
+	parts := strings.SplitN(cfg.StagePath, "/stages/", 2)
+	if len(parts) == 2 {
+		projectPath := parts[0] // "projects/<id>_<Name>"
+		paths = append(paths,
+			projectPath+"/_ext",
+			cfg.StagePath+"/_ext",
+		)
+	}
+	return paths
+}
+
+// GitPull performs a sparse checkout of CLAUDE.md + _ext/ for the current stage.
+// First call: clones. Subsequent calls: pulls with --rebase.
+// Never returns a fatal error — caller logs and continues without git context.
+func GitPull(cfg GitSyncConfig) error {
+	if !cfg.IsConfigured() {
+		logger.Debug("[git-sync] not configured, skipping pull")
+		return nil
+	}
+
+	contextDir := cfg.gitContextDir()
+	gitDir := filepath.Join(contextDir, ".git")
+
+	if _, err := os.Stat(gitDir); os.IsNotExist(err) {
+		return gitInitialClone(cfg, contextDir)
+	}
+	return gitPullRebase(cfg, contextDir)
+}
+
+// gitInitialClone creates a shallow sparse clone of the git mirror.
+func gitInitialClone(cfg GitSyncConfig, contextDir string) error {
+	if err := os.MkdirAll(contextDir, 0755); err != nil {
+		return fmt.Errorf("[git-sync] mkdir %s: %w", contextDir, err)
+	}
+
+	repoURL := cfg.RepoURL()
+	if repoURL == "" {
+		return fmt.Errorf("[git-sync] could not build repo URL from base URL %q", cfg.BaseURL)
+	}
+
+	sparseSetArgs := append([]string{"sparse-checkout", "set"}, buildSparsePaths(cfg)...)
+
+	steps := []struct {
+		timeout time.Duration
+		args    []string
+	}{
+		{5 * time.Second, []string{"init"}},
+		{5 * time.Second, []string{"remote", "add", "origin", repoURL}},
+		{5 * time.Second, []string{"sparse-checkout", "init", "--cone"}},
+		{5 * time.Second, sparseSetArgs},
+		{30 * time.Second, []string{"fetch", "--depth=1", "origin"}},
+		// checkout -b creates a local branch so pull --rebase and push work correctly.
+		{10 * time.Second, []string{"checkout", "-b", "main", "FETCH_HEAD"}},
+		{5 * time.Second, []string{"branch", "--set-upstream-to=origin/main", "main"}},
+	}
+
+	for _, s := range steps {
+		if _, err := gitRun(contextDir, s.timeout, s.args...); err != nil {
+			return fmt.Errorf("[git-sync] clone step %v: %w", s.args[0], err)
+		}
+	}
+
+	logger.Info("[git-sync] cloned context for stage %q", cfg.StagePath)
+	return nil
+}
+
+// gitPullRebase refreshes the sparse clone and rebases any local _ext/ commits.
+func gitPullRebase(cfg GitSyncConfig, contextDir string) error {
+	// Keep credentials current in case they changed.
+	if repoURL := cfg.RepoURL(); repoURL != "" {
+		_, _ = gitRun(contextDir, 5*time.Second, "remote", "set-url", "origin", repoURL)
+	}
+
+	// Update sparse paths in case StagePath changed.
+	paths := buildSparsePaths(cfg)
+	sparsePaths := append([]string{"sparse-checkout", "set"}, paths...)
+	if _, err := gitRun(contextDir, 5*time.Second, sparsePaths...); err != nil {
+		logger.Warn("[git-sync] sparse-checkout update failed: %v", err)
+	}
+
+	if _, err := gitRun(contextDir, 15*time.Second, "pull", "--rebase", "origin", "main"); err != nil {
+		return fmt.Errorf("[git-sync] pull --rebase: %w", err)
+	}
+
+	logger.Info("[git-sync] pulled context for stage %q", cfg.StagePath)
+	return nil
+}
+
+// GitPush commits local _ext/ changes and pushes to the mirror.
+// Returns a descriptive error if push is rejected (403 = not yet enabled).
+func GitPush(cfg GitSyncConfig, message string) error {
+	if !cfg.IsConfigured() {
+		logger.Debug("[git-sync] not configured, skipping push")
+		return nil
+	}
+
+	contextDir := cfg.gitContextDir()
+	if _, err := os.Stat(contextDir); os.IsNotExist(err) {
+		return fmt.Errorf("[git-sync] context dir not found — run git-pull-context first")
+	}
+
+	// Stage _ext/ only.
+	extPath := gitExtPath(cfg, contextDir)
+	if _, err := gitRun(contextDir, 5*time.Second, "add", extPath); err != nil {
+		return fmt.Errorf("[git-sync] git add: %w", err)
+	}
+
+	// Nothing to commit?
+	status, err := gitRun(contextDir, 5*time.Second, "status", "--porcelain")
+	if err != nil {
+		return fmt.Errorf("[git-sync] git status: %w", err)
+	}
+	if strings.TrimSpace(status) == "" {
+		logger.Debug("[git-sync] nothing to push")
+		return nil
+	}
+
+	if message == "" {
+		message = fmt.Sprintf("docs: update _ext/docs/ after task session %s", time.Now().UTC().Format(time.RFC3339))
+	}
+	if _, err := gitRun(contextDir, 5*time.Second, "commit", "-m", message); err != nil {
+		return fmt.Errorf("[git-sync] git commit: %w", err)
+	}
+
+	// Pull --rebase before push to minimise conflicts.
+	if _, err := gitRun(contextDir, 15*time.Second, "pull", "--rebase", "origin", "main"); err != nil {
+		logger.Warn("[git-sync] pull before push failed (continuing): %v", err)
+	}
+
+	if _, err := gitRun(contextDir, 15*time.Second, "push", "origin", "main"); err != nil {
+		output := err.Error()
+		if strings.Contains(output, "403") {
+			return fmt.Errorf("[git-sync] push not yet available (server-side push access pending). Changes committed locally in .git-context/")
+		}
+		return fmt.Errorf("[git-sync] push: %w", err)
+	}
+
+	logger.Info("[git-sync] pushed _ext/ changes")
+	return nil
+}
+
+// ReadContextFile reads a file from _ext/ relative to the current stage path.
+// path should be like "_ext/docs/context.md".
+// Returns (content, true) on success or ("", false) if not found.
+func ReadContextFile(cfg GitSyncConfig, path string) (string, bool) {
+	fullPath := gitStagePath(cfg, path)
+	data, err := os.ReadFile(fullPath)
+	if err != nil {
+		return "", false
+	}
+	return string(data), true
+}
+
+// UpdateContextFile writes content to a file in _ext/docs/ for the current stage.
+// mode "append" appends; mode "replace" overwrites.
+func UpdateContextFile(cfg GitSyncConfig, path string, content string, mode string) error {
+	fullPath := gitStagePath(cfg, path)
+
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+		return fmt.Errorf("[git-sync] mkdir for %s: %w", path, err)
+	}
+
+	if mode == "append" {
+		f, err := os.OpenFile(fullPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			return fmt.Errorf("[git-sync] open %s: %w", path, err)
+		}
+		defer f.Close()
+		_, err = f.WriteString(content)
+		return err
+	}
+
+	return os.WriteFile(fullPath, []byte(content), 0644)
+}
+
+// gitStagePath builds an absolute path inside .git-context for the given relative path.
+// If StagePath is set, the path is relative to the stage directory.
+func gitStagePath(cfg GitSyncConfig, relPath string) string {
+	contextDir := cfg.gitContextDir()
+	if cfg.StagePath != "" {
+		return filepath.Join(contextDir, cfg.StagePath, relPath)
+	}
+	return filepath.Join(contextDir, relPath)
+}
+
+// gitExtPath returns the absolute path to the _ext/ directory of the current stage.
+func gitExtPath(cfg GitSyncConfig, contextDir string) string {
+	if cfg.StagePath != "" {
+		return filepath.Join(contextDir, cfg.StagePath, "_ext")
+	}
+	return filepath.Join(contextDir, "_ext")
+}

--- a/plugins/corezoid/mcp-server/git-sync_test.go
+++ b/plugins/corezoid/mcp-server/git-sync_test.go
@@ -1,0 +1,259 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- GitSyncConfig.IsConfigured ---
+
+func TestGitSyncConfig_IsConfigured_AllFields(t *testing.T) {
+	cfg := GitSyncConfig{
+		LoginID:   "52210",
+		Secret:    "secret123",
+		CompanyID: "ace69ce6-ee38-4297-b0a2-39ce4ba8eb9a",
+		BaseURL:   "https://git-dev.dev.corezoid.com",
+	}
+	if !cfg.IsConfigured() {
+		t.Error("expected IsConfigured=true when all fields set")
+	}
+}
+
+func TestGitSyncConfig_IsConfigured_MissingLogin(t *testing.T) {
+	cfg := GitSyncConfig{
+		Secret:    "secret123",
+		CompanyID: "ace69ce6",
+		BaseURL:   "https://git-dev.dev.corezoid.com",
+	}
+	if cfg.IsConfigured() {
+		t.Error("expected IsConfigured=false when LoginID missing")
+	}
+}
+
+func TestGitSyncConfig_IsConfigured_MissingSecret(t *testing.T) {
+	cfg := GitSyncConfig{
+		LoginID:   "52210",
+		CompanyID: "ace69ce6",
+		BaseURL:   "https://git-dev.dev.corezoid.com",
+	}
+	if cfg.IsConfigured() {
+		t.Error("expected IsConfigured=false when Secret missing")
+	}
+}
+
+func TestGitSyncConfig_IsConfigured_Empty(t *testing.T) {
+	cfg := GitSyncConfig{}
+	if cfg.IsConfigured() {
+		t.Error("expected IsConfigured=false for empty config")
+	}
+}
+
+// --- GitSyncConfig.RepoURL ---
+
+func TestGitSyncConfig_RepoURL_UUID(t *testing.T) {
+	cfg := GitSyncConfig{
+		LoginID:   "52210",
+		Secret:    "plainSecret",
+		CompanyID: "ace69ce6-ee38-4297-b0a2-39ce4ba8eb9a",
+		BaseURL:   "https://git-dev.dev.corezoid.com",
+	}
+	got := cfg.RepoURL()
+	want := "https://52210:plainSecret@git-dev.dev.corezoid.com/corezoid-dev/c-ace69ce6-ee38-4297-b0a2-39ce4ba8eb9a.git"
+	if got != want {
+		t.Errorf("RepoURL UUID:\n got  %s\n want %s", got, want)
+	}
+}
+
+func TestGitSyncConfig_RepoURL_OldFormat(t *testing.T) {
+	cfg := GitSyncConfig{
+		LoginID:   "52210",
+		Secret:    "sec",
+		CompanyID: "i188280",
+		BaseURL:   "https://git-dev.dev.corezoid.com",
+	}
+	got := cfg.RepoURL()
+	if !strings.Contains(got, "c-i188280") {
+		t.Errorf("expected c-i188280 in URL, got %s", got)
+	}
+}
+
+func TestGitSyncConfig_RepoURL_SpecialCharsInSecret(t *testing.T) {
+	cfg := GitSyncConfig{
+		LoginID:   "52210",
+		Secret:    "p@ss:w/ord#1",
+		CompanyID: "company-id",
+		BaseURL:   "https://git-dev.dev.corezoid.com",
+	}
+	got := cfg.RepoURL()
+	// Special chars must be percent-encoded so they don't break URL parsing.
+	if strings.Contains(got, "p@ss") {
+		t.Errorf("raw @ in secret not encoded in URL: %s", got)
+	}
+	// url.UserPassword encodes @ as %40 in the password field.
+	if !strings.Contains(got, "%40") {
+		t.Errorf("expected %%40 for @ in secret, got %s", got)
+	}
+}
+
+func TestGitSyncConfig_RepoURL_InvalidBaseURL(t *testing.T) {
+	cfg := GitSyncConfig{
+		LoginID:   "52210",
+		Secret:    "sec",
+		CompanyID: "company",
+		BaseURL:   "not-a-url",
+	}
+	got := cfg.RepoURL()
+	if got != "" {
+		t.Errorf("expected empty RepoURL for invalid BaseURL, got %s", got)
+	}
+}
+
+// --- buildSparsePaths ---
+
+func TestBuildSparsePaths_NoStagePath(t *testing.T) {
+	cfg := GitSyncConfig{}
+	paths := buildSparsePaths(cfg)
+	if len(paths) != 1 || paths[0] != "_ext" {
+		t.Errorf("expected [_ext], got %v", paths)
+	}
+}
+
+func TestBuildSparsePaths_WithStagePath(t *testing.T) {
+	cfg := GitSyncConfig{
+		StagePath: "projects/188280_Smart_Form/stages/188281_develop",
+	}
+	paths := buildSparsePaths(cfg)
+
+	want := map[string]bool{
+		"_ext":                                                              true,
+		"projects/188280_Smart_Form/_ext":                                  true,
+		"projects/188280_Smart_Form/stages/188281_develop/_ext":            true,
+	}
+	if len(paths) != len(want) {
+		t.Errorf("expected %d paths, got %d: %v", len(want), len(paths), paths)
+	}
+	for _, p := range paths {
+		if !want[p] {
+			t.Errorf("unexpected path %q in sparse paths", p)
+		}
+	}
+}
+
+// --- GitPull with unconfigured config ---
+
+func TestGitPull_NotConfigured_ReturnsNil(t *testing.T) {
+	cfg := GitSyncConfig{} // empty — not configured
+	if err := GitPull(cfg); err != nil {
+		t.Errorf("GitPull on unconfigured config should return nil, got: %v", err)
+	}
+}
+
+// --- GitPush with unconfigured config ---
+
+func TestGitPush_NotConfigured_ReturnsNil(t *testing.T) {
+	cfg := GitSyncConfig{}
+	if err := GitPush(cfg, ""); err != nil {
+		t.Errorf("GitPush on unconfigured config should return nil, got: %v", err)
+	}
+}
+
+// --- ReadContextFile / UpdateContextFile ---
+
+func TestReadContextFile_NotFound(t *testing.T) {
+	cfg := GitSyncConfig{WorkDir: t.TempDir()}
+	content, found := ReadContextFile(cfg, "_ext/docs/context.md")
+	if found {
+		t.Error("expected found=false for missing file")
+	}
+	if content != "" {
+		t.Errorf("expected empty content, got %q", content)
+	}
+}
+
+func TestUpdateContextFile_Replace(t *testing.T) {
+	dir := t.TempDir()
+	cfg := GitSyncConfig{WorkDir: dir}
+
+	if err := UpdateContextFile(cfg, "_ext/docs/context.md", "hello world", "replace"); err != nil {
+		t.Fatalf("UpdateContextFile replace: %v", err)
+	}
+
+	content, found := ReadContextFile(cfg, "_ext/docs/context.md")
+	if !found {
+		t.Fatal("expected file to exist after write")
+	}
+	if content != "hello world" {
+		t.Errorf("unexpected content: %q", content)
+	}
+}
+
+func TestUpdateContextFile_Append(t *testing.T) {
+	dir := t.TempDir()
+	cfg := GitSyncConfig{WorkDir: dir}
+
+	if err := UpdateContextFile(cfg, "_ext/docs/issues.md", "line1\n", "replace"); err != nil {
+		t.Fatalf("initial write: %v", err)
+	}
+	if err := UpdateContextFile(cfg, "_ext/docs/issues.md", "line2\n", "append"); err != nil {
+		t.Fatalf("append: %v", err)
+	}
+
+	content, _ := ReadContextFile(cfg, "_ext/docs/issues.md")
+	if !strings.Contains(content, "line1") || !strings.Contains(content, "line2") {
+		t.Errorf("expected both lines, got %q", content)
+	}
+}
+
+func TestUpdateContextFile_CreatesSubdirs(t *testing.T) {
+	dir := t.TempDir()
+	cfg := GitSyncConfig{WorkDir: dir}
+
+	if err := UpdateContextFile(cfg, "_ext/docs/decisions.md", "decision1", "replace"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedPath := filepath.Join(dir, ".git-context", "_ext", "docs", "decisions.md")
+	if _, err := os.Stat(expectedPath); err != nil {
+		t.Errorf("expected file at %s, got error: %v", expectedPath, err)
+	}
+}
+
+func TestUpdateContextFile_WithStagePath(t *testing.T) {
+	dir := t.TempDir()
+	cfg := GitSyncConfig{
+		WorkDir:   dir,
+		StagePath: "projects/188280_Test/stages/188281_develop",
+	}
+
+	if err := UpdateContextFile(cfg, "_ext/docs/context.md", "stage context", "replace"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	expectedPath := filepath.Join(dir, ".git-context",
+		"projects/188280_Test/stages/188281_develop",
+		"_ext/docs/context.md")
+	if _, err := os.Stat(expectedPath); err != nil {
+		t.Errorf("expected file at %s: %v", expectedPath, err)
+	}
+}
+
+// --- gitContextDir ---
+
+func TestGitContextDir_UsesWorkDir(t *testing.T) {
+	cfg := GitSyncConfig{WorkDir: "/tmp/myproject"}
+	got := cfg.gitContextDir()
+	want := "/tmp/myproject/.git-context"
+	if got != want {
+		t.Errorf("gitContextDir: got %s, want %s", got, want)
+	}
+}
+
+func TestGitContextDir_FallsBackToCwd(t *testing.T) {
+	cfg := GitSyncConfig{} // no WorkDir
+	got := cfg.gitContextDir()
+	if !strings.HasSuffix(got, ".git-context") {
+		t.Errorf("expected path ending in .git-context, got %s", got)
+	}
+}

--- a/plugins/corezoid/mcp-server/main.go
+++ b/plugins/corezoid/mcp-server/main.go
@@ -49,6 +49,14 @@ var insecureTLS bool
 var gitLoginID string
 var gitSecret string
 
+// apiLogin and apiSecret are the Corezoid API key credentials (API_LOGIN /
+// API_SECRET). They provide an alternative to OAuth2 PKCE for environments
+// where browser-based authentication is not available. When both are set,
+// requests are signed with HMAC-SHA1 instead of using a Simulator bearer token.
+// These are distinct from gitLoginID / gitSecret which are used for git-sync.
+var apiLogin string
+var apiSecret string
+
 // authSnapshot returns a coherent snapshot of the auth-state globals taken
 // under the read lock. Callers that subsequently need to mutate state must
 // acquire authStateMu.Lock() (not upgrade — Go's RWMutex doesn't support that).
@@ -56,6 +64,14 @@ func authSnapshot() (apiURLv, tokenv, workspaceIDv, accountURLv string, stageIDv
 	authStateMu.RLock()
 	defer authStateMu.RUnlock()
 	return apiURL, apiToken, workspaceID, accountURL, stageID
+}
+
+// apiKeySnapshot returns a coherent snapshot of the API key credentials taken
+// under the read lock. Same pattern as authSnapshot.
+func apiKeySnapshot() (login, secret string) {
+	authStateMu.RLock()
+	defer authStateMu.RUnlock()
+	return apiLogin, apiSecret
 }
 
 // withAuthLock runs fn while holding the auth-state write lock. Use for
@@ -161,6 +177,8 @@ func loadConfig() {
 	insecureTLS = os.Getenv("COREZOID_INSECURE_TLS") != ""
 	gitLoginID = os.Getenv("COREZOID_LOGIN")
 	gitSecret = os.Getenv("COREZOID_SECRET")
+	apiLogin = os.Getenv("API_LOGIN")
+	apiSecret = os.Getenv("API_SECRET")
 }
 
 // runCLI executes a single MCP tool from the command line and exits.
@@ -230,11 +248,14 @@ func main() {
 	loadConfig()
 	logger.Debug("Loaded configuration: apiURL=%s workspaceID=%s apigwURL=%s hasToken=%v", apiURL, workspaceID, apigwURL, apiToken != "")
 
-	if apiToken == "" {
+	if apiToken == "" && (apiLogin == "" || apiSecret == "") {
 		fmt.Fprintln(os.Stderr, "[corezoid-mcp] NOTICE: No credentials found.")
-		fmt.Fprintln(os.Stderr, "[corezoid-mcp] Run the 'login' MCP tool to authenticate via OAuth2.")
+		fmt.Fprintln(os.Stderr, "[corezoid-mcp] Authenticate via one of:")
+		fmt.Fprintln(os.Stderr, "[corezoid-mcp]   1. OAuth2 browser flow — run the 'login' MCP tool.")
+		fmt.Fprintln(os.Stderr, "[corezoid-mcp]   2. API key — set API_LOGIN and API_SECRET in your project .env,")
+		fmt.Fprintln(os.Stderr, "[corezoid-mcp]      then call the 'login' MCP tool to select workspace/stage.")
 		if credPath, err := credentialsFilePath(); err == nil {
-			fmt.Fprintf(os.Stderr, "[corezoid-mcp] Token will be saved to: %s\n", credPath)
+			fmt.Fprintf(os.Stderr, "[corezoid-mcp] OAuth2 token will be saved to: %s\n", credPath)
 		}
 	}
 

--- a/plugins/corezoid/mcp-server/main.go
+++ b/plugins/corezoid/mcp-server/main.go
@@ -46,6 +46,8 @@ var debug bool
 var apigwURL string
 var stageID int
 var insecureTLS bool
+var gitLoginID string
+var gitSecret string
 
 // authSnapshot returns a coherent snapshot of the auth-state globals taken
 // under the read lock. Callers that subsequently need to mutate state must
@@ -157,6 +159,8 @@ func loadConfig() {
 	}
 	stageID, _ = strconv.Atoi(os.Getenv("COREZOID_STAGE_ID"))
 	insecureTLS = os.Getenv("COREZOID_INSECURE_TLS") != ""
+	gitLoginID = os.Getenv("COREZOID_LOGIN")
+	gitSecret = os.Getenv("COREZOID_SECRET")
 }
 
 // runCLI executes a single MCP tool from the command line and exits.
@@ -519,4 +523,52 @@ func fixStruct(dataBin string, inProcessID int) (string, []string) {
 		return dataBin, messages
 	}
 	return string(dataRspBin), messages
+}
+
+// loadGitSyncConfig builds a GitSyncConfig from the current auth globals.
+// StagePath is left empty — callers set it from the resolved project/stage names.
+func loadGitSyncConfig() GitSyncConfig {
+	authStateMu.RLock()
+	loginID := gitLoginID
+	secret := gitSecret
+	wsID := workspaceID
+	baseURL := apiURL
+	authStateMu.RUnlock()
+
+	workDir, _ := os.Getwd()
+	return GitSyncConfig{
+		LoginID:   loginID,
+		Secret:    secret,
+		CompanyID: wsID,
+		BaseURL:   baseURL,
+		WorkDir:   workDir,
+	}
+}
+
+// buildGitStagePath resolves the git mirror path for the given Corezoid folder.
+// It calls ShowFolder to walk up to the stage and project and formats:
+// "projects/<projectId>_<ProjectName>/stages/<stageId>_<StageName>"
+func buildGitStagePath(v *Executor, folderID int) (string, error) {
+	stageInfo, err := v.ShowFolder(folderID)
+	if err != nil {
+		return "", fmt.Errorf("ShowFolder(%d): %w", folderID, err)
+	}
+
+	// obj_type 3 = stage
+	if stageInfo.ObjType != 3 {
+		return "", fmt.Errorf("folder %d is not a stage (obj_type=%d)", folderID, stageInfo.ObjType)
+	}
+
+	projectInfo, err := v.ShowFolder(stageInfo.ParentObjID)
+	if err != nil {
+		return "", fmt.Errorf("ShowFolder(project %d): %w", stageInfo.ParentObjID, err)
+	}
+
+	stageName := strings.ReplaceAll(stageInfo.Title, " ", "_")
+	projectName := strings.ReplaceAll(projectInfo.Title, " ", "_")
+
+	return fmt.Sprintf("projects/%d_%s/stages/%d_%s",
+		projectInfo.ObjID, projectName,
+		stageInfo.ObjID, stageName,
+	), nil
 }

--- a/plugins/corezoid/mcp-server/main_config_test.go
+++ b/plugins/corezoid/mcp-server/main_config_test.go
@@ -140,9 +140,11 @@ func snapshotConfigGlobals(t *testing.T) {
 	t.Helper()
 	prevAPI, prevAcc, prevWS, prevTok, prevGW := apiURL, accountURL, workspaceID, apiToken, apigwURL
 	prevStage, prevInsecure := stageID, insecureTLS
+	prevAPILogin, prevAPISecret := apiLogin, apiSecret
 	t.Cleanup(func() {
 		apiURL, accountURL, workspaceID, apiToken, apigwURL = prevAPI, prevAcc, prevWS, prevTok, prevGW
 		stageID, insecureTLS = prevStage, prevInsecure
+		apiLogin, apiSecret = prevAPILogin, prevAPISecret
 	})
 }
 

--- a/plugins/corezoid/mcp-server/mcp_discovery.go
+++ b/plugins/corezoid/mcp-server/mcp_discovery.go
@@ -139,10 +139,12 @@ func fetchStageList(ctx context.Context, companyID string, projectID int64) ([]s
 	return result, nil
 }
 
-// ensureTokenAuth checks that a valid API token is present. If apiToken is
-// empty it attempts to load saved OAuth credentials; the check-then-load-then-set
-// runs under the auth write lock so concurrent requests can't double-load or
-// race the read against the write.
+// ensureTokenAuth checks that a valid API token or API key credentials are
+// present. If apiToken is empty it attempts to load saved OAuth credentials;
+// if those are also absent, API key credentials (apiLogin + apiSecret) are
+// checked as a fallback. The check-then-load-then-set runs under the auth
+// write lock so concurrent requests can't double-load or race the read against
+// the write.
 func ensureTokenAuth() error {
 	_, snapToken, _, _, _ := authSnapshot()
 	if snapToken == "" {
@@ -158,7 +160,12 @@ func ensureTokenAuth() error {
 		}
 	}
 	if snapToken == "" {
-		return fmt.Errorf("[Error] Not authenticated: missing [ACCESS_TOKEN]. Invoke the 'corezoid-init' skill to set up credentials (use the Skill tool with skill=\"corezoid-init\").")
+		// Fall back to API key authentication if both login and secret are set.
+		snapAPILogin, snapAPISecret := apiKeySnapshot()
+		if snapAPILogin != "" && snapAPISecret != "" {
+			return nil
+		}
+		return fmt.Errorf("[Error] Not authenticated: missing [ACCESS_TOKEN] or [API_LOGIN + API_SECRET]. Invoke the 'corezoid-init' skill to set up credentials (use the Skill tool with skill=\"corezoid-init\").")
 	}
 	return nil
 }

--- a/plugins/corezoid/mcp-server/mcp_handlers.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers.go
@@ -82,6 +82,12 @@ var toolHandlers = map[string]toolHandler{
 
 	// feedback
 	"send-feedback": handleSendFeedback,
+
+	// git mirror context
+	"git-pull-context":     handleGitPullContext,
+	"git-push-context":     handleGitPushContext,
+	"read-context-file":    handleReadContextFile,
+	"update-context-file":  handleUpdateContextFile,
 }
 
 // noAuthTools don't need any credentials. lint runs entirely on local files;
@@ -89,10 +95,14 @@ var toolHandlers = map[string]toolHandler{
 // send-feedback must not require auth so users can report problems that
 // occurred before or during the login flow.
 var noAuthTools = map[string]struct{}{
-	"lint-process":  {},
-	"login":         {},
-	"logout":        {},
-	"send-feedback": {},
+	"lint-process":        {},
+	"login":               {},
+	"logout":              {},
+	"send-feedback":       {},
+	"git-pull-context":    {},
+	"git-push-context":    {},
+	"read-context-file":   {},
+	"update-context-file": {},
 }
 
 // tokenOnlyTools need an OAuth token but not a fully configured workspace or

--- a/plugins/corezoid/mcp-server/mcp_handlers_auth.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_auth.go
@@ -37,6 +37,15 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 		stageID, _ = strconv.Atoi(os.Getenv("COREZOID_STAGE_ID"))
 		apiURL = os.Getenv("COREZOID_API_URL")
 
+		// Reload API key credentials if currently empty (e.g. added to .env
+		// after the server started).
+		if apiLogin == "" {
+			apiLogin = os.Getenv("API_LOGIN")
+		}
+		if apiSecret == "" {
+			apiSecret = os.Getenv("API_SECRET")
+		}
+
 		// Record initial stageID to detect if it gets set during this call.
 		stageIDAtStart = stageID
 
@@ -73,13 +82,29 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 				}
 			}
 		}
+		// Handle api_login and api_secret arguments.
+		if v := optStrArg(args, "api_login"); v != "" {
+			apiLogin = v
+			os.Setenv("API_LOGIN", v)
+			if err := updateEnvFile(envPath, "API_LOGIN", v); err != nil {
+				logger.Warn("login: could not save API_LOGIN from arg: %v", err)
+			}
+		}
+		if v := optStrArg(args, "api_secret"); v != "" {
+			apiSecret = v
+			os.Setenv("API_SECRET", v)
+			if err := updateEnvFile(envPath, "API_SECRET", v); err != nil {
+				logger.Warn("login: could not save API_SECRET from arg: %v", err)
+			}
+		}
 	})
 
 	// Snapshot the post-reload state for use in this handler — long-running
 	// OAuth / elicitation must not hold the auth lock, so we drive most
 	// logic from these locals and only re-acquire the lock for writes.
 	_, snapToken, snapWorkspaceID, snapAccountURL, snapStageID := authSnapshot()
-	logger.Info("login: accountURL=%q workspaceID=%q stageID=%d", snapAccountURL, snapWorkspaceID, snapStageID)
+	snapAPILogin, snapAPISecret := apiKeySnapshot()
+	logger.Info("login: accountURL=%q workspaceID=%q stageID=%d hasAPIKey=%v", snapAccountURL, snapWorkspaceID, snapStageID, snapAPILogin != "" && snapAPISecret != "")
 
 	// Step 1: ensure Account API URL.
 	if snapAccountURL == "" {
@@ -124,9 +149,10 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 		}
 	}
 
-	// Step 2: OAuth2 PKCE browser flow (skipped if already authenticated).
+	// Step 2: OAuth2 PKCE browser flow (skipped if already authenticated or if
+	// API key credentials are present — API key auth doesn't require a browser flow).
 	var tokenExpiry time.Time
-	if snapToken == "" {
+	if snapToken == "" && !(snapAPILogin != "" && snapAPISecret != "") {
 		res, err := oauthPKCEFlow(snapAccountURL, oauthClientID)
 		if err != nil {
 			return fmt.Sprintf("Authentication failed: %v", err), true
@@ -160,7 +186,7 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 				logger.Info("login: derived COREZOID_API_URL=%q from clients API", corezoidURL)
 			}
 		}
-	} else {
+	} else if snapToken != "" {
 		// If we already have a token but no derived API URL (e.g. token came from
 		// .env directly without completing OAuth), fetch the URL now.
 		authStateMu.RLock()
@@ -178,6 +204,23 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 				}
 				logger.Info("login: derived COREZOID_API_URL=%q from clients API (pre-existing token)", corezoidURL)
 			}
+		}
+	} else {
+		// API key flow: COREZOID_API_URL cannot be derived via /face/api/1/clients
+		// (that endpoint requires a Bearer/Simulator token). Fall back to ACCOUNT_URL —
+		// in most Corezoid deployments the API is served from the same host as the
+		// admin UI. Users who need a different API host can set COREZOID_API_URL in .env.
+		authStateMu.RLock()
+		apiURLEmpty := apiURL == ""
+		authStateMu.RUnlock()
+		if apiURLEmpty && snapAccountURL != "" {
+			fallback := strings.TrimRight(snapAccountURL, "/")
+			withAuthLock(func() { apiURL = fallback })
+			os.Setenv("COREZOID_API_URL", fallback)
+			if err := updateEnvFile(envPath, "COREZOID_API_URL", fallback); err != nil {
+				logger.Warn("login: could not save COREZOID_API_URL fallback: %v", err)
+			}
+			logger.Info("login: COREZOID_API_URL not set — defaulting to ACCOUNT_URL %q", fallback)
 		}
 	}
 
@@ -460,8 +503,9 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 }
 
 // handleLogout deletes the saved credentials from ~/.corezoid/credentials and
-// clears the cached access token. The token write is under the auth lock so a
-// concurrent in-flight request can't briefly use the cleared token-before-deletion state.
+// clears the cached access token. API key credentials are also removed from the
+// project .env. The writes are under the auth lock so a concurrent in-flight
+// request can't briefly use the cleared credentials.
 func handleLogout(_ context.Context, _ map[string]interface{}) (string, bool) {
 	credPath, err := credentialsFilePath()
 	if err != nil {
@@ -470,12 +514,24 @@ func handleLogout(_ context.Context, _ map[string]interface{}) (string, bool) {
 	if err := deleteCredentials(); err != nil {
 		return fmt.Sprintf("Failed to remove credentials: %v", err), true
 	}
+	// Remove API key credentials from the project .env.
+	envPath := envFilePath()
+	if err := removeEnvKey(envPath, "API_LOGIN"); err != nil {
+		logger.Warn("logout: could not remove API_LOGIN from .env: %v", err)
+	}
+	if err := removeEnvKey(envPath, "API_SECRET"); err != nil {
+		logger.Warn("logout: could not remove API_SECRET from .env: %v", err)
+	}
+	os.Unsetenv("API_LOGIN")
+	os.Unsetenv("API_SECRET")
 	withAuthLock(func() {
 		apiToken = ""
 		accountURL = ""
 		workspaceID = ""
 		stageID = 0
 		apiURL = ""
+		apiLogin = ""
+		apiSecret = ""
 	})
 	return fmt.Sprintf("Logged out. ACCESS_TOKEN removed from %s.", credPath), false
 }

--- a/plugins/corezoid/mcp-server/mcp_handlers_git.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_git.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// handleGitPullContext performs a sparse checkout / git pull of CLAUDE.md + _ext/
+// for the current stage. Uses credentials from env (COREZOID_LOGIN / COREZOID_SECRET).
+func handleGitPullContext(ctx context.Context, args map[string]interface{}) (string, bool) {
+	cfg := loadGitSyncConfig()
+	if !cfg.IsConfigured() {
+		return "Git context skipped: COREZOID_LOGIN or COREZOID_SECRET not set.", false
+	}
+
+	if err := GitPull(cfg); err != nil {
+		return fmt.Sprintf("⚠ Git context unavailable, continuing without it.\nDetails: %v", err), false
+	}
+	return "Git context pulled successfully. CLAUDE.md and _ext/ are up to date.", false
+}
+
+// handleGitPushContext commits local _ext/ changes and pushes to the git mirror.
+func handleGitPushContext(ctx context.Context, args map[string]interface{}) (string, bool) {
+	cfg := loadGitSyncConfig()
+	if !cfg.IsConfigured() {
+		return "Git push skipped: COREZOID_LOGIN or COREZOID_SECRET not set.", false
+	}
+
+	message, _ := args["message"].(string)
+
+	if err := GitPush(cfg, message); err != nil {
+		msg := err.Error()
+		if strings.Contains(msg, "push not yet available") {
+			return "⚠ Git push not yet available (server-side push access pending). Changes committed locally in .git-context/", false
+		}
+		return fmt.Sprintf("⚠ Git push failed. Changes saved locally.\nDetails: %v", err), false
+	}
+	return "Git context pushed successfully.", false
+}
+
+// handleReadContextFile reads a file from _ext/ for the current stage.
+func handleReadContextFile(ctx context.Context, args map[string]interface{}) (string, bool) {
+	path, err := strArg(args, "path")
+	if err != nil {
+		return "Error: " + err.Error(), true
+	}
+
+	cfg := loadGitSyncConfig()
+	content, found := ReadContextFile(cfg, path)
+	if !found {
+		return fmt.Sprintf(`{"content":"","found":false,"path":%q}`, path), false
+	}
+	// json.Marshal handles all special chars: \, ", \n, \r, \t, control chars.
+	contentJSON, err := json.Marshal(content)
+	if err != nil {
+		return fmt.Sprintf("Error encoding file content: %v", err), true
+	}
+	return fmt.Sprintf(`{"content":%s,"found":true,"path":%q}`, contentJSON, path), false
+}
+
+// handleUpdateContextFile writes or appends content to a file in _ext/.
+func handleUpdateContextFile(ctx context.Context, args map[string]interface{}) (string, bool) {
+	path, err := strArg(args, "path")
+	if err != nil {
+		return "Error: " + err.Error(), true
+	}
+	content, err := strArg(args, "content")
+	if err != nil {
+		return "Error: " + err.Error(), true
+	}
+
+	mode := "append"
+	if m, ok := args["mode"].(string); ok && (m == "append" || m == "replace") {
+		mode = m
+	}
+
+	cfg := loadGitSyncConfig()
+	if err := UpdateContextFile(cfg, path, content, mode); err != nil {
+		return fmt.Sprintf("Error updating context file: %v", err), true
+	}
+	return fmt.Sprintf(`{"status":"ok","path":%q,"mode":%q}`, path, mode), false
+}

--- a/plugins/corezoid/mcp-server/mcp_handlers_process.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_process.go
@@ -102,6 +102,20 @@ func handlePullFolder(ctx context.Context, args map[string]interface{}) (string,
 	}
 
 	v := NewValidator(ctx, 0)
+
+	// Pull git context before Corezoid processes — never blocks on failure.
+	gitCfg := loadGitSyncConfig()
+	if gitCfg.IsConfigured() {
+		if stagePath, err := buildGitStagePath(v, folderID); err != nil {
+			logger.Warn("[git-sync] could not resolve stage path: %v", err)
+		} else {
+			gitCfg.StagePath = stagePath
+		}
+		if err := GitPull(gitCfg); err != nil {
+			logger.Warn("[git-sync] pull failed, continuing without git context: %v", err)
+		}
+	}
+
 	if err := downloadStageRecursively(v, folderID, "."); err != nil {
 		return fmt.Sprintf("Error fetching folder: %v", err), true
 	}

--- a/plugins/corezoid/mcp-server/pull-project.go
+++ b/plugins/corezoid/mcp-server/pull-project.go
@@ -79,13 +79,20 @@ func unzipFile(src, destDir string) error {
 	return nil
 }
 
-// findStageDir looks for a directory named *.stage up to maxDepth levels deep inside root.
+// findStageDir looks for the root content directory inside an extracted Corezoid
+// ZIP up to maxDepth levels deep. Matches *.stage, *.folder, and *.project —
+// Corezoid uses different suffixes depending on the exported obj_type.
 func findStageDir(root string, maxDepth int) (string, error) {
 	var found string
 	err := walkDepth(root, 0, maxDepth, func(path string, d os.DirEntry) bool {
-		if d.IsDir() && strings.HasSuffix(d.Name(), ".stage") {
-			found = path
-			return true // stop
+		if d.IsDir() {
+			name := d.Name()
+			if strings.HasSuffix(name, ".stage") ||
+				strings.HasSuffix(name, ".folder") ||
+				strings.HasSuffix(name, ".project") {
+				found = path
+				return true // stop
+			}
 		}
 		return false
 	})
@@ -134,10 +141,21 @@ func downloadStageRecursively(e *Executor, folderID int, filePath string) error 
 	if err := e.checkCancel(); err != nil {
 		return err
 	}
-	// Try "folder" first (works for sub-folder IDs), fall back to "stage" for stage roots.
-	data, err := e.PullZip(folderID, "folder")
-	if err != nil {
-		data, err = e.PullZip(folderID, "stage")
+	// If folderID matches the configured stage root, we know it's a stage —
+	// no need to probe. Otherwise try in order: stage → folder → project.
+	var objTypes []string
+	if e.StageID != 0 && folderID == e.StageID {
+		objTypes = []string{"stage"}
+	} else {
+		objTypes = []string{"stage", "folder", "project"}
+	}
+	var data []byte
+	var err error
+	for _, objType := range objTypes {
+		data, err = e.PullZip(folderID, objType)
+		if err == nil {
+			break
+		}
 	}
 	if err != nil {
 		return fmt.Errorf("failed to PullZip: %w", err)
@@ -182,7 +200,7 @@ func downloadStageRecursively(e *Executor, folderID int, filePath string) error 
 		return fmt.Errorf("failed to find stage dir: %v", err)
 	}
 	if stageDir == "" {
-		return fmt.Errorf("stage directory not found (*.stage)")
+		return fmt.Errorf("stage directory not found (*.stage / *.folder / *.project)")
 	}
 	// stagesDir is the parent of stageDir (needed for cleanup)
 	stagesDir := filepath.Dir(stageDir)
@@ -214,38 +232,6 @@ func downloadStageRecursively(e *Executor, folderID int, filePath string) error 
 	}
 
 	return nil
-	//
-	//fmt.Println("procInfo", procInfo)
-	//if err != nil {
-	//	logger.Error("Failed to PullFolder: %v", err)
-	//	return
-	//}
-	//for _, p := range procInfo {
-	//	convType, _ := p.(map[string]interface{})["conv_type"].(string)
-	//	if convType != "process" {
-	//		continue
-	//	}
-	//	// save to filePath
-	//	data, err := json.MarshalIndent(p, "", "  ")
-	//	if err != nil {
-	//		logger.Error("Failed to json marshal process: %v", err)
-	//		return
-	//	}
-	//	//data := []byte(UpdateTestJson)
-	//	title, _ := p.(map[string]interface{})["title"].(string)
-	//	objID := strconv.Itoa(int(p.(map[string]interface{})["obj_id"].(float64)))
-	//	if title == "" {
-	//		title = objID
-	//	} else {
-	//		title = title + "." + objID
-	//	}
-	//	err = os.WriteFile(filePath+"/"+title+".json", data, 0644)
-	//	if err != nil {
-	//		logger.Error("Failed to write file: %v", err)
-	//		return
-	//	}
-	//	fmt.Println("Process saved to", filePath+"/"+title+".json")
-	//}
 }
 
 func renameFiles2Folders(filePath string) error {
@@ -258,7 +244,9 @@ func renameFiles2Folders(filePath string) error {
 	for _, f := range files {
 		if f.IsDir() {
 			dirName := f.Name()
-			newName := strings.ReplaceAll(dirName, ".folder", "")
+			newName := strings.TrimSuffix(dirName, ".stage")
+			newName = strings.TrimSuffix(newName, ".folder")
+			newName = strings.TrimSuffix(newName, ".project")
 			newPath := filepath.Join(filePath, newName)
 			if newName != dirName {
 				oldPath := filepath.Join(filePath, dirName)
@@ -280,18 +268,6 @@ func renameFiles2Folders(filePath string) error {
 			if err != nil {
 				return fmt.Errorf("Failed to rename files in directory: %v", err)
 			}
-		} else {
-			if filepath.Ext(f.Name()) != ".json" {
-				continue
-			}
-			//if strings.Contains(f.Name(), ".folder.json") {
-			//	//	 remove
-			//	err := os.Remove(filepath.Join(filePath, f.Name()))
-			//	if err != nil {
-			//		return fmt.Errorf("failed to remove file: %v", err)
-			//	}
-			//}
-			// Rename file if it follows pattern with numeric prefix
 		}
 
 	}

--- a/plugins/corezoid/mcp-server/tools_registry.go
+++ b/plugins/corezoid/mcp-server/tools_registry.go
@@ -392,7 +392,7 @@ var toolRegistry = []mcpTool{
 	},
 	{
 		Name:        "login",
-		Description: "Authenticate with Corezoid via OAuth2 browser flow. Opens a browser window and saves the token so it persists across sessions. Optionally accepts account_url, workspace_id, and stage_id to skip interactive prompts.",
+		Description: "Authenticate with Corezoid. Supports two auth methods: (1) OAuth2 browser flow — opens a browser window and saves the token so it persists across sessions; (2) API key — provide api_login and api_secret to skip the browser flow (credentials saved to project .env). Optionally accepts account_url, workspace_id, and stage_id to skip interactive prompts.",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
@@ -407,6 +407,14 @@ var toolRegistry = []mcpTool{
 				"stage_id": map[string]interface{}{
 					"type":        "string",
 					"description": "Corezoid stage (root folder) ID",
+				},
+				"api_login": map[string]interface{}{
+					"type":        "string",
+					"description": "API key login (alternative to OAuth2 browser flow). If both api_login and api_secret are provided, browser authentication is skipped.",
+				},
+				"api_secret": map[string]interface{}{
+					"type":        "string",
+					"description": "API key secret (alternative to OAuth2 browser flow). Must be paired with api_login. Stored in project .env — ensure .env is in .gitignore.",
 				},
 			},
 		},

--- a/plugins/corezoid/mcp-server/tools_registry.go
+++ b/plugins/corezoid/mcp-server/tools_registry.go
@@ -1002,4 +1002,62 @@ var toolRegistry = []mcpTool{
 			"required": []string{"problem"},
 		},
 	},
+	{
+		Name:        "git-pull-context",
+		Description: "Pull CLAUDE.md and _ext/ from the Corezoid git mirror for the current stage. Requires COREZOID_LOGIN and COREZOID_SECRET env vars. Silently skipped if not configured.",
+		InputSchema: map[string]interface{}{
+			"type":       "object",
+			"properties": map[string]interface{}{},
+		},
+	},
+	{
+		Name:        "git-push-context",
+		Description: "Commit and push local _ext/ changes to the Corezoid git mirror. Requires COREZOID_LOGIN and COREZOID_SECRET. Returns a warning (not an error) if server-side push is not yet enabled.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"message": map[string]interface{}{
+					"type":        "string",
+					"description": "Optional git commit message. Defaults to 'docs: update _ext/docs/ after task session <timestamp>'.",
+				},
+			},
+		},
+	},
+	{
+		Name:        "read-context-file",
+		Description: "Read a file from _ext/ of the current stage in the git mirror. Returns content and a found flag.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"path": map[string]interface{}{
+					"type":        "string",
+					"description": "Relative path inside the stage directory, e.g. '_ext/docs/context.md'.",
+				},
+			},
+			"required": []string{"path"},
+		},
+	},
+	{
+		Name:        "update-context-file",
+		Description: "Write or append content to a file in _ext/docs/ of the current stage. Use mode='append' to add new information, mode='replace' to overwrite.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"path": map[string]interface{}{
+					"type":        "string",
+					"description": "Relative path inside the stage directory, e.g. '_ext/docs/context.md'.",
+				},
+				"content": map[string]interface{}{
+					"type":        "string",
+					"description": "Text to write or append.",
+				},
+				"mode": map[string]interface{}{
+					"type":        "string",
+					"enum":        []string{"append", "replace"},
+					"description": "append (default) — add to end of file; replace — overwrite the file.",
+				},
+			},
+			"required": []string{"path", "content"},
+		},
+	},
 }

--- a/plugins/corezoid/skills/corezoid-create/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-create/SKILL.md
@@ -170,6 +170,15 @@ Use the `Read` tool to load these files when specific node or validation details
 | `${CLAUDE_PLUGIN_ROOT}/docs/process/node-positioning-best-practices.md` | Coordinate system and layout guidelines |
 | `${CLAUDE_PLUGIN_ROOT}/docs/variables-guide.md` | Variable naming rules, creation workflow, usage examples |
 
+## Git Context Update (if configured)
+
+If `COREZOID_LOGIN` is set, after successful deployment:
+- Use `update-context-file` with `mode="append"` to record what this process does (`_ext/docs/context.md`), any external dependencies (`_ext/docs/dependencies.md`), or notable decisions made during creation (`_ext/docs/decisions.md`)
+- Then call `git-push-context`
+- On push failure (403): warn the user, do not block
+
+---
+
 ## Example Processes
 
 | Path | Description |

--- a/plugins/corezoid/skills/corezoid-edit/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-edit/SKILL.md
@@ -96,6 +96,16 @@ After a successful deploy, notify the user:
 
 ---
 
+## Step 5: Update Git Context (if configured)
+
+If `COREZOID_LOGIN` is set, update `_ext/docs/` with any new knowledge from this session:
+- Use `update-context-file` with `mode="append"` for the relevant files
+- Then call `git-push-context`
+- On push failure (403): warn the user, do not block
+- If nothing new was learned, skip this step
+
+---
+
 ## Reference Documents
 
 Use the `Read` tool to load these files when specific node or validation details are needed:

--- a/plugins/corezoid/skills/corezoid-git-context/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-git-context/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: corezoid-git-context
+description: >
+  Explicitly updates _ext/docs/ files for the current Corezoid stage in the
+  git mirror. Use when the user wants to view or update stage documentation:
+  business context, external dependencies, architectural decisions, invariants,
+  or known issues. Activate when the user says "обнови документацию стейджа",
+  "update stage docs", "what's in _ext", "show context", "add to decisions",
+  "record an issue", "document dependencies", or asks to write anything to
+  _ext/docs/. Also activate after any edit/create/review session when the user
+  says "save what we learned" or "update the docs".
+---
+
+# Corezoid Git Context Manager
+
+You manage the `_ext/docs/` documentation layer for the current stage in the
+Corezoid git mirror. These files accumulate knowledge across sessions and are
+included in `CLAUDE.md` automatically via a server-side hook.
+
+## File map
+
+| File | Purpose |
+|---|---|
+| `_ext/docs/context.md` | Business purpose of this stage — what it does, why it exists |
+| `_ext/docs/dependencies.md` | External APIs, services, queues, databases this stage integrates with |
+| `_ext/docs/decisions.md` | Architectural decisions (ADR-style): what was chosen and why |
+| `_ext/docs/invariants.md` | Constraints that must not be violated (rate limits, ordering, field formats) |
+| `_ext/docs/issues.md` | Known bugs, TODOs, tech debt items |
+
+---
+
+## Step 1: Read current state
+
+Call `read-context-file` for each of the five files. Note which exist and what they contain.
+
+If the user asked for a specific file only, read that one.
+
+---
+
+## Step 2: Determine what to update
+
+Based on:
+- The user's explicit instruction ("add this to decisions.md")
+- The current conversation context (what was just done in this session)
+- What is already in the files (do not duplicate)
+
+Decide which files need to be created or appended.
+
+---
+
+## Step 3: Generate content
+
+Write in plain Markdown. Follow these conventions per file:
+
+### `context.md`
+One paragraph describing the stage's business purpose. Focus on WHAT and WHY,
+not HOW. Example:
+```
+## Stage context
+This stage handles the Smart Form Prompt Node feature — a Corezoid-native AI
+assistant that enriches incoming form submissions with LLM-generated suggestions
+before routing them to downstream processes.
+```
+
+### `dependencies.md`
+Bullet list. Each entry: service name, what it's used for, the env_var holding the URL/key.
+```
+## External dependencies
+- **OpenAI API** — LLM completions for prompt enrichment (`{{env_var[@openai-url]}}`)
+- **Simulator.Company** — actor creation and form submission (`{{env_var[@simulator-url]}}`)
+```
+
+### `decisions.md`
+ADR-style entries with date. Each entry: decision, rationale, alternatives considered.
+```
+## [2026-07-07] Use api_rpc for all sub-process calls
+**Decision:** All inter-process calls use `api_rpc` (synchronous), not fire-and-forget.
+**Why:** The caller needs the result to decide the next routing step.
+**Alternatives:** `api_copy` (async) — rejected because response is needed immediately.
+```
+
+### `invariants.md`
+Bullet list of hard constraints.
+```
+## Invariants
+- `ref` must be unique per form submission — duplicate refs cause silent task merge
+- The Escalation process (379055) must always be called before the Final node
+- Do not hardcode model names — use `{{env_var[@llm-model]}}` to allow hot-swap
+```
+
+### `issues.md`
+Numbered list. Each entry: severity, description, date found.
+```
+## Known issues
+1. **[MEDIUM 2026-07-07]** Retry logic missing on OpenAI 429 — tasks may fail silently under load
+2. **[LOW 2026-07-07]** TODO: add `context.md` description for the Configuration folder
+```
+
+---
+
+## Step 4: Apply updates
+
+For each file that needs updating:
+```
+update-context-file(
+  path="_ext/docs/<file>.md",
+  content="<new content>",
+  mode="append"   // or "replace" if rewriting the whole file
+)
+```
+
+Use `mode="replace"` only when restructuring the entire file. Default to `append`.
+
+---
+
+## Step 5: Push
+
+Call `git-push-context` to commit and push all changes.
+
+If push returns 403 (server-side push not yet enabled):
+> "Changes saved locally in `.git-context/`. They will be pushed automatically when server-side write access is enabled."
+
+---
+
+## Notes
+
+- Never fabricate dependencies or decisions not visible in the processes or stated by the user
+- If the user asks to "view" without updating, skip Steps 3–5
+- Read `CLAUDE.md` of the stage for broader context if needed (it embeds `_ext/docs/` content)

--- a/plugins/corezoid/skills/corezoid-init/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-init/SKILL.md
@@ -75,7 +75,28 @@ When `login` returns "Setup complete", proceed to **Step 2**.
 
 ---
 
-## Step 2 — Pull the project
+## Step 2 — Configure Git context (optional)
+
+After login completes, offer the user Git context integration:
+
+> "Хотите подключить Git-контекст для этого стейджа? Это позволит агенту автоматически читать документацию (`_ext/docs/`) и сохранять выводы после работы с процессами. Вам потребуется Corezoid API key (login_id / secret).
+> **[Y] Настроить  [N] Пропустить**"
+
+If the user agrees:
+1. Offer to create a new API key via **`create-api-key`** or use an existing one
+2. Ask for `login_id` (numeric key ID) and `secret`
+3. Save to the correct locations:
+   - `COREZOID_LOGIN=<login_id>` → append to project `.env`
+   - `COREZOID_SECRET=<secret>` → append to `~/.corezoid/credentials` (**never** in `.env`)
+4. Verify access: call **`git-pull-context`** (timeout 5 sec)
+5. If successful → "Git context configured. CLAUDE.md and _ext/ will be loaded on every pull-folder."
+6. If failed → "Git context unavailable — setup skipped. You can add COREZOID_LOGIN / COREZOID_SECRET later."
+
+If the user skips, proceed to Step 3.
+
+---
+
+## Step 3 — Pull the project
 
 After `login` returns "Setup complete", call MCP tool **`pull-folder`** with:
 - `folder_id`: value of `COREZOID_STAGE_ID` (now set in `.env`)
@@ -167,3 +188,5 @@ The server appends `/api/2/json` or `/api/2/download` automatically.
 | `WORKSPACE_ID` | project `.env` | login step 3 — workspace selection |
 | `COREZOID_STAGE_ID` | project `.env` | login step 4 — stage selection |
 | `COREZOID_OAUTH_CLIENT_ID` | project `.env` | pre-login (on-prem only) — OAuth2 client ID for deployments with a custom authorization server; cloud users do not need this |
+| `COREZOID_LOGIN` | project `.env` | Step 2 — git context setup — API key login_id |
+| `COREZOID_SECRET` | `~/.corezoid/credentials` | Step 2 — git context setup — API key secret (never in `.env`) |

--- a/plugins/corezoid/skills/corezoid-init/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-init/SKILL.md
@@ -119,6 +119,34 @@ Then call `login` — it will skip already-set values and only prompt for what's
 
 ---
 
+## Exception: API key auth (login + secret)
+
+When the user provides an **API key login and secret** instead of OAuth credentials, use API key auth. This is common on private/on-prem Corezoid instances where browser OAuth is not available.
+
+**How to recognise:** user says something like "use login 12345 secret abc..." or "connect with API key".
+
+**Exact steps — call `login` with `api_login` and `api_secret` as arguments:**
+
+```
+login(
+  account_url=<host>,
+  workspace_id=<company_id>,
+  stage_id=<stage_id>,
+  api_login=<login_id>,
+  api_secret=<secret>
+)
+```
+
+⚠️ **Critical:** pass `api_login` and `api_secret` **as arguments to the `login` tool** — do NOT write them to `.env` manually. The tool saves them to `.env` automatically with the correct variable names (`API_LOGIN`, `API_SECRET`). Writing them manually with wrong names (e.g. `COREZOID_LOGIN`) will break authentication.
+
+The login tool will:
+1. Skip the OAuth2 browser flow
+2. Save `API_LOGIN` and `API_SECRET` to the project `.env`
+3. Set `COREZOID_API_URL` from `ACCOUNT_URL` if not already set
+4. Complete workspace/stage selection normally
+
+---
+
 ## Exception: OAuth fails on private on-prem instances
 
 On private Corezoid installations, the OAuth2 browser flow may time out because `localhost` is not registered as an allowed `redirect_uri` (see issue #7). Symptom: browser opens the workspace UI instead of redirecting back.

--- a/plugins/corezoid/skills/corezoid-review/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-review/SKILL.md
@@ -354,3 +354,14 @@ Use the `Read` tool to load these files when specific node or validation details
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/api-call-node.md` | HTTP API call configuration |
 | `${CLAUDE_PLUGIN_ROOT}/docs/process/error-handling.md` | Error handling patterns |
 | `${CLAUDE_PLUGIN_ROOT}/docs/process/process-json-validation.md` | Validation rules and common errors |
+
+
+---
+
+## Git Context Update (if configured)
+
+If `COREZOID_LOGIN` is set, after completing the review:
+- Record discovered issues with `update-context-file("_ext/docs/issues.md", ..., mode="append")`
+- Record violated invariants with `update-context-file("_ext/docs/invariants.md", ..., mode="append")`
+- Then call `git-push-context`
+- On push failure (403): warn the user, do not block

--- a/plugins/corezoid/skills/corezoid/SKILL.md
+++ b/plugins/corezoid/skills/corezoid/SKILL.md
@@ -49,6 +49,10 @@ You have access to the Corezoid API via the `corezoid` MCP server.
 | `list-api-keys` | List API keys in the workspace |
 | `find-principal` | Resolve user / group / API-key name → obj_id (call before share-object) |
 | `invite-user` | Invite an external email AND share an object in one call |
+| `git-pull-context` | Pull CLAUDE.md + `_ext/` from the git mirror for the current stage |
+| `git-push-context` | Commit and push local `_ext/` changes to the git mirror |
+| `read-context-file` | Read a file from `_ext/` of the current stage |
+| `update-context-file` | Write or append content to a file in `_ext/docs/` |
 
 ## Platform Architecture
 
@@ -131,6 +135,7 @@ For domain-specific workflows use the specialized skills:
 - `/corezoid-variable-manager` — creating, listing, modifying, deleting variables (visible/secret, raw/json)
 - `/corezoid-process-optimizer` — reduce tacts (merge nodes), clean data flow, fill names, add semaphors
 - `/corezoid-api-connector` — build processes that call the Corezoid public API (`/api/2/json/`) using `api_secret_outer`
+- `/corezoid-git-context` — explicitly update `_ext/docs/` files for the current stage (context, dependencies, decisions, invariants, issues)
 
 ## Reference Documents
 
@@ -154,6 +159,26 @@ Use the `Read` tool to load these files when you need deeper detail:
 | `${CLAUDE_PLUGIN_ROOT}/docs/state-diagrams/state-diagram-node-structures.md` | JSON schemas for nodes inside a state diagram |
 | `${CLAUDE_PLUGIN_ROOT}/docs/state-diagrams/state-diagram-process-interaction.md` | How driver processes read / create / modify state tasks |
 | `${CLAUDE_PLUGIN_ROOT}/docs/variables-guide.md` | Variable naming rules, creation workflow, usage examples |
+
+## Git Context Update (if configured)
+
+After completing any task that involved creating, editing, or reviewing processes:
+
+1. Determine what new knowledge was gained in this session
+2. For each relevant update call `update-context-file` with `mode="append"`:
+   - `_ext/docs/context.md` — if you understood the stage's business purpose
+   - `_ext/docs/dependencies.md` — if you discovered an external API call or integration
+   - `_ext/docs/decisions.md` — if a non-obvious architectural decision was made
+   - `_ext/docs/invariants.md` — if you found a constraint that must not be violated
+   - `_ext/docs/issues.md` — if you found a bug or left a TODO
+3. Call `git-push-context` to persist changes
+
+**Rules:**
+- Only update if something genuinely new was learned — do not duplicate existing content
+- If `COREZOID_LOGIN` is not set, skip this section silently
+- On push failure (403 = not yet enabled): warn the user, do not block the session
+
+---
 
 ## Tips
 


### PR DESCRIPTION
## Summary

- **API key authentication** (`API_LOGIN` + `API_SECRET`) added as fallback to OAuth2 Simulator token for on-prem and headless environments where browser OAuth is unavailable
- Simulator token remains priority; API key activates only when no token is present
- `login` tool accepts `api_login` and `api_secret` args — stores them in project `.env`, skips OAuth PKCE flow
- Download URLs authenticated via `/{login}/{ts}/{sig}` appended to URL path (documented Corezoid pattern)
- Signature formula: `hex(sha1(ts + secret + body + secret))`

**Also fixed:**
- `pull-folder` obj_type probe: configured stage root always uses `"stage"`; others probe `stage → folder → project`
- Export op type: `"download"` on `/api/2/download` (Simulator), `"create"` on `/api/2/json` (API key) — prevents "undefined request" on some deployments
- `findStageDir` now matches `*.stage`, `*.folder`, `*.project`; `renameFiles2Folders` uses `TrimSuffix` (not `ReplaceAll`)
- `fetchDownload` propagates executor context for proper cancellation
- Removed dead `PullFolder` method and leftover commented-out code
- `corezoid-init` skill documents API key flow explicitly

## Test plan

- [ ] OAuth2 login flow unchanged — existing Simulator token path not affected
- [ ] `login(api_login=..., api_secret=...)` skips browser, saves to `.env`, proceeds to workspace/stage selection
- [ ] `pull-process` works with API key auth (inline JSON via `/api/2/json`)
- [ ] `pull-folder` works with API key auth (ZIP download via `{url}/{login}/{ts}/{sig}`)
- [ ] `go test ./...` passes (including new `TestAPIKeySign_KnownValue` with pinned hash)
- [ ] Verified on `admin-pre.corezoid.com` with real API key credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)