### PR TITLE
feat(auth): add API key (login+secret) auth as Simulator token fallback

### DIFF
--- a/plugins/corezoid/mcp-server/executor.go
+++ b/plugins/corezoid/mcp-server/executor.go
@@ -57,10 +57,11 @@ func NewValidator(ctx context.Context, inProcessID int) *Executor {
 		ctx = context.Background()
 	}
 	apiURLv, tokenv, workspaceIDv, _, stageIDv := authSnapshot()
+	snapAPILogin, snapAPISecret := apiKeySnapshot()
 	v := &Executor{
 		Ctx:         ctx,
-		APILogin:    "",
-		APISecret:   "",
+		APILogin:    snapAPILogin,
+		APISecret:   snapAPISecret,
 		APIUrl:      apiURLv,
 		Token:       tokenv,
 		WorkspaceID: workspaceIDv,

--- a/plugins/corezoid/mcp-server/executor_api.go
+++ b/plugins/corezoid/mcp-server/executor_api.go
@@ -3,7 +3,9 @@ package main
 import (
 	"bytes"
 	"context"
+	"crypto/sha1" //nolint:gosec
 	"crypto/tls"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -57,20 +59,23 @@ func (v *Executor) req(method string, ops []map[string]any) (map[string]interfac
 	path := "json"
 	switch method {
 	case "export_process":
+		// Always use /api/2/download for exports — it returns a download_url.
+		// fetchDownload handles both auth modes:
+		//   Simulator: Authorization: Simulator <token> header
+		//   API key:   GET {url}/{login}/{ts}/{sig} (URL-embedded signature)
 		path = "download"
 	case "compare", "merge":
 		// The stage compare/merge (deploy) admin ops have their own endpoints —
 		// /api/2/compare and /api/2/merge — not the shared /api/2/json.
 		path = method
 	}
-	authURL := fmt.Sprintf("%s/api/2/%s", v.APIUrl, path)
 
 	if v.Debug {
-		logger.Debug("Request URL, url=%s", authURL)
+		logger.Debug("Request baseURL=%s path=%s", v.APIUrl, path)
 	}
 
 	client := newHTTPClient()
-	resp, body, err := doWithRetry(v.Ctx, client, "POST", authURL, payloadJSON, v.Token, v.Debug)
+	resp, body, err := doWithRetry(v.Ctx, client, "POST", v.APIUrl, path, payloadJSON, v.Token, v.APILogin, v.APISecret, v.Debug)
 	if err != nil {
 		return nil, err
 	}
@@ -112,17 +117,30 @@ func newHTTPClient() *http.Client {
 	}
 }
 
+// apiKeySign computes the Corezoid API key request signature:
+// hex(sha1(timestamp + apiSecret + body + apiSecret))
+func apiKeySign(secret, timestamp, body string) string {
+	h := sha1.New() //nolint:gosec
+	h.Write([]byte(timestamp + secret + body + secret))
+	return hex.EncodeToString(h.Sum(nil))
+}
+
 // doWithRetry sends an authenticated request and retries transient 429/503
 // responses with exponential backoff and jitter. Non-retriable statuses (and
 // non-network errors) are returned to the caller after the first attempt;
 // retrying e.g. a 4xx auth failure would just delay the user-visible error.
 //
+// Authentication mode:
+//   - If token != "": Simulator bearer token. URL = baseURL/api/2/path, header Authorization: Simulator <token>.
+//   - If token == "" and apiLogin+apiSecret != "": API key HMAC-SHA1. URL = baseURL/api/2/path/apiLogin/ts/sig, no auth header.
+//
 // The response body is rebuilt from `payloadJSON` on each attempt, so the body
 // must be idempotent — which it is, since Corezoid's JSON-RPC ops are.
+// For API key mode the timestamp+signature are recomputed fresh on each retry.
 //
 // Returns the final response and the already-read body. Caller owns resp.Body
 // and must close it.
-func doWithRetry(ctx context.Context, client *http.Client, method, url string, payloadJSON []byte, token string, debug bool) (*http.Response, []byte, error) {
+func doWithRetry(ctx context.Context, client *http.Client, method, baseURL, path string, payloadJSON []byte, token, apiLoginArg, apiSecretArg string, debug bool) (*http.Response, []byte, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -134,18 +152,35 @@ func doWithRetry(ctx context.Context, client *http.Client, method, url string, p
 		if err := ctx.Err(); err != nil {
 			return nil, nil, err
 		}
-		req, err := http.NewRequestWithContext(ctx, method, url, bytes.NewReader(payloadJSON))
+
+		// Build per-attempt URL. For API key auth, recompute timestamp+signature
+		// on every retry so the signature is never stale.
+		var reqURL string
+		if token != "" {
+			reqURL = fmt.Sprintf("%s/api/2/%s", baseURL, path)
+		} else {
+			ts := strconv.FormatInt(time.Now().Unix(), 10)
+			sig := apiKeySign(apiSecretArg, ts, string(payloadJSON))
+			reqURL = fmt.Sprintf("%s/api/2/%s/%s/%s/%s", baseURL, path, apiLoginArg, ts, sig)
+		}
+
+		req, err := http.NewRequestWithContext(ctx, method, reqURL, bytes.NewReader(payloadJSON))
 		if err != nil {
 			// NewRequest fails only on programmer error (bad method/URL),
 			// not on transient I/O — no point retrying.
 			return nil, nil, err
 		}
 		req.Header.Set("Content-Type", "application/json")
-		req.Header.Set("Authorization", fmt.Sprintf("Simulator %s", token))
+		if token != "" {
+			req.Header.Set("Authorization", fmt.Sprintf("Simulator %s", token))
+		}
 		if debug && attempt == 1 {
-			safeHeaders := req.Header.Clone()
-			safeHeaders.Set("Authorization", "Simulator ***")
-			logger.Debug("Header: %v", safeHeaders)
+			logger.Debug("Request URL: %s", reqURL)
+			if token != "" {
+				safeHeaders := req.Header.Clone()
+				safeHeaders.Set("Authorization", "Simulator ***")
+				logger.Debug("Header: %v", safeHeaders)
+			}
 		}
 
 		resp, err := client.Do(req)

--- a/plugins/corezoid/mcp-server/executor_api.go
+++ b/plugins/corezoid/mcp-server/executor_api.go
@@ -175,7 +175,13 @@ func doWithRetry(ctx context.Context, client *http.Client, method, baseURL, path
 			req.Header.Set("Authorization", fmt.Sprintf("Simulator %s", token))
 		}
 		if debug && attempt == 1 {
-			logger.Debug("Request URL: %s", reqURL)
+			// In API key mode the URL embeds /{login}/{ts}/{sig} — mask the suffix
+			// so the login ID is not exposed in logs (symmetry with Simulator masking).
+			logURL := reqURL
+			if token == "" {
+				logURL = fmt.Sprintf("%s/api/2/%s/***/***", baseURL, path)
+			}
+			logger.Debug("Request URL: %s", logURL)
 			if token != "" {
 				safeHeaders := req.Header.Clone()
 				safeHeaders.Set("Authorization", "Simulator ***")

--- a/plugins/corezoid/mcp-server/executor_api.go
+++ b/plugins/corezoid/mcp-server/executor_api.go
@@ -117,7 +117,8 @@ func newHTTPClient() *http.Client {
 	}
 }
 
-// apiKeySign computes the Corezoid API key request signature:
+// apiKeySign computes the Corezoid API key request signature using the
+// documented double-salted SHA1 pattern (not standard HMAC-SHA1 / RFC 2104):
 // hex(sha1(timestamp + apiSecret + body + apiSecret))
 func apiKeySign(secret, timestamp, body string) string {
 	h := sha1.New() //nolint:gosec
@@ -132,7 +133,7 @@ func apiKeySign(secret, timestamp, body string) string {
 //
 // Authentication mode:
 //   - If token != "": Simulator bearer token. URL = baseURL/api/2/path, header Authorization: Simulator <token>.
-//   - If token == "" and apiLogin+apiSecret != "": API key HMAC-SHA1. URL = baseURL/api/2/path/apiLogin/ts/sig, no auth header.
+//   - If token == "" and apiLogin+apiSecret != "": API key (double-salted SHA1). URL = baseURL/api/2/path/apiLogin/ts/sig, no auth header.
 //
 // The response body is rebuilt from `payloadJSON` on each attempt, so the body
 // must be idempotent — which it is, since Corezoid's JSON-RPC ops are.

--- a/plugins/corezoid/mcp-server/executor_api_test.go
+++ b/plugins/corezoid/mcp-server/executor_api_test.go
@@ -280,8 +280,9 @@ func TestDoWithRetry_CancelDuringBackoff(t *testing.T) {
 // ---- apiKeySign -------------------------------------------------------------
 
 func TestAPIKeySign_KnownValue(t *testing.T) {
-	// Verify the HMAC-SHA1 formula: hex(sha1(ts + secret + body + secret))
-	// Expected value cross-checked independently:
+	// Verify the Corezoid API key signature: hex(sha1(ts + secret + body + secret))
+	// This is a double-salted SHA1 pattern (secret wraps the message), not
+	// standard HMAC-SHA1 (RFC 2104). Expected value cross-checked independently:
 	//   python3 -c "import hashlib; print(hashlib.sha1(b'1700000000mysecret{}mysecret').hexdigest())"
 	const want = "8c5cd99f9cfa598f65e6b3fae56cc859cecd5ee6"
 	got := apiKeySign("mysecret", "1700000000", "{}")

--- a/plugins/corezoid/mcp-server/executor_api_test.go
+++ b/plugins/corezoid/mcp-server/executor_api_test.go
@@ -160,7 +160,7 @@ func TestDoWithRetry_RetriesOn503ThenSucceeds(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	resp, body, err := doWithRetry(context.Background(), srv.Client(), "POST", srv.URL, []byte(`{}`), "tkn", false)
+	resp, body, err := doWithRetry(context.Background(), srv.Client(), "POST", srv.URL, "json", []byte(`{}`), "tkn", "", "", false)
 	if err != nil {
 		t.Fatalf("expected success after retries, got %v", err)
 	}
@@ -190,7 +190,7 @@ func TestDoWithRetry_RetriesOn429(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	resp, _, err := doWithRetry(context.Background(), srv.Client(), "POST", srv.URL, []byte(`{}`), "tkn", false)
+	resp, _, err := doWithRetry(context.Background(), srv.Client(), "POST", srv.URL, "json", []byte(`{}`), "tkn", "", "", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestDoWithRetry_DoesNotRetry4xx(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	resp, _, err := doWithRetry(context.Background(), srv.Client(), "POST", srv.URL, []byte(`{}`), "tkn", false)
+	resp, _, err := doWithRetry(context.Background(), srv.Client(), "POST", srv.URL, "json", []byte(`{}`), "tkn", "", "", false)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -233,7 +233,7 @@ func TestDoWithRetry_GivesUpAfterMaxAttempts(t *testing.T) {
 	}))
 	t.Cleanup(srv.Close)
 
-	resp, _, err := doWithRetry(context.Background(), srv.Client(), "POST", srv.URL, []byte(`{}`), "tkn", false)
+	resp, _, err := doWithRetry(context.Background(), srv.Client(), "POST", srv.URL, "json", []byte(`{}`), "tkn", "", "", false)
 	if err == nil {
 		if resp != nil {
 			resp.Body.Close()
@@ -264,7 +264,7 @@ func TestDoWithRetry_CancelDuringBackoff(t *testing.T) {
 		cancel()
 	}()
 
-	_, _, err := doWithRetry(ctx, srv.Client(), "POST", srv.URL, []byte(`{}`), "tkn", false)
+	_, _, err := doWithRetry(ctx, srv.Client(), "POST", srv.URL, "json", []byte(`{}`), "tkn", "", "", false)
 	if err == nil {
 		t.Fatal("expected context.Canceled error, got nil")
 	}
@@ -274,6 +274,27 @@ func TestDoWithRetry_CancelDuringBackoff(t *testing.T) {
 	// We allow either 1 or 2 attempts before cancel races in.
 	if got := atomic.LoadInt32(&calls); got > 2 {
 		t.Errorf("cancel should stop retries quickly, got %d attempts", got)
+	}
+}
+
+// ---- apiKeySign -------------------------------------------------------------
+
+func TestAPIKeySign_KnownValue(t *testing.T) {
+	// Verify the HMAC-SHA1 formula: hex(sha1(ts + secret + body + secret))
+	// Expected value cross-checked independently:
+	//   python3 -c "import hashlib; print(hashlib.sha1(b'1700000000mysecret{}mysecret').hexdigest())"
+	const want = "8c5cd99f9cfa598f65e6b3fae56cc859cecd5ee6"
+	got := apiKeySign("mysecret", "1700000000", "{}")
+	if got != want {
+		t.Errorf("apiKeySign formula mismatch:\n  got  %q\n  want %q", got, want)
+	}
+	// Different secret must produce a different signature.
+	if got2 := apiKeySign("othersecret", "1700000000", "{}"); got == got2 {
+		t.Error("different secrets should produce different signatures")
+	}
+	// Different timestamp must produce a different signature.
+	if got3 := apiKeySign("mysecret", "1700000001", "{}"); got == got3 {
+		t.Error("different timestamps should produce different signatures")
 	}
 }
 

--- a/plugins/corezoid/mcp-server/executor_process.go
+++ b/plugins/corezoid/mcp-server/executor_process.go
@@ -6,15 +6,70 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
 
+// fetchDownload downloads the content at downloadURL and returns the raw bytes.
+//
+// Auth strategy:
+//   - Simulator token → Authorization: Simulator <token> header, URL unchanged.
+//   - API key (no token) → URL extended with /{API_LOGIN}/{TIMESTAMP}/{SIGNATURE}.
+//     Signature uses empty body: hex(sha1(ts + secret + "" + secret)).
+//     This is the documented Corezoid pattern for authenticating file downloads
+//     with an API key.
+//
+// HTTP status is checked: any 4xx/5xx is returned as an error with the first
+// 256 bytes of the response body for diagnosis.
+func (v *Executor) fetchDownload(downloadURL string) ([]byte, error) {
+	var reqURL string
+	if v.Token != "" {
+		reqURL = downloadURL
+	} else {
+		ts := strconv.FormatInt(time.Now().Unix(), 10)
+		sig := apiKeySign(v.APISecret, ts, "")
+		reqURL = fmt.Sprintf("%s/%s/%s/%s", downloadURL, v.APILogin, ts, sig)
+	}
+
+	req, err := http.NewRequestWithContext(v.Ctx, "GET", reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build download request: %w", err)
+	}
+	if v.Token != "" {
+		req.Header.Set("Authorization", fmt.Sprintf("Simulator %s", v.Token))
+	}
+
+	resp, err := newHTTPClient().Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read download response: %w", err)
+	}
+	if resp.StatusCode >= 400 {
+		snippet := body
+		if len(snippet) > 256 {
+			snippet = snippet[:256]
+		}
+		return nil, fmt.Errorf("download failed with HTTP %d: %s", resp.StatusCode, snippet)
+	}
+	return body, nil
+}
+
 // PullZip exports a process or folder as a ZIP archive and returns the raw bytes.
 func (v *Executor) PullZip(id int, objType string) ([]byte, error) {
+	// /api/2/download (Simulator) accepts type="download".
+	// /api/2/json (API key) only accepts type="create" — "download" returns "undefined request".
+	opType := "create"
+	if v.Token != "" {
+		opType = "download"
+	}
 	ops := []map[string]any{
 		{
-			"type":       "create",
+			"type":       opType,
 			"obj":        "obj_scheme",
 			"obj_id":     id,
 			"company_id": v.WorkspaceID,
@@ -39,95 +94,25 @@ func (v *Executor) PullZip(id int, objType string) ([]byte, error) {
 	if !ok {
 		return nil, fmt.Errorf("failed to export process: unexpected ops format")
 	}
-	downloadURL1, ok := firstOp["download_url"].(string)
-	if !ok || downloadURL1 == "" {
+	downloadURL, ok := firstOp["download_url"].(string)
+	if !ok || downloadURL == "" {
 		return nil, fmt.Errorf("failed to export process: no download_url in response")
 	}
-
-	req, err := http.NewRequest("GET", downloadURL1, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	if v.Token != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Simulator %s", v.Token))
-	}
-	resp, err := newHTTPClient().Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to download process: %v", err)
-	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read process: %v", err)
-	}
-	return body, nil
-}
-
-// PullFolder exports all processes in a folder as a JSON array.
-func (v *Executor) PullFolder(id int, objType string) ([]any, error) {
-	ops := []map[string]any{
-		{
-			"type":       "create",
-			"obj":        "obj_scheme",
-			"obj_id":     id,
-			"company_id": v.WorkspaceID,
-			"obj_type":   objType,
-			"with_alias": true,
-			"async":      false,
-			"format":     "json",
-		},
-	}
-	response, err := v.req("export_process", ops)
-	if err != nil {
-		return nil, fmt.Errorf("failed to export process: %w", err)
-	}
-	if response["request_proc"] != "ok" {
-		return nil, fmt.Errorf("failed to export process: %v", response)
-	}
-	ops1, ok := response["ops"].([]any)
-	if !ok || len(ops1) == 0 {
-		return nil, fmt.Errorf("failed to export process: no ops in response")
-	}
-	firstOp, ok := ops1[0].(map[string]any)
-	if !ok {
-		return nil, fmt.Errorf("failed to export process: unexpected ops format")
-	}
-	downloadURL1, ok := firstOp["download_url"].(string)
-	if !ok || downloadURL1 == "" {
-		return nil, fmt.Errorf("failed to export process: no download_url in response")
-	}
-
-	req, err := http.NewRequest("GET", downloadURL1, nil)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	if v.Token != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Simulator %s", v.Token))
-	}
-	resp, err := newHTTPClient().Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to download process: %v", err)
-	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read process: %v", err)
-	}
-	var processes []any
-	err = json.Unmarshal(body, &processes)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal process: %v", err)
-	}
-	return processes, nil
+	return v.fetchDownload(downloadURL)
 }
 
 // ExportProcess downloads the current process definition as parsed JSON.
+// Both Simulator and API key modes use /api/2/download and follow the download_url.
+// fetchDownload handles auth: Simulator uses an Authorization header; API key
+// appends /{login}/{ts}/{sig} to the URL.
 func (v *Executor) ExportProcess() (any, error) {
+	opType := "create"
+	if v.Token != "" {
+		opType = "download"
+	}
 	ops := []map[string]any{
 		{
-			"type":       "create",
+			"type":       opType,
 			"obj":        "obj_scheme",
 			"obj_id":     v.ProcessID,
 			"company_id": v.WorkspaceID,
@@ -144,6 +129,8 @@ func (v *Executor) ExportProcess() (any, error) {
 	if response["request_proc"] != "ok" {
 		return nil, fmt.Errorf("failed to export process: %v", response)
 	}
+
+	// Follow download_url.
 	ops1, ok := response["ops"].([]any)
 	if !ok || len(ops1) == 0 {
 		return nil, fmt.Errorf("failed to export process: no ops in response")
@@ -152,32 +139,17 @@ func (v *Executor) ExportProcess() (any, error) {
 	if !ok {
 		return nil, fmt.Errorf("failed to export process: unexpected ops format")
 	}
-	downloadURL1, ok := firstOp["download_url"].(string)
-	if !ok || downloadURL1 == "" {
+	downloadURL, ok := firstOp["download_url"].(string)
+	if !ok || downloadURL == "" {
 		return nil, fmt.Errorf("failed to export process: no download_url in response")
 	}
-
-	req, err := http.NewRequest("GET", downloadURL1, nil)
+	body, err := v.fetchDownload(downloadURL)
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Content-Type", "application/json")
-	if v.Token != "" {
-		req.Header.Set("Authorization", fmt.Sprintf("Simulator %s", v.Token))
-	}
-	resp, err := newHTTPClient().Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to download process: %v", err)
-	}
-	defer resp.Body.Close()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read process: %v", err)
-	}
 	var process []any
-	err = json.Unmarshal(body, &process)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal process: %v", err)
+	if err = json.Unmarshal(body, &process); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal process: %w", err)
 	}
 
 	// Fallback for undeployed processes: export_process returns empty scheme.nodes

--- a/plugins/corezoid/mcp-server/main.go
+++ b/plugins/corezoid/mcp-server/main.go
@@ -52,6 +52,14 @@ var insecureTLS bool
 // Reset to 0 on every loadConfig so a workspace switch gets a fresh value.
 var cachedProjectID int
 
+// apiLogin and apiSecret are the Corezoid API key credentials (API_LOGIN /
+// API_SECRET). They provide an alternative to OAuth2 PKCE for environments
+// where browser-based authentication is not available. When both are set,
+// requests are signed with HMAC-SHA1 instead of using a Simulator bearer token.
+// These are distinct from gitLoginID / gitSecret which are used for git-sync.
+var apiLogin string
+var apiSecret string
+
 // authSnapshot returns a coherent snapshot of the auth-state globals taken
 // under the read lock. Callers that subsequently need to mutate state must
 // acquire authStateMu.Lock() (not upgrade — Go's RWMutex doesn't support that).
@@ -59,6 +67,14 @@ func authSnapshot() (apiURLv, tokenv, workspaceIDv, accountURLv string, stageIDv
 	authStateMu.RLock()
 	defer authStateMu.RUnlock()
 	return apiURL, apiToken, workspaceID, accountURL, stageID
+}
+
+// apiKeySnapshot returns a coherent snapshot of the API key credentials taken
+// under the read lock. Same pattern as authSnapshot.
+func apiKeySnapshot() (login, secret string) {
+	authStateMu.RLock()
+	defer authStateMu.RUnlock()
+	return apiLogin, apiSecret
 }
 
 // withAuthLock runs fn while holding the auth-state write lock. Use for
@@ -164,6 +180,8 @@ func loadConfig() {
 	insecureTLS = os.Getenv("COREZOID_INSECURE_TLS") != ""
 	cachedProjectID = 0              // reset on workspace switch so it is re-resolved
 	os.Unsetenv("COREZOID_PROJECT_ID") // prevent stale process env from short-circuiting resolution
+	apiLogin = os.Getenv("API_LOGIN")
+	apiSecret = os.Getenv("API_SECRET")
 }
 
 // runCLI executes a single MCP tool from the command line and exits.
@@ -255,11 +273,14 @@ func main() {
 	loadConfig()
 	logger.Debug("Loaded configuration: apiURL=%s workspaceID=%s apigwURL=%s hasToken=%v", apiURL, workspaceID, apigwURL, apiToken != "")
 
-	if apiToken == "" {
+	if apiToken == "" && (apiLogin == "" || apiSecret == "") {
 		fmt.Fprintln(os.Stderr, "[corezoid-mcp] NOTICE: No credentials found.")
-		fmt.Fprintln(os.Stderr, "[corezoid-mcp] Run the 'login' MCP tool to authenticate via OAuth2.")
+		fmt.Fprintln(os.Stderr, "[corezoid-mcp] Authenticate via one of:")
+		fmt.Fprintln(os.Stderr, "[corezoid-mcp]   1. OAuth2 browser flow — run the 'login' MCP tool.")
+		fmt.Fprintln(os.Stderr, "[corezoid-mcp]   2. API key — set API_LOGIN and API_SECRET in your project .env,")
+		fmt.Fprintln(os.Stderr, "[corezoid-mcp]      then call the 'login' MCP tool to select workspace/stage.")
 		if credPath, err := credentialsFilePath(); err == nil {
-			fmt.Fprintf(os.Stderr, "[corezoid-mcp] Token will be saved to: %s\n", credPath)
+			fmt.Fprintf(os.Stderr, "[corezoid-mcp] OAuth2 token will be saved to: %s\n", credPath)
 		}
 	}
 

--- a/plugins/corezoid/mcp-server/main.go
+++ b/plugins/corezoid/mcp-server/main.go
@@ -55,7 +55,7 @@ var cachedProjectID int
 // apiLogin and apiSecret are the Corezoid API key credentials (API_LOGIN /
 // API_SECRET). They provide an alternative to OAuth2 PKCE for environments
 // where browser-based authentication is not available. When both are set,
-// requests are signed with HMAC-SHA1 instead of using a Simulator bearer token.
+// requests are signed using the Corezoid double-salted SHA1 pattern instead of using a Simulator bearer token.
 // These are distinct from gitLoginID / gitSecret which are used for git-sync.
 var apiLogin string
 var apiSecret string

--- a/plugins/corezoid/mcp-server/main_config_test.go
+++ b/plugins/corezoid/mcp-server/main_config_test.go
@@ -140,9 +140,11 @@ func snapshotConfigGlobals(t *testing.T) {
 	t.Helper()
 	prevAPI, prevAcc, prevWS, prevTok, prevGW := apiURL, accountURL, workspaceID, apiToken, apigwURL
 	prevStage, prevInsecure := stageID, insecureTLS
+	prevAPILogin, prevAPISecret := apiLogin, apiSecret
 	t.Cleanup(func() {
 		apiURL, accountURL, workspaceID, apiToken, apigwURL = prevAPI, prevAcc, prevWS, prevTok, prevGW
 		stageID, insecureTLS = prevStage, prevInsecure
+		apiLogin, apiSecret = prevAPILogin, prevAPISecret
 	})
 }
 

--- a/plugins/corezoid/mcp-server/mcp_discovery.go
+++ b/plugins/corezoid/mcp-server/mcp_discovery.go
@@ -139,10 +139,12 @@ func fetchStageList(ctx context.Context, companyID string, projectID int64) ([]s
 	return result, nil
 }
 
-// ensureTokenAuth checks that a valid API token is present. If apiToken is
-// empty it attempts to load saved OAuth credentials; the check-then-load-then-set
-// runs under the auth write lock so concurrent requests can't double-load or
-// race the read against the write.
+// ensureTokenAuth checks that a valid API token or API key credentials are
+// present. If apiToken is empty it attempts to load saved OAuth credentials;
+// if those are also absent, API key credentials (apiLogin + apiSecret) are
+// checked as a fallback. The check-then-load-then-set runs under the auth
+// write lock so concurrent requests can't double-load or race the read against
+// the write.
 func ensureTokenAuth() error {
 	_, snapToken, _, _, _ := authSnapshot()
 	if snapToken == "" {
@@ -158,7 +160,12 @@ func ensureTokenAuth() error {
 		}
 	}
 	if snapToken == "" {
-		return fmt.Errorf("[Error] Not authenticated: missing [ACCESS_TOKEN]. Invoke the 'corezoid-init' skill to set up credentials (use the Skill tool with skill=\"corezoid-init\").")
+		// Fall back to API key authentication if both login and secret are set.
+		snapAPILogin, snapAPISecret := apiKeySnapshot()
+		if snapAPILogin != "" && snapAPISecret != "" {
+			return nil
+		}
+		return fmt.Errorf("[Error] Not authenticated: missing [ACCESS_TOKEN] or [API_LOGIN + API_SECRET]. Invoke the 'corezoid-init' skill to set up credentials (use the Skill tool with skill=\"corezoid-init\").")
 	}
 	return nil
 }

--- a/plugins/corezoid/mcp-server/mcp_handlers_auth.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_auth.go
@@ -37,6 +37,15 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 		stageID, _ = strconv.Atoi(os.Getenv("COREZOID_STAGE_ID"))
 		apiURL = os.Getenv("COREZOID_API_URL")
 
+		// Reload API key credentials if currently empty (e.g. added to .env
+		// after the server started).
+		if apiLogin == "" {
+			apiLogin = os.Getenv("API_LOGIN")
+		}
+		if apiSecret == "" {
+			apiSecret = os.Getenv("API_SECRET")
+		}
+
 		// Record initial stageID to detect if it gets set during this call.
 		stageIDAtStart = stageID
 
@@ -73,13 +82,29 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 				}
 			}
 		}
+		// Handle api_login and api_secret arguments.
+		if v := optStrArg(args, "api_login"); v != "" {
+			apiLogin = v
+			os.Setenv("API_LOGIN", v)
+			if err := updateEnvFile(envPath, "API_LOGIN", v); err != nil {
+				logger.Warn("login: could not save API_LOGIN from arg: %v", err)
+			}
+		}
+		if v := optStrArg(args, "api_secret"); v != "" {
+			apiSecret = v
+			os.Setenv("API_SECRET", v)
+			if err := updateEnvFile(envPath, "API_SECRET", v); err != nil {
+				logger.Warn("login: could not save API_SECRET from arg: %v", err)
+			}
+		}
 	})
 
 	// Snapshot the post-reload state for use in this handler — long-running
 	// OAuth / elicitation must not hold the auth lock, so we drive most
 	// logic from these locals and only re-acquire the lock for writes.
 	_, snapToken, snapWorkspaceID, snapAccountURL, snapStageID := authSnapshot()
-	logger.Info("login: accountURL=%q workspaceID=%q stageID=%d", snapAccountURL, snapWorkspaceID, snapStageID)
+	snapAPILogin, snapAPISecret := apiKeySnapshot()
+	logger.Info("login: accountURL=%q workspaceID=%q stageID=%d hasAPIKey=%v", snapAccountURL, snapWorkspaceID, snapStageID, snapAPILogin != "" && snapAPISecret != "")
 
 	// Step 1: ensure Account API URL.
 	if snapAccountURL == "" {
@@ -124,9 +149,10 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 		}
 	}
 
-	// Step 2: OAuth2 PKCE browser flow (skipped if already authenticated).
+	// Step 2: OAuth2 PKCE browser flow (skipped if already authenticated or if
+	// API key credentials are present — API key auth doesn't require a browser flow).
 	var tokenExpiry time.Time
-	if snapToken == "" {
+	if snapToken == "" && !(snapAPILogin != "" && snapAPISecret != "") {
 		res, err := oauthPKCEFlow(snapAccountURL, oauthClientID)
 		if err != nil {
 			return fmt.Sprintf("Authentication failed: %v", err), true
@@ -160,7 +186,7 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 				logger.Info("login: derived COREZOID_API_URL=%q from clients API", corezoidURL)
 			}
 		}
-	} else {
+	} else if snapToken != "" {
 		// If we already have a token but no derived API URL (e.g. token came from
 		// .env directly without completing OAuth), fetch the URL now.
 		authStateMu.RLock()
@@ -178,6 +204,23 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 				}
 				logger.Info("login: derived COREZOID_API_URL=%q from clients API (pre-existing token)", corezoidURL)
 			}
+		}
+	} else {
+		// API key flow: COREZOID_API_URL cannot be derived via /face/api/1/clients
+		// (that endpoint requires a Bearer/Simulator token). Fall back to ACCOUNT_URL —
+		// in most Corezoid deployments the API is served from the same host as the
+		// admin UI. Users who need a different API host can set COREZOID_API_URL in .env.
+		authStateMu.RLock()
+		apiURLEmpty := apiURL == ""
+		authStateMu.RUnlock()
+		if apiURLEmpty && snapAccountURL != "" {
+			fallback := strings.TrimRight(snapAccountURL, "/")
+			withAuthLock(func() { apiURL = fallback })
+			os.Setenv("COREZOID_API_URL", fallback)
+			if err := updateEnvFile(envPath, "COREZOID_API_URL", fallback); err != nil {
+				logger.Warn("login: could not save COREZOID_API_URL fallback: %v", err)
+			}
+			logger.Info("login: COREZOID_API_URL not set — defaulting to ACCOUNT_URL %q", fallback)
 		}
 	}
 
@@ -460,8 +503,9 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 }
 
 // handleLogout deletes the saved credentials from ~/.corezoid/credentials and
-// clears the cached access token. The token write is under the auth lock so a
-// concurrent in-flight request can't briefly use the cleared token-before-deletion state.
+// clears the cached access token. API key credentials are also removed from the
+// project .env. The writes are under the auth lock so a concurrent in-flight
+// request can't briefly use the cleared credentials.
 func handleLogout(_ context.Context, _ map[string]interface{}) (string, bool) {
 	credPath, err := credentialsFilePath()
 	if err != nil {
@@ -470,12 +514,24 @@ func handleLogout(_ context.Context, _ map[string]interface{}) (string, bool) {
 	if err := deleteCredentials(); err != nil {
 		return fmt.Sprintf("Failed to remove credentials: %v", err), true
 	}
+	// Remove API key credentials from the project .env.
+	envPath := envFilePath()
+	if err := removeEnvKey(envPath, "API_LOGIN"); err != nil {
+		logger.Warn("logout: could not remove API_LOGIN from .env: %v", err)
+	}
+	if err := removeEnvKey(envPath, "API_SECRET"); err != nil {
+		logger.Warn("logout: could not remove API_SECRET from .env: %v", err)
+	}
+	os.Unsetenv("API_LOGIN")
+	os.Unsetenv("API_SECRET")
 	withAuthLock(func() {
 		apiToken = ""
 		accountURL = ""
 		workspaceID = ""
 		stageID = 0
 		apiURL = ""
+		apiLogin = ""
+		apiSecret = ""
 	})
 	return fmt.Sprintf("Logged out. ACCESS_TOKEN removed from %s.", credPath), false
 }

--- a/plugins/corezoid/mcp-server/pull-project.go
+++ b/plugins/corezoid/mcp-server/pull-project.go
@@ -155,12 +155,13 @@ func downloadStageRecursively(e *Executor, folderID int, filePath string) error 
 		return err
 	}
 	// If folderID matches the configured stage root, we know it's a stage —
-	// no need to probe. Otherwise try in order: stage → folder → project.
+	// no need to probe. Otherwise try folder first (common case for sub-folders),
+	// then stage and project as fallbacks.
 	var objTypes []string
 	if e.StageID != 0 && folderID == e.StageID {
 		objTypes = []string{"stage"}
 	} else {
-		objTypes = []string{"stage", "folder", "project"}
+		objTypes = []string{"folder", "stage", "project"}
 	}
 	var data []byte
 	var err error

--- a/plugins/corezoid/mcp-server/pull-project.go
+++ b/plugins/corezoid/mcp-server/pull-project.go
@@ -79,13 +79,20 @@ func unzipFile(src, destDir string) error {
 	return nil
 }
 
-// findStageDir looks for a directory named *.stage up to maxDepth levels deep inside root.
+// findStageDir looks for the root content directory inside an extracted Corezoid
+// ZIP up to maxDepth levels deep. Matches *.stage, *.folder, and *.project —
+// Corezoid uses different suffixes depending on the exported obj_type.
 func findStageDir(root string, maxDepth int) (string, error) {
 	var found string
 	err := walkDepth(root, 0, maxDepth, func(path string, d os.DirEntry) bool {
-		if d.IsDir() && strings.HasSuffix(d.Name(), ".stage") {
-			found = path
-			return true // stop
+		if d.IsDir() {
+			name := d.Name()
+			if strings.HasSuffix(name, ".stage") ||
+				strings.HasSuffix(name, ".folder") ||
+				strings.HasSuffix(name, ".project") {
+				found = path
+				return true // stop
+			}
 		}
 		return false
 	})
@@ -147,10 +154,21 @@ func downloadStageRecursively(e *Executor, folderID int, filePath string) error 
 	if err := e.checkCancel(); err != nil {
 		return err
 	}
-	// Try "folder" first (works for sub-folder IDs), fall back to "stage" for stage roots.
-	data, err := e.PullZip(folderID, "folder")
-	if err != nil {
-		data, err = e.PullZip(folderID, "stage")
+	// If folderID matches the configured stage root, we know it's a stage —
+	// no need to probe. Otherwise try in order: stage → folder → project.
+	var objTypes []string
+	if e.StageID != 0 && folderID == e.StageID {
+		objTypes = []string{"stage"}
+	} else {
+		objTypes = []string{"stage", "folder", "project"}
+	}
+	var data []byte
+	var err error
+	for _, objType := range objTypes {
+		data, err = e.PullZip(folderID, objType)
+		if err == nil {
+			break
+		}
 	}
 	if err != nil {
 		return fmt.Errorf("failed to PullZip: %w", err)
@@ -195,7 +213,7 @@ func downloadStageRecursively(e *Executor, folderID int, filePath string) error 
 		return fmt.Errorf("failed to find stage dir: %v", err)
 	}
 	if stageDir == "" {
-		return fmt.Errorf("stage directory not found (*.stage) — " +
+		return fmt.Errorf("stage directory not found (*.stage / *.folder / *.project) — " +
 			"if COREZOID_WORK_DIR (or the MCP server launch directory) is $HOME " +
 			"or another large directory, set it to a dedicated project folder and " +
 			"restart Claude Code / the MCP server")
@@ -230,38 +248,6 @@ func downloadStageRecursively(e *Executor, folderID int, filePath string) error 
 	}
 
 	return nil
-	//
-	//fmt.Println("procInfo", procInfo)
-	//if err != nil {
-	//	logger.Error("Failed to PullFolder: %v", err)
-	//	return
-	//}
-	//for _, p := range procInfo {
-	//	convType, _ := p.(map[string]interface{})["conv_type"].(string)
-	//	if convType != "process" {
-	//		continue
-	//	}
-	//	// save to filePath
-	//	data, err := json.MarshalIndent(p, "", "  ")
-	//	if err != nil {
-	//		logger.Error("Failed to json marshal process: %v", err)
-	//		return
-	//	}
-	//	//data := []byte(UpdateTestJson)
-	//	title, _ := p.(map[string]interface{})["title"].(string)
-	//	objID := strconv.Itoa(int(p.(map[string]interface{})["obj_id"].(float64)))
-	//	if title == "" {
-	//		title = objID
-	//	} else {
-	//		title = title + "." + objID
-	//	}
-	//	err = os.WriteFile(filePath+"/"+title+".json", data, 0644)
-	//	if err != nil {
-	//		logger.Error("Failed to write file: %v", err)
-	//		return
-	//	}
-	//	fmt.Println("Process saved to", filePath+"/"+title+".json")
-	//}
 }
 
 func renameFiles2Folders(filePath string) error {
@@ -274,7 +260,9 @@ func renameFiles2Folders(filePath string) error {
 	for _, f := range files {
 		if f.IsDir() {
 			dirName := f.Name()
-			newName := strings.ReplaceAll(dirName, ".folder", "")
+			newName := strings.TrimSuffix(dirName, ".stage")
+			newName = strings.TrimSuffix(newName, ".folder")
+			newName = strings.TrimSuffix(newName, ".project")
 			newPath := filepath.Join(filePath, newName)
 			if newName != dirName {
 				oldPath := filepath.Join(filePath, dirName)
@@ -296,18 +284,6 @@ func renameFiles2Folders(filePath string) error {
 			if err != nil {
 				return fmt.Errorf("Failed to rename files in directory: %v", err)
 			}
-		} else {
-			if filepath.Ext(f.Name()) != ".json" {
-				continue
-			}
-			//if strings.Contains(f.Name(), ".folder.json") {
-			//	//	 remove
-			//	err := os.Remove(filepath.Join(filePath, f.Name()))
-			//	if err != nil {
-			//		return fmt.Errorf("failed to remove file: %v", err)
-			//	}
-			//}
-			// Rename file if it follows pattern with numeric prefix
 		}
 
 	}

--- a/plugins/corezoid/mcp-server/tools_registry.go
+++ b/plugins/corezoid/mcp-server/tools_registry.go
@@ -482,7 +482,7 @@ var toolRegistry = []mcpTool{
 	},
 	{
 		Name:        "login",
-		Description: "Authenticate with Corezoid via OAuth2 browser flow. Opens a browser window and saves the token so it persists across sessions. Optionally accepts account_url, workspace_id, and stage_id to skip interactive prompts.",
+		Description: "Authenticate with Corezoid. Supports two auth methods: (1) OAuth2 browser flow — opens a browser window and saves the token so it persists across sessions; (2) API key — provide api_login and api_secret to skip the browser flow (credentials saved to project .env). Optionally accepts account_url, workspace_id, and stage_id to skip interactive prompts.",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
@@ -497,6 +497,14 @@ var toolRegistry = []mcpTool{
 				"stage_id": map[string]interface{}{
 					"type":        "string",
 					"description": "Corezoid stage (root folder) ID",
+				},
+				"api_login": map[string]interface{}{
+					"type":        "string",
+					"description": "API key login (alternative to OAuth2 browser flow). If both api_login and api_secret are provided, browser authentication is skipped.",
+				},
+				"api_secret": map[string]interface{}{
+					"type":        "string",
+					"description": "API key secret (alternative to OAuth2 browser flow). Must be paired with api_login. Stored in project .env — ensure .env is in .gitignore.",
 				},
 			},
 		},

--- a/plugins/corezoid/skills/corezoid-init/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-init/SKILL.md
@@ -98,6 +98,34 @@ Then call `login` — it will skip already-set values and only prompt for what's
 
 ---
 
+## Exception: API key auth (login + secret)
+
+When the user provides an **API key login and secret** instead of OAuth credentials, use API key auth. This is common on private/on-prem Corezoid instances where browser OAuth is not available.
+
+**How to recognise:** user says something like "use login 12345 secret abc..." or "connect with API key".
+
+**Exact steps — call `login` with `api_login` and `api_secret` as arguments:**
+
+```
+login(
+  account_url=<host>,
+  workspace_id=<company_id>,
+  stage_id=<stage_id>,
+  api_login=<login_id>,
+  api_secret=<secret>
+)
+```
+
+⚠️ **Critical:** pass `api_login` and `api_secret` **as arguments to the `login` tool** — do NOT write them to `.env` manually. The tool saves them to `.env` automatically with the correct variable names (`API_LOGIN`, `API_SECRET`). Writing them manually with wrong names (e.g. `COREZOID_LOGIN`) will break authentication.
+
+The login tool will:
+1. Skip the OAuth2 browser flow
+2. Save `API_LOGIN` and `API_SECRET` to the project `.env`
+3. Set `COREZOID_API_URL` from `ACCOUNT_URL` if not already set
+4. Complete workspace/stage selection normally
+
+---
+
 ## Exception: OAuth fails on private on-prem instances
 
 On private Corezoid installations, the OAuth2 browser flow may time out because `localhost` is not registered as an allowed `redirect_uri` (see issue #7). Symptom: browser opens the workspace UI instead of redirecting back.


### PR DESCRIPTION
## Summary

- **API key authentication** (`API_LOGIN` + `API_SECRET`) added as fallback to OAuth2 Simulator token for on-prem and headless environments where browser OAuth is unavailable
- Simulator token remains priority; API key activates only when no token is present
- `login` tool accepts `api_login` and `api_secret` args — stores them in project `.env`, skips OAuth PKCE flow
- Download URLs authenticated via `/{login}/{ts}/{sig}` appended to URL path (documented Corezoid pattern)
- Signature formula: `hex(sha1(ts + secret + body + secret))`

**Also fixed:**
- `pull-folder` obj_type probe: configured stage root always uses `"stage"`; others probe `stage → folder → project`
- Export op type: `"download"` on `/api/2/download` (Simulator), `"create"` on `/api/2/json` (API key)
- `findStageDir` now matches `*.stage`, `*.folder`, `*.project`; `renameFiles2Folders` uses `TrimSuffix`
- `fetchDownload` propagates executor context for proper cancellation
- Removed dead `PullFolder` method and leftover commented-out code
- `corezoid-init` skill documents API key flow explicitly

## Test plan

- [ ] OAuth2 login flow unchanged
- [ ] `login(api_login=..., api_secret=...)` skips browser, saves to `.env`
- [ ] `pull-folder` works with API key auth
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)