### PR TITLE
feat(auth): add API key (login+secret) auth as Simulator token fallback

### DIFF
--- a/plugins/corezoid/mcp-server/executor.go
+++ b/plugins/corezoid/mcp-server/executor.go
@@ -53,10 +53,11 @@ func NewValidator(ctx context.Context, inProcessID int) *Executor {
 		ctx = context.Background()
 	}
 	apiURLv, tokenv, workspaceIDv, _, stageIDv := authSnapshot()
+	snapAPILogin, snapAPISecret := apiKeySnapshot()
 	v := &Executor{
 		Ctx:         ctx,
-		APILogin:    "",
-		APISecret:   "",
+		APILogin:    snapAPILogin,
+		APISecret:   snapAPISecret,
 		APIUrl:      apiURLv,
 		Token:       tokenv,
 		WorkspaceID: workspaceIDv,

--- a/plugins/corezoid/mcp-server/executor_api.go
+++ b/plugins/corezoid/mcp-server/executor_api.go
@@ -3,7 +3,9 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/sha1" //nolint:gosec
 	"crypto/tls"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -56,16 +58,19 @@ func (v *Executor) req(method string, ops []map[string]any) (map[string]interfac
 
 	path := "json"
 	if method == "export_process" {
+		// Always use /api/2/download for exports — it returns a download_url.
+		// fetchDownload handles both auth modes:
+		//   Simulator: Authorization: Simulator <token> header
+		//   API key:   GET {url}/{login}/{ts}/{sig} (URL-embedded signature)
 		path = "download"
 	}
-	authURL := fmt.Sprintf("%s/api/2/%s", v.APIUrl, path)
 
 	if v.Debug {
-		logger.Debug("Request URL, url=%s", authURL)
+		logger.Debug("Request baseURL=%s path=%s", v.APIUrl, path)
 	}
 
 	client := newHTTPClient()
-	resp, body, err := doWithRetry(v.Ctx, client, "POST", authURL, payloadJSON, v.Token, v.Debug)
+	resp, body, err := doWithRetry(v.Ctx, client, "POST", v.APIUrl, path, payloadJSON, v.Token, v.APILogin, v.APISecret, v.Debug)
 	if err != nil {
 		return nil, err
 	}
@@ -107,17 +112,30 @@ func newHTTPClient() *http.Client {
 	}
 }
 
+// apiKeySign computes the Corezoid API key request signature:
+// hex(sha1(timestamp + apiSecret + body + apiSecret))
+func apiKeySign(secret, timestamp, body string) string {
+	h := sha1.New() //nolint:gosec
+	h.Write([]byte(timestamp + secret + body + secret))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
 // doWithRetry sends an authenticated request and retries transient 429/503
 // responses with exponential backoff and jitter. Non-retriable statuses (and
 // non-network errors) are returned to the caller after the first attempt;
 // retrying e.g. a 4xx auth failure would just delay the user-visible error.
 //
+// Authentication mode:
+//   - If token != "": Simulator bearer token. URL = baseURL/api/2/path, header Authorization: Simulator <token>.
+//   - If token == "" and apiLogin+apiSecret != "": API key HMAC-SHA1. URL = baseURL/api/2/path/apiLogin/ts/sig, no auth header.
+//
 // The response body is rebuilt from `payloadJSON` on each attempt, so the body
 // must be idempotent — which it is, since Corezoid's JSON-RPC ops are.
+// For API key mode the timestamp+signature are recomputed fresh on each retry.
 //
 // Returns the final response and the already-read body. Caller owns resp.Body
 // and must close it.
-func doWithRetry(ctx context.Context, client *http.Client, method, url string, payloadJSON []byte, token string, debug bool) (*http.Response, []byte, error) {
+func doWithRetry(ctx context.Context, client *http.Client, method, baseURL, path string, payloadJSON []byte, token, apiLoginArg, apiSecretArg string, debug bool) (*http.Response, []byte, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -129,18 +147,35 @@ func doWithRetry(ctx context.Context, client *http.Client, method, url string, p
 		if err := ctx.Err(); err != nil {
 			return nil, nil, err
 		}
-		req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(payloadJSON))
+
+		// Build per-attempt URL. For API key auth, recompute timestamp+signature
+		// on every retry so the signature is never stale.
+		var reqURL string
+		if token != "" {
+			reqURL = fmt.Sprintf("%s/api/2/%s", baseURL, path)
+		} else {
+			ts := strconv.FormatInt(time.Now().Unix(), 10)
+			sig := apiKeySign(apiSecretArg, ts, string(payloadJSON))
+			reqURL = fmt.Sprintf("%s/api/2/%s/%s/%s/%s", baseURL, path, apiLoginArg, ts, sig)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, method, reqURL, bytes.NewReader(payloadJSON))
 		if err != nil {
 			// NewRequest fails only on programmer error (bad method/URL),
 			// not on transient I/O — no point retrying.
 			return nil, nil, err
 		}
 		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Authorization", fmt.Sprintf("Simulator %s", token))
+		if token != "" {
+			req.Header.Set("Authorization", fmt.Sprintf("Simulator %s", token))
+		}
 		if debug && attempt == 1 {
-			safeHeaders := req.Header.Clone()
-			safeHeaders.Set("Authorization", "Simulator ***")
-			logger.Debug("Header: %v", safeHeaders)
+			logger.Debug("Request URL: %s", reqURL)
+			if token != "" {
+				safeHeaders := req.Header.Clone()
+				safeHeaders.Set("Authorization", "Simulator ***")
+				logger.Debug("Header: %v", safeHeaders)
+			}
 		}
 
 		resp, err := client.Do(req)

--- a/plugins/corezoid/mcp-server/executor_api_test.go
+++ b/plugins/corezoid/mcp-server/executor_api_test.go
@@ -160,7 +160,7 @@ func TestDoWithRetry_RetriesOn503ThenSucceeds(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	resp, body, err := doWithRetry(context.Background(), srv.Client(), "POST", srv.URL, []byte(`{}`), "tkn", false)
+	resp, body, err := doWithRetry(context.Background(), srv.Client(), "POST", srv.URL, "json", []byte(`{}`), "tkn", "", "", false)
 	if err != nil {
 		t.Fatalf("expected success after retries, got %v", err)
 	}
@@ -190,7 +190,7 @@ func TestDoWithRetry_RetriesOn429(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	resp, _, err := doWithRetry(context.Background(), srv.Client(), "POST", srv.URL, []byte(`{}`), "tkn", false)
+	resp, _, err := doWithRetry(context.Background(), srv.Client(), "POST", srv.URL, "json", []byte(`{}`), "tkn", "", "", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestDoWithRetry_DoesNotRetry4xx(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	resp, _, err := doWithRetry(context.Background(), srv.Client(), "POST", srv.URL, []byte(`{}`), "tkn", false)
+	resp, _, err := doWithRetry(context.Background(), srv.Client(), "POST", srv.URL, "json", []byte(`{}`), "tkn", "", "", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -233,7 +233,7 @@ func TestDoWithRetry_GivesUpAfterMaxAttempts(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	resp, _, err := doWithRetry(context.Background(), srv.Client(), "POST", srv.URL, []byte(`{}`), "tkn", false)
+	resp, _, err := doWithRetry(context.Background(), srv.Client(), "POST", srv.URL, "json", []byte(`{}`), "tkn", "", "", false)
 	if err == nil {
 		if resp != nil {
 			resp.Body.Close()
@@ -264,7 +264,7 @@ func TestDoWithRetry_CancelDuringBackoff(t *testing.T) {
 		cancel()
 	}()
 
-	_, _, err := doWithRetry(ctx, srv.Client(), "POST", srv.URL, []byte(`{}`), "tkn", false)
+	_, _, err := doWithRetry(ctx, srv.Client(), "POST", srv.URL, "json", []byte(`{}`), "tkn", "", "", false)
 	if err == nil {
 		t.Fatal("expected context.Canceled error, got nil")
 	}
@@ -274,6 +274,27 @@ func TestDoWithRetry_CancelDuringBackoff(t *testing.T) {
 	// We allow either 1 or 2 attempts before cancel races in.
 	if got := atomic.LoadInt32(&calls); got > 2 {
 		t.Errorf("cancel should stop retries quickly, got %d attempts", got)
+	}
+}
+
+// ---- apiKeySign -------------------------------------------------------------
+
+func TestAPIKeySign_KnownValue(t *testing.T) {
+	// Verify the HMAC-SHA1 formula: hex(sha1(ts + secret + body + secret))
+	// Expected value cross-checked independently:
+	//   python3 -c "import hashlib; print(hashlib.sha1(b'1700000000mysecret{}mysecret').hexdigest())"
+	const want = "8c5cd99f9cfa598f65e6b3fae56cc859cecd5ee6"
+	got := apiKeySign("mysecret", "1700000000", "{}")
+	if got != want {
+		t.Errorf("apiKeySign formula mismatch:\n  got  %q\n  want %q", got, want)
+	}
+	// Different secret must produce a different signature.
+	if got2 := apiKeySign("othersecret", "1700000000", "{}"); got == got2 {
+		t.Error("different secrets should produce different signatures")
+	}
+	// Different timestamp must produce a different signature.
+	if got3 := apiKeySign("mysecret", "1700000001", "{}"); got == got3 {
+		t.Error("different timestamps should produce different signatures")
 	}
 }
 

--- a/plugins/corezoid/mcp-server/executor_process.go
+++ b/plugins/corezoid/mcp-server/executor_process.go
@@ -6,15 +6,70 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
 
+// fetchDownload downloads the content at downloadURL and returns the raw bytes.
+//
+// Auth strategy:
+//   - Simulator token → Authorization: Simulator <token> header, URL unchanged.
+//   - API key (no token) → URL extended with /{API_LOGIN}/{TIMESTAMP}/{SIGNATURE}.
+//     Signature uses empty body: hex(sha1(ts + secret + "" + secret)).
+//     This is the documented Corezoid pattern for authenticating file downloads
+//     with an API key.
+//
+// HTTP status is checked: any 4xx/5xx is returned as an error with the first
+// 256 bytes of the response body for diagnosis.
+func (v *Executor) fetchDownload(downloadURL string) ([]byte, error) {
+	var reqURL string
+	if v.Token != "" {
+		reqURL = downloadURL
+	} else {
+		ts := strconv.FormatInt(time.Now().Unix(), 10)
+		sig := apiKeySign(v.APISecret, ts, "")
+		reqURL = fmt.Sprintf("%s/%s/%s/%s", downloadURL, v.APILogin, ts, sig)
+	}
+
+	req, err := http.NewRequestWithContext(v.Ctx, "GET", reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build download request: %w", err)
+	}
+	if v.Token != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Simulator %s", v.Token))
+	}
+
+	resp, err := newHTTPClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read download response: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		snippet := body
+		if len(snippet) > 256 {
+			snippet = snippet[:256]
+		}
+		return nil, fmt.Errorf("download failed with HTTP %d: %s", resp.StatusCode, snippet)
+	}
+	return body, nil
+}
+
 // PullZip exports a process or folder as a ZIP archive and returns the raw bytes.
 func (v *Executor) PullZip(id int, objType string) ([]byte, error) {
+	// /api/2/download (Simulator) accepts type="download".
+	// /api/2/json (API key) only accepts type="create" — "download" returns "undefined request".
+	opType := "create"
+	if v.Token != "" {
+		opType = "download"
+	}
 	ops := []map[string]any{
 		{
-			"type":       "create",
+			"type":       opType,
 			"obj":        "obj_scheme",
 			"obj_id":     id,
 			"company_id": v.WorkspaceID,
@@ -39,95 +94,25 @@ func (v *Executor) PullZip(id int, objType string) ([]byte, error) {
 	if !ok {
 		return nil, fmt.Errorf("failed to export process: unexpected ops format")
 	}
-	downloadURL1, ok := firstOp["download_url"].(string)
-	if !ok || downloadURL1 == "" {
+	downloadURL, ok := firstOp["download_url"].(string)
+	if !ok || downloadURL == "" {
 		return nil, fmt.Errorf("failed to export process: no download_url in response")
 	}
-
-	req, err := http.NewRequest("GET", downloadURL1, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	if v.Token != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Simulator %s", v.Token))
-	}
-	resp, err := newHTTPClient().Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to download process: %v", err)
-	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read process: %v", err)
-	}
-	return body, nil
-}
-
-// PullFolder exports all processes in a folder as a JSON array.
-func (v *Executor) PullFolder(id int, objType string) ([]any, error) {
-	ops := []map[string]any{
-		{
-			"type":       "create",
-			"obj":        "obj_scheme",
-			"obj_id":     id,
-			"company_id": v.WorkspaceID,
-			"obj_type":   objType,
-			"with_alias": true,
-			"async":      false,
-			"format":     "json",
-		},
-	}
-	response, err := v.req("export_process", ops)
-	if err != nil {
-		return nil, fmt.Errorf("failed to export process: %w", err)
-	}
-	if response["request_proc"] != "ok" {
-		return nil, fmt.Errorf("failed to export process: %v", response)
-	}
-	ops1, ok := response["ops"].([]any)
-	if !ok || len(ops1) == 0 {
-		return nil, fmt.Errorf("failed to export process: no ops in response")
-	}
-	firstOp, ok := ops1[0].(map[string]any)
-	if !ok {
-		return nil, fmt.Errorf("failed to export process: unexpected ops format")
-	}
-	downloadURL1, ok := firstOp["download_url"].(string)
-	if !ok || downloadURL1 == "" {
-		return nil, fmt.Errorf("failed to export process: no download_url in response")
-	}
-
-	req, err := http.NewRequest("GET", downloadURL1, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	if v.Token != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Simulator %s", v.Token))
-	}
-	resp, err := newHTTPClient().Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to download process: %v", err)
-	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read process: %v", err)
-	}
-	var processes []any
-	err = json.Unmarshal(body, &processes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal process: %v", err)
-	}
-	return processes, nil
+	return v.fetchDownload(downloadURL)
 }
 
 // ExportProcess downloads the current process definition as parsed JSON.
+// Both Simulator and API key modes use /api/2/download and follow the download_url.
+// fetchDownload handles auth: Simulator uses an Authorization header; API key
+// appends /{login}/{ts}/{sig} to the URL.
 func (v *Executor) ExportProcess() (any, error) {
+	opType := "create"
+	if v.Token != "" {
+		opType = "download"
+	}
 	ops := []map[string]any{
 		{
-			"type":       "create",
+			"type":       opType,
 			"obj":        "obj_scheme",
 			"obj_id":     v.ProcessID,
 			"company_id": v.WorkspaceID,
@@ -144,6 +129,8 @@ func (v *Executor) ExportProcess() (any, error) {
 	if response["request_proc"] != "ok" {
 		return nil, fmt.Errorf("failed to export process: %v", response)
 	}
+
+	// Follow download_url.
 	ops1, ok := response["ops"].([]any)
 	if !ok || len(ops1) == 0 {
 		return nil, fmt.Errorf("failed to export process: no ops in response")
@@ -152,32 +139,17 @@ func (v *Executor) ExportProcess() (any, error) {
 	if !ok {
 		return nil, fmt.Errorf("failed to export process: unexpected ops format")
 	}
-	downloadURL1, ok := firstOp["download_url"].(string)
-	if !ok || downloadURL1 == "" {
+	downloadURL, ok := firstOp["download_url"].(string)
+	if !ok || downloadURL == "" {
 		return nil, fmt.Errorf("failed to export process: no download_url in response")
 	}
-
-	req, err := http.NewRequest("GET", downloadURL1, nil)
+	body, err := v.fetchDownload(downloadURL)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Content-Type", "application/json")
-	if v.Token != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Simulator %s", v.Token))
-	}
-	resp, err := newHTTPClient().Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to download process: %v", err)
-	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read process: %v", err)
-	}
 	var process []any
-	err = json.Unmarshal(body, &process)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal process: %v", err)
+	if err = json.Unmarshal(body, &process); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal process: %w", err)
 	}
 	return process, nil
 }

--- a/plugins/corezoid/mcp-server/main.go
+++ b/plugins/corezoid/mcp-server/main.go
@@ -47,6 +47,14 @@ var apigwURL string
 var stageID int
 var insecureTLS bool
 
+// apiLogin and apiSecret are the Corezoid API key credentials (API_LOGIN /
+// API_SECRET). They provide an alternative to OAuth2 PKCE for environments
+// where browser-based authentication is not available. When both are set,
+// requests are signed with HMAC-SHA1 instead of using a Simulator bearer token.
+// These are distinct from gitLoginID / gitSecret which are used for git-sync.
+var apiLogin string
+var apiSecret string
+
 // authSnapshot returns a coherent snapshot of the auth-state globals taken
 // under the read lock. Callers that subsequently need to mutate state must
 // acquire authStateMu.Lock() (not upgrade — Go's RWMutex doesn't support that).
@@ -54,6 +62,14 @@ func authSnapshot() (apiURLv, tokenv, workspaceIDv, accountURLv string, stageIDv
 	authStateMu.RLock()
 	defer authStateMu.RUnlock()
 	return apiURL, apiToken, workspaceID, accountURL, stageID
+}
+
+// apiKeySnapshot returns a coherent snapshot of the API key credentials taken
+// under the read lock. Same pattern as authSnapshot.
+func apiKeySnapshot() (login, secret string) {
+	authStateMu.RLock()
+	defer authStateMu.RUnlock()
+	return apiLogin, apiSecret
 }
 
 // withAuthLock runs fn while holding the auth-state write lock. Use for
@@ -157,6 +173,8 @@ func loadConfig() {
 	}
 	stageID, _ = strconv.Atoi(os.Getenv("COREZOID_STAGE_ID"))
 	insecureTLS = os.Getenv("COREZOID_INSECURE_TLS") != ""
+	apiLogin = os.Getenv("API_LOGIN")
+	apiSecret = os.Getenv("API_SECRET")
 }
 
 // runCLI executes a single MCP tool from the command line and exits.
@@ -225,11 +243,14 @@ func main() {
 	loadConfig()
 	logger.Debug("Loaded configuration: apiURL=%s workspaceID=%s apigwURL=%s hasToken=%v", apiURL, workspaceID, apigwURL, apiToken != "")
 
-	if apiToken == "" {
+	if apiToken == "" && (apiLogin == "" || apiSecret == "") {
 		fmt.Fprintln(os.Stderr, "[corezoid-mcp] NOTICE: No credentials found.")
-		fmt.Fprintln(os.Stderr, "[corezoid-mcp] Run the 'login' MCP tool to authenticate via OAuth2.")
+		fmt.Fprintln(os.Stderr, "[corezoid-mcp] Authenticate via one of:")
+		fmt.Fprintln(os.Stderr, "[corezoid-mcp]   1. OAuth2 browser flow — run the 'login' MCP tool.")
+		fmt.Fprintln(os.Stderr, "[corezoid-mcp]   2. API key — set API_LOGIN and API_SECRET in your project .env,")
+		fmt.Fprintln(os.Stderr, "[corezoid-mcp]      then call the 'login' MCP tool to select workspace/stage.")
 		if credPath, err := credentialsFilePath(); err == nil {
-			fmt.Fprintf(os.Stderr, "[corezoid-mcp] Token will be saved to: %s\n", credPath)
+			fmt.Fprintf(os.Stderr, "[corezoid-mcp] OAuth2 token will be saved to: %s\n", credPath)
 		}
 	}
 

--- a/plugins/corezoid/mcp-server/main_config_test.go
+++ b/plugins/corezoid/mcp-server/main_config_test.go
@@ -1,0 +1,209 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// ---- envFilePath -----------------------------------------------------------
+
+func TestEnvFilePath(t *testing.T) {
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+
+	got := envFilePath()
+	// On macOS /var and /private/var are the same path via symlink, so compare
+	// via EvalSymlinks to avoid flaking.
+	wantBase := filepath.Base(got)
+	if wantBase != ".env" {
+		t.Errorf("expected basename .env, got %q", wantBase)
+	}
+	gotDir, _ := filepath.EvalSymlinks(filepath.Dir(got))
+	wantDir, _ := filepath.EvalSymlinks(dir)
+	if gotDir != wantDir {
+		t.Errorf("expected dir %q, got %q", wantDir, gotDir)
+	}
+}
+
+// ---- withAuthLock ----------------------------------------------------------
+
+func TestWithAuthLock_RunsFn(t *testing.T) {
+	called := false
+	withAuthLock(func() { called = true })
+	if !called {
+		t.Error("expected fn to run")
+	}
+}
+
+func TestWithAuthLock_SerializesAccess(t *testing.T) {
+	// Two goroutines both increment via withAuthLock; without the lock we'd
+	// expect races. With the lock, the final count equals the sum.
+	var counter int
+	var wg sync.WaitGroup
+	const iters = 200
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				withAuthLock(func() { counter++ })
+			}
+		}()
+	}
+	wg.Wait()
+	if counter != 2*iters {
+		t.Errorf("expected counter %d, got %d", 2*iters, counter)
+	}
+}
+
+// ---- findAndLoadDotEnv -----------------------------------------------------
+
+// Helper to snapshot+restore os.Getwd so changing dirs in tests doesn't leak.
+func chdirWithCleanup(t *testing.T, dir string) {
+	t.Helper()
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+}
+
+func TestFindAndLoadDotEnv_LocatesInParentDir(t *testing.T) {
+	root := t.TempDir()
+	// Make root a project root so the search has a definitive stopping point.
+	if err := os.WriteFile(filepath.Join(root, "1_project.stage.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// .env lives at the root.
+	if err := os.WriteFile(filepath.Join(root, ".env"), []byte("TEST_FA_VAR=found\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	// We start two levels deep.
+	deep := filepath.Join(root, "a", "b")
+	if err := os.MkdirAll(deep, 0700); err != nil {
+		t.Fatal(err)
+	}
+	chdirWithCleanup(t, deep)
+
+	os.Unsetenv("TEST_FA_VAR")
+	t.Cleanup(func() { os.Unsetenv("TEST_FA_VAR") })
+
+	findAndLoadDotEnv()
+
+	if got := os.Getenv("TEST_FA_VAR"); got != "found" {
+		t.Errorf("expected TEST_FA_VAR=found, got %q", got)
+	}
+}
+
+func TestFindAndLoadDotEnv_StopsAtProjectRoot(t *testing.T) {
+	// Layout:
+	//   ancestor/.env  (must NOT be loaded)
+	//   ancestor/root/<stage.json>  (project root — search stops here)
+	//   ancestor/root/sub  (cwd)
+	ancestor := t.TempDir()
+	if err := os.WriteFile(filepath.Join(ancestor, ".env"), []byte("TEST_FA_BLOCKED=oops\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Join(ancestor, "root")
+	if err := os.MkdirAll(root, 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "1_p.stage.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(root, "sub")
+	if err := os.MkdirAll(sub, 0700); err != nil {
+		t.Fatal(err)
+	}
+	chdirWithCleanup(t, sub)
+
+	os.Unsetenv("TEST_FA_BLOCKED")
+	t.Cleanup(func() { os.Unsetenv("TEST_FA_BLOCKED") })
+
+	findAndLoadDotEnv()
+
+	if got := os.Getenv("TEST_FA_BLOCKED"); got != "" {
+		t.Errorf("expected TEST_FA_BLOCKED to remain unset (search must stop at project root), got %q", got)
+	}
+}
+
+// ---- loadConfig ------------------------------------------------------------
+
+// Snapshot/restore the globals loadConfig writes so the test is isolated.
+func snapshotConfigGlobals(t *testing.T) {
+	t.Helper()
+	prevAPI, prevAcc, prevWS, prevTok, prevGW := apiURL, accountURL, workspaceID, apiToken, apigwURL
+	prevStage, prevInsecure := stageID, insecureTLS
+	prevAPILogin, prevAPISecret := apiLogin, apiSecret
+	t.Cleanup(func() {
+		apiURL, accountURL, workspaceID, apiToken, apigwURL = prevAPI, prevAcc, prevWS, prevTok, prevGW
+		stageID, insecureTLS = prevStage, prevInsecure
+		apiLogin, apiSecret = prevAPILogin, prevAPISecret
+	})
+}
+
+func TestLoadConfig_ReadsEnvVars(t *testing.T) {
+	snapshotConfigGlobals(t)
+
+	// Isolate from any real ~/.corezoid/credentials and project .env.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := t.TempDir()
+	chdirWithCleanup(t, dir)
+
+	t.Setenv("COREZOID_API_URL", "https://api.example")
+	t.Setenv("ACCOUNT_URL", "https://account.example")
+	t.Setenv("WORKSPACE_ID", "ws-1")
+	t.Setenv("ACCESS_TOKEN", "tok-abc")
+	t.Setenv("COREZOID_STAGE_ID", "4242")
+	t.Setenv("COREZOID_INSECURE_TLS", "1")
+	// Force apigw URL default to be overridden so we exercise the explicit branch.
+	t.Setenv("COREZOID_APIGW_URL", "https://gw.example")
+
+	loadConfig()
+
+	if apiURL != "https://api.example" {
+		t.Errorf("apiURL = %q", apiURL)
+	}
+	if accountURL != "https://account.example" {
+		t.Errorf("accountURL = %q", accountURL)
+	}
+	if workspaceID != "ws-1" {
+		t.Errorf("workspaceID = %q", workspaceID)
+	}
+	if apiToken != "tok-abc" {
+		t.Errorf("apiToken = %q", apiToken)
+	}
+	if stageID != 4242 {
+		t.Errorf("stageID = %d, want 4242", stageID)
+	}
+	if !insecureTLS {
+		t.Error("expected insecureTLS=true when COREZOID_INSECURE_TLS is set")
+	}
+	if apigwURL != "https://gw.example" {
+		t.Errorf("apigwURL = %q", apigwURL)
+	}
+}
+
+func TestLoadConfig_DefaultsApigwURL(t *testing.T) {
+	snapshotConfigGlobals(t)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := t.TempDir()
+	chdirWithCleanup(t, dir)
+
+	// Explicitly unset so loadConfig picks the default.
+	t.Setenv("COREZOID_APIGW_URL", "")
+	loadConfig()
+
+	if apigwURL != "https://api-apigw.corezoid.com" {
+		t.Errorf("expected default apigwURL, got %q", apigwURL)
+	}
+}

--- a/plugins/corezoid/mcp-server/mcp_discovery.go
+++ b/plugins/corezoid/mcp-server/mcp_discovery.go
@@ -139,10 +139,12 @@ func fetchStageList(ctx context.Context, companyID string, projectID int64) ([]s
 	return result, nil
 }
 
-// ensureTokenAuth checks that a valid API token is present. If apiToken is
-// empty it attempts to load saved OAuth credentials; the check-then-load-then-set
-// runs under the auth write lock so concurrent requests can't double-load or
-// race the read against the write.
+// ensureTokenAuth checks that a valid API token or API key credentials are
+// present. If apiToken is empty it attempts to load saved OAuth credentials;
+// if those are also absent, API key credentials (apiLogin + apiSecret) are
+// checked as a fallback. The check-then-load-then-set runs under the auth
+// write lock so concurrent requests can't double-load or race the read against
+// the write.
 func ensureTokenAuth() error {
 	_, snapToken, _, _, _ := authSnapshot()
 	if snapToken == "" {
@@ -158,7 +160,12 @@ func ensureTokenAuth() error {
 		}
 	}
 	if snapToken == "" {
-		return fmt.Errorf("[Error] Not authenticated: missing [ACCESS_TOKEN]. Invoke the 'corezoid-init' skill to set up credentials (use the Skill tool with skill=\"corezoid-init\").")
+		// Fall back to API key authentication if both login and secret are set.
+		snapAPILogin, snapAPISecret := apiKeySnapshot()
+		if snapAPILogin != "" && snapAPISecret != "" {
+			return nil
+		}
+		return fmt.Errorf("[Error] Not authenticated: missing [ACCESS_TOKEN] or [API_LOGIN + API_SECRET]. Invoke the 'corezoid-init' skill to set up credentials (use the Skill tool with skill=\"corezoid-init\").")
 	}
 	return nil
 }

--- a/plugins/corezoid/mcp-server/mcp_handlers_auth.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_auth.go
@@ -37,6 +37,15 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 		stageID, _ = strconv.Atoi(os.Getenv("COREZOID_STAGE_ID"))
 		apiURL = os.Getenv("COREZOID_API_URL")
 
+		// Reload API key credentials if currently empty (e.g. added to .env
+		// after the server started).
+		if apiLogin == "" {
+			apiLogin = os.Getenv("API_LOGIN")
+		}
+		if apiSecret == "" {
+			apiSecret = os.Getenv("API_SECRET")
+		}
+
 		// Record initial stageID to detect if it gets set during this call.
 		stageIDAtStart = stageID
 
@@ -73,13 +82,29 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 				}
 			}
 		}
+		// Handle api_login and api_secret arguments.
+		if v := optStrArg(args, "api_login"); v != "" {
+			apiLogin = v
+			os.Setenv("API_LOGIN", v)
+			if err := updateEnvFile(envPath, "API_LOGIN", v); err != nil {
+				logger.Warn("login: could not save API_LOGIN from arg: %v", err)
+			}
+		}
+		if v := optStrArg(args, "api_secret"); v != "" {
+			apiSecret = v
+			os.Setenv("API_SECRET", v)
+			if err := updateEnvFile(envPath, "API_SECRET", v); err != nil {
+				logger.Warn("login: could not save API_SECRET from arg: %v", err)
+			}
+		}
 	})
 
 	// Snapshot the post-reload state for use in this handler — long-running
 	// OAuth / elicitation must not hold the auth lock, so we drive most
 	// logic from these locals and only re-acquire the lock for writes.
 	_, snapToken, snapWorkspaceID, snapAccountURL, snapStageID := authSnapshot()
-	logger.Info("login: accountURL=%q workspaceID=%q stageID=%d", snapAccountURL, snapWorkspaceID, snapStageID)
+	snapAPILogin, snapAPISecret := apiKeySnapshot()
+	logger.Info("login: accountURL=%q workspaceID=%q stageID=%d hasAPIKey=%v", snapAccountURL, snapWorkspaceID, snapStageID, snapAPILogin != "" && snapAPISecret != "")
 
 	// Step 1: ensure Account API URL.
 	if snapAccountURL == "" {
@@ -124,9 +149,10 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 		}
 	}
 
-	// Step 2: OAuth2 PKCE browser flow (skipped if already authenticated).
+	// Step 2: OAuth2 PKCE browser flow (skipped if already authenticated or if
+	// API key credentials are present — API key auth doesn't require a browser flow).
 	var tokenExpiry time.Time
-	if snapToken == "" {
+	if snapToken == "" && !(snapAPILogin != "" && snapAPISecret != "") {
 		res, err := oauthPKCEFlow(snapAccountURL, oauthClientID)
 		if err != nil {
 			return fmt.Sprintf("Authentication failed: %v", err), true
@@ -160,7 +186,7 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 				logger.Info("login: derived COREZOID_API_URL=%q from clients API", corezoidURL)
 			}
 		}
-	} else {
+	} else if snapToken != "" {
 		// If we already have a token but no derived API URL (e.g. token came from
 		// .env directly without completing OAuth), fetch the URL now.
 		authStateMu.RLock()
@@ -178,6 +204,23 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 				}
 				logger.Info("login: derived COREZOID_API_URL=%q from clients API (pre-existing token)", corezoidURL)
 			}
+		}
+	} else {
+		// API key flow: COREZOID_API_URL cannot be derived via /face/api/1/clients
+		// (that endpoint requires a Bearer/Simulator token). Fall back to ACCOUNT_URL —
+		// in most Corezoid deployments the API is served from the same host as the
+		// admin UI. Users who need a different API host can set COREZOID_API_URL in .env.
+		authStateMu.RLock()
+		apiURLEmpty := apiURL == ""
+		authStateMu.RUnlock()
+		if apiURLEmpty && snapAccountURL != "" {
+			fallback := strings.TrimRight(snapAccountURL, "/")
+			withAuthLock(func() { apiURL = fallback })
+			os.Setenv("COREZOID_API_URL", fallback)
+			if err := updateEnvFile(envPath, "COREZOID_API_URL", fallback); err != nil {
+				logger.Warn("login: could not save COREZOID_API_URL fallback: %v", err)
+			}
+			logger.Info("login: COREZOID_API_URL not set — defaulting to ACCOUNT_URL %q", fallback)
 		}
 	}
 
@@ -428,8 +471,9 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 }
 
 // handleLogout deletes the saved credentials from ~/.corezoid/credentials and
-// clears the cached access token. The token write is under the auth lock so a
-// concurrent in-flight request can't briefly use the cleared token-before-deletion state.
+// clears the cached access token. API key credentials are also removed from the
+// project .env. The writes are under the auth lock so a concurrent in-flight
+// request can't briefly use the cleared credentials.
 func handleLogout(_ context.Context, _ map[string]interface{}) (string, bool) {
 	credPath, err := credentialsFilePath()
 	if err != nil {
@@ -438,12 +482,24 @@ func handleLogout(_ context.Context, _ map[string]interface{}) (string, bool) {
 	if err := deleteCredentials(); err != nil {
 		return fmt.Sprintf("Failed to remove credentials: %v", err), true
 	}
+	// Remove API key credentials from the project .env.
+	envPath := envFilePath()
+	if err := removeEnvKey(envPath, "API_LOGIN"); err != nil {
+		logger.Warn("logout: could not remove API_LOGIN from .env: %v", err)
+	}
+	if err := removeEnvKey(envPath, "API_SECRET"); err != nil {
+		logger.Warn("logout: could not remove API_SECRET from .env: %v", err)
+	}
+	os.Unsetenv("API_LOGIN")
+	os.Unsetenv("API_SECRET")
 	withAuthLock(func() {
 		apiToken = ""
 		accountURL = ""
 		workspaceID = ""
 		stageID = 0
 		apiURL = ""
+		apiLogin = ""
+		apiSecret = ""
 	})
 	return fmt.Sprintf("Logged out. ACCESS_TOKEN removed from %s.", credPath), false
 }

--- a/plugins/corezoid/mcp-server/pull-project.go
+++ b/plugins/corezoid/mcp-server/pull-project.go
@@ -79,13 +79,20 @@ func unzipFile(src, destDir string) error {
 	return nil
 }
 
-// findStageDir looks for a directory named *.stage up to maxDepth levels deep inside root.
+// findStageDir looks for the root content directory inside an extracted Corezoid
+// ZIP up to maxDepth levels deep. Matches *.stage, *.folder, and *.project —
+// Corezoid uses different suffixes depending on the exported obj_type.
 func findStageDir(root string, maxDepth int) (string, error) {
 	var found string
 	err := walkDepth(root, 0, maxDepth, func(path string, d os.DirEntry) bool {
-		if d.IsDir() && strings.HasSuffix(d.Name(), ".stage") {
-			found = path
-			return true // stop
+		if d.IsDir() {
+			name := d.Name()
+			if strings.HasSuffix(name, ".stage") ||
+				strings.HasSuffix(name, ".folder") ||
+				strings.HasSuffix(name, ".project") {
+				found = path
+				return true // stop
+			}
 		}
 		return false
 	})
@@ -134,10 +141,21 @@ func downloadStageRecursively(e *Executor, folderID int, filePath string) error 
 	if err := e.checkCancel(); err != nil {
 		return err
 	}
-	// Try "folder" first (works for sub-folder IDs), fall back to "stage" for stage roots.
-	data, err := e.PullZip(folderID, "folder")
-	if err != nil {
-		data, err = e.PullZip(folderID, "stage")
+	// If folderID matches the configured stage root, we know it's a stage —
+	// no need to probe. Otherwise try in order: stage → folder → project.
+	var objTypes []string
+	if e.StageID != 0 && folderID == e.StageID {
+		objTypes = []string{"stage"}
+	} else {
+		objTypes = []string{"stage", "folder", "project"}
+	}
+	var data []byte
+	var err error
+	for _, objType := range objTypes {
+		data, err = e.PullZip(folderID, objType)
+		if err == nil {
+			break
+		}
 	}
 	if err != nil {
 		return fmt.Errorf("failed to PullZip: %w", err)
@@ -182,7 +200,7 @@ func downloadStageRecursively(e *Executor, folderID int, filePath string) error 
 		return fmt.Errorf("failed to find stage dir: %v", err)
 	}
 	if stageDir == "" {
-		return fmt.Errorf("stage directory not found (*.stage)")
+		return fmt.Errorf("stage directory not found (*.stage / *.folder / *.project)")
 	}
 	// stagesDir is the parent of stageDir (needed for cleanup)
 	stagesDir := filepath.Dir(stageDir)
@@ -214,38 +232,6 @@ func downloadStageRecursively(e *Executor, folderID int, filePath string) error 
 	}
 
 	return nil
-	//
-	//fmt.Println("procInfo", procInfo)
-	//if err != nil {
-	//	logger.Error("Failed to PullFolder: %v", err)
-	//	return
-	//}
-	//for _, p := range procInfo {
-	//	convType, _ := p.(map[string]interface{})["conv_type"].(string)
-	//	if convType != "process" {
-	//		continue
-	//	}
-	//	// save to filePath
-	//	data, err := json.MarshalIndent(p, "", "  ")
-	//	if err != nil {
-	//		logger.Error("Failed to json marshal process: %v", err)
-	//		return
-	//	}
-	//	//data := []byte(UpdateTestJson)
-	//	title, _ := p.(map[string]interface{})["title"].(string)
-	//	objID := strconv.Itoa(int(p.(map[string]interface{})["obj_id"].(float64)))
-	//	if title == "" {
-	//		title = objID
-	//	} else {
-	//		title = title + "." + objID
-	//	}
-	//	err = os.WriteFile(filePath+"/"+title+".json", data, 0644)
-	//	if err != nil {
-	//		logger.Error("Failed to write file: %v", err)
-	//		return
-	//	}
-	//	fmt.Println("Process saved to", filePath+"/"+title+".json")
-	//}
 }
 
 func renameFiles2Folders(filePath string) error {
@@ -258,7 +244,9 @@ func renameFiles2Folders(filePath string) error {
 	for _, f := range files {
 		if f.IsDir() {
 			dirName := f.Name()
-			newName := strings.ReplaceAll(dirName, ".folder", "")
+			newName := strings.TrimSuffix(dirName, ".stage")
+			newName = strings.TrimSuffix(newName, ".folder")
+			newName = strings.TrimSuffix(newName, ".project")
 			newPath := filepath.Join(filePath, newName)
 			if newName != dirName {
 				oldPath := filepath.Join(filePath, dirName)
@@ -280,18 +268,6 @@ func renameFiles2Folders(filePath string) error {
 			if err != nil {
 				return fmt.Errorf("Failed to rename files in directory: %v", err)
 			}
-		} else {
-			if filepath.Ext(f.Name()) != ".json" {
-				continue
-			}
-			//if strings.Contains(f.Name(), ".folder.json") {
-			//	//	 remove
-			//	err := os.Remove(filepath.Join(filePath, f.Name()))
-			//	if err != nil {
-			//		return fmt.Errorf("failed to remove file: %v", err)
-			//	}
-			//}
-			// Rename file if it follows pattern with numeric prefix
 		}
 
 	}

--- a/plugins/corezoid/mcp-server/tools_registry.go
+++ b/plugins/corezoid/mcp-server/tools_registry.go
@@ -200,7 +200,7 @@ var toolRegistry = []mcpTool{
 	},
 	{
 		Name:        "login",
-		Description: "Authenticate with Corezoid via OAuth2 browser flow. Opens a browser window and saves the token so it persists across sessions. Optionally accepts account_url, workspace_id, and stage_id to skip interactive prompts.",
+		Description: "Authenticate with Corezoid. Supports two auth methods: (1) OAuth2 browser flow — opens a browser window and saves the token so it persists across sessions; (2) API key — provide api_login and api_secret to skip the browser flow (credentials saved to project .env). Optionally accepts account_url, workspace_id, and stage_id to skip interactive prompts.",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
@@ -215,6 +215,14 @@ var toolRegistry = []mcpTool{
 				"stage_id": map[string]interface{}{
 					"type":        "string",
 					"description": "Corezoid stage (root folder) ID",
+				},
+				"api_login": map[string]interface{}{
+					"type":        "string",
+					"description": "API key login (alternative to OAuth2 browser flow). If both api_login and api_secret are provided, browser authentication is skipped.",
+				},
+				"api_secret": map[string]interface{}{
+					"type":        "string",
+					"description": "API key secret (alternative to OAuth2 browser flow). Must be paired with api_login. Stored in project .env — ensure .env is in .gitignore.",
 				},
 			},
 		},

--- a/plugins/corezoid/skills/corezoid-init/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-init/SKILL.md
@@ -98,6 +98,34 @@ Then call `login` — it will skip already-set values and only prompt for what's
 
 ---
 
+## Exception: API key auth (login + secret)
+
+When the user provides an **API key login and secret** instead of OAuth credentials, use API key auth. This is common on private/on-prem Corezoid instances where browser OAuth is not available.
+
+**How to recognise:** user says something like "use login 12345 secret abc..." or "connect with API key".
+
+**Exact steps — call `login` with `api_login` and `api_secret` as arguments:**
+
+```
+login(
+  account_url=<host>,
+  workspace_id=<company_id>,
+  stage_id=<stage_id>,
+  api_login=<login_id>,
+  api_secret=<secret>
+)
+```
+
+⚠️ **Critical:** pass `api_login` and `api_secret` **as arguments to the `login` tool** — do NOT write them to `.env` manually. The tool saves them to `.env` automatically with the correct variable names (`API_LOGIN`, `API_SECRET`). Writing them manually with wrong names (e.g. `COREZOID_LOGIN`) will break authentication.
+
+The login tool will:
+1. Skip the OAuth2 browser flow
+2. Save `API_LOGIN` and `API_SECRET` to the project `.env`
+3. Set `COREZOID_API_URL` from `ACCOUNT_URL` if not already set
+4. Complete workspace/stage selection normally
+
+---
+
 ## Exception: OAuth fails on private on-prem instances
 
 On private Corezoid installations, the OAuth2 browser flow may time out because `localhost` is not registered as an allowed `redirect_uri` (see issue #7). Symptom: browser opens the workspace UI instead of redirecting back.


### PR DESCRIPTION
## Summary

- **API key authentication** (`API_LOGIN` + `API_SECRET`) added as fallback to OAuth2 Simulator token for on-prem and headless environments where browser OAuth is unavailable
- Simulator token remains priority; API key activates only when no token is present
- `login` tool accepts `api_login` and `api_secret` args — stores them in project `.env`, skips OAuth PKCE flow
- Download URLs authenticated via `/{login}/{ts}/{sig}` appended to URL path (documented Corezoid pattern)
- Signature formula: `hex(sha1(ts + secret + body + secret))`

**Also fixed:**
- `pull-folder` obj_type probe: configured stage root always uses `"stage"`; others probe `stage → folder → project`
- Export op type: `"download"` on `/api/2/download` (Simulator), `"create"` on `/api/2/json` (API key) — prevents "undefined request" on some deployments
- `findStageDir` now matches `*.stage`, `*.folder`, `*.project`; `renameFiles2Folders` uses `TrimSuffix` (not `ReplaceAll`)
- `fetchDownload` propagates executor context for proper cancellation
- Removed dead `PullFolder` method and leftover commented-out code
- `corezoid-init` skill documents API key flow explicitly

## Test plan

- [ ] OAuth2 login flow unchanged — existing Simulator token path not affected
- [ ] `login(api_login=..., api_secret=...)` skips browser, saves to `.env`, proceeds to workspace/stage selection
- [ ] `pull-process` works with API key auth
- [ ] `pull-folder` works with API key auth (ZIP download via `{url}/{login}/{ts}/{sig}`)
- [ ] `go test ./...` passes (including `TestAPIKeySign_KnownValue` with pinned hash)
- [ ] Verified on `admin-pre.corezoid.com` with real API key credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)