### PR TITLE
feat(run-task): allow passing a custom task ref

### DIFF
--- a/plugins/corezoid/mcp-server/mcp_handlers_process.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_process.go
@@ -298,7 +298,10 @@ func handleRunTask(ctx context.Context, args map[string]interface{}) (string, bo
 		return fmt.Sprintf("Error parsing task data: %v", err), true
 	}
 
-	ref := fmt.Sprintf("%d_%d", time.Now().Unix(), rand.Intn(1000000))
+	ref := optStrArg(args, "ref")
+	if ref == "" {
+		ref = fmt.Sprintf("%d_%d", time.Now().Unix(), rand.Intn(1000000))
+	}
 	if err := v.createTask(ref, taskData); err != nil {
 		return fmt.Sprintf("Error creating task: %v", err), true
 	}

--- a/plugins/corezoid/mcp-server/tools_registry.go
+++ b/plugins/corezoid/mcp-server/tools_registry.go
@@ -215,7 +215,7 @@ var toolRegistry = []mcpTool{
 				},
 				"ref": map[string]interface{}{
 					"type":        "string",
-					"description": "Optional custom task ref (idempotency key). Use this to create a task with a specific, lookup-able ref — e.g. matching an external ID a downstream process keys off of. If omitted, an auto-generated ref (\"<unix_ts>_<rand>\") is used, same as before.",
+					"description": "Optional custom task ref (lookup key, not a guaranteed idempotency key — duplicate-ref behavior depends on the target process/state-diagram). Use this to create a task with a specific, lookup-able ref — e.g. matching an external ID a downstream process keys off of. If omitted, an auto-generated ref (\"<unix_ts>_<rand>\") is used, same as before.",
 				},
 				"wait_sec": map[string]interface{}{
 					"type":        "integer",

--- a/plugins/corezoid/mcp-server/tools_registry.go
+++ b/plugins/corezoid/mcp-server/tools_registry.go
@@ -213,6 +213,10 @@ var toolRegistry = []mcpTool{
 					"type":        "string",
 					"description": "JSON string with task input parameters",
 				},
+				"ref": map[string]interface{}{
+					"type":        "string",
+					"description": "Optional custom task ref (idempotency key). Use this to create a task with a specific, lookup-able ref — e.g. matching an external ID a downstream process keys off of. If omitted, an auto-generated ref (\"<unix_ts>_<rand>\") is used, same as before.",
+				},
 				"wait_sec": map[string]interface{}{
 					"type":        "integer",
 					"description": "How long to wait (seconds) for the task to reach a final node before reporting it as in progress. Default 30, max 600. Raise it for processes with slow external calls or delay nodes.",


### PR DESCRIPTION
## Summary

`run-task` always generated its own task ref (`<unix_ts>_<rand>`) and had no way to accept a caller-supplied one — even though the underlying `createTask(ref, taskData)` call already takes an arbitrary `ref` and sends it straight through to the Corezoid `create task` API op. This makes it impossible to create a task with a specific, lookup-able ref that a downstream process/state-diagram keys off of (e.g. a whitelist entry matched by `ref=telegram_<id>`).

## Changes

- `tools_registry.go`: add an optional `ref` input to the `run-task` tool schema.
- `mcp_handlers_process.go`: in `handleRunTask`, use the caller-supplied `ref` via `optStrArg(args, "ref")` when present; fall back to the existing auto-generated ref otherwise.

Backward compatible — callers that don't pass `ref` see no change in behavior.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full suite passes)
- [ ] Manual smoke test: `run-task` with an explicit `ref` against a state-diagram process, confirm the created task's `ref` (via `list-node-tasks`) matches the supplied value instead of an auto-generated one

🤖 Generated with [Claude Code](https://claude.com/claude-code)