### PR TITLE
fix(layout): preserve arranged layout; nicer default; smooth insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+- Fix: `push-process` no longer destroys a hand-arranged layout. On push the auto-layout re-lays-out the whole process only when **every** node is unplaced (`x==0 && y==0`); an edit that dropped node coordinates therefore used to wipe a nice arrangement. Push now **re-hydrates** any lost coordinate from the process's current server version first (matched by node title, or `obj_type`+ordinal for untitled nodes), so an existing layout is preserved — whether the edit dropped every coordinate or just some — and only genuinely-new nodes are placed; it reports `Restored N node coordinate(s)`. The server is consulted only when some node arrives unplaced.
+- Feat: a **from-scratch process now gets the full layout engine** on push (the same waterfall / layered+error-rail / regions strategies as the `layout-process` tool), instead of the lean grid — so a new process comes out cleanly arranged by default rather than cramped.
+- Feat: **smooth expansion** when inserting a node. Adding a node directly above its own placed down-child now slides that child and its downstream subtree down one row to open an in-style gap, instead of nudging the new node far below; unrelated/parallel nodes stay put, and incidental overlaps still nudge. Already-placed nodes are otherwise never moved.
+
 ## [2.9.0]
 
 - Feat: `push-process` now runs `lint-process` before deploying and blocks on issues that would break the deploy or its callers (broken node links, old-format nodes, RPC paths without reply, nodes missing a default `go`, sub-30s timers, literal reply values); advisory findings are shown but do not block, and `force=true` overrides. Advisory findings from `lint-process` are also surfaced back on a successful push instead of silently swallowed.

--- a/plugins/corezoid/mcp-server/coords.go
+++ b/plugins/corezoid/mcp-server/coords.go
@@ -1,0 +1,171 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// coords.go keeps push from destroying a laid-out process. On every push,
+// fixStruct -> applyLayout re-lays-out the WHOLE scheme when every node looks
+// unplaced (x==0 && y==0), and otherwise re-places any single unplaced node. An
+// edit that dropped node coordinates (e.g. the scheme was rebuilt without x/y),
+// fully or partially, therefore silently moves nodes. Before layout runs we
+// re-hydrate any lost coordinate from the process's current server version,
+// matched by node identity, so an existing arrangement is preserved and only
+// genuinely-new nodes (absent on the server) get placed.
+
+// schemeNodesFromConv parses scheme.nodes out of a conv JSON string.
+func schemeNodesFromConv(convJSON string) []map[string]any {
+	var doc map[string]any
+	if json.Unmarshal([]byte(convJSON), &doc) != nil {
+		return nil
+	}
+	return schemeNodesFromDoc(doc)
+}
+
+// schemeNodesFromDoc pulls scheme.nodes out of an already-parsed conv document.
+func schemeNodesFromDoc(doc map[string]any) []map[string]any {
+	scheme, ok := doc["scheme"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	raw, ok := scheme["nodes"].([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]map[string]any, 0, len(raw))
+	for _, r := range raw {
+		if m, ok := r.(map[string]any); ok {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// nodePlaced reports whether a node carries a real (non-origin) position.
+func nodePlaced(n map[string]any) bool {
+	x, _ := n["x"].(float64)
+	y, _ := n["y"].(float64)
+	return x != 0 || y != 0
+}
+
+// anyNodeUnplaced is true when at least one node sits at (0,0)/has no
+// coordinates. Any unplaced node means a coordinate may have been lost (fully
+// or partially), so it is worth checking the server for a saved position before
+// layout runs. Genuinely-new nodes (absent on the server) simply won't match
+// and stay unplaced for normal placement.
+func anyNodeUnplaced(convJSON string) bool {
+	for _, n := range schemeNodesFromConv(convJSON) {
+		if !nodePlaced(n) {
+			return true
+		}
+	}
+	return false
+}
+
+// coordMatchKeys returns, per node in scheme order, a cross-version match key:
+// the title for titled nodes, or obj_type + ordinal for untitled ones (Start
+// events and error finals are frequently untitled). Node ids are unusable — the
+// server regenerates them on every push.
+func coordMatchKeys(nodes []map[string]any) []string {
+	keys := make([]string, len(nodes))
+	ord := map[int]int{}
+	for i, n := range nodes {
+		if t, _ := n["title"].(string); t != "" {
+			keys[i] = "t:" + t
+		} else {
+			ot := coordObjType(n)
+			keys[i] = fmt.Sprintf("u:%d:%d", ot, ord[ot])
+			ord[ot]++
+		}
+	}
+	return keys
+}
+
+func coordObjType(n map[string]any) int {
+	switch v := n["obj_type"].(type) {
+	case float64:
+		return int(v)
+	case int:
+		return v
+	}
+	return 0
+}
+
+// rehydrateCoords fills missing x/y on local nodes from the server scheme,
+// matched by key. Returns the updated conv JSON and how many nodes were
+// restored. Best-effort and safe: it only fills a coordinate the local file
+// lacks, only from a server node that actually has a position, and skips
+// ambiguous (duplicate) keys so a wrong match can never move a node.
+func rehydrateCoords(localJSON string, serverNodes []map[string]any) (string, int) {
+	var doc map[string]any
+	if json.Unmarshal([]byte(localJSON), &doc) != nil {
+		return localJSON, 0
+	}
+	localNodes := schemeNodesFromDoc(doc)
+	if len(localNodes) == 0 || len(serverNodes) == 0 {
+		return localJSON, 0
+	}
+
+	skeys := coordMatchKeys(serverNodes)
+	count := map[string]int{}
+	for _, k := range skeys {
+		count[k]++
+	}
+	type xy struct{ x, y any }
+	pos := map[string]xy{}
+	for i, n := range serverNodes {
+		k := skeys[i]
+		if count[k] > 1 { // ambiguous — never impose a coordinate
+			continue
+		}
+		if nodePlaced(n) {
+			pos[k] = xy{n["x"], n["y"]}
+		}
+	}
+
+	lkeys := coordMatchKeys(localNodes)
+	filled := 0
+	for i, n := range localNodes {
+		if nodePlaced(n) {
+			continue
+		}
+		if p, ok := pos[lkeys[i]]; ok {
+			n["x"] = p.x
+			n["y"] = p.y
+			filled++
+		}
+	}
+	if filled == 0 {
+		return localJSON, 0
+	}
+	b, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return localJSON, 0
+	}
+	return string(b), filled
+}
+
+// rehydrateCoordsFromServer fetches the process's current server scheme and
+// re-hydrates lost coordinates into localJSON. Never fails a push — a fetch
+// error just means no re-hydration.
+func rehydrateCoordsFromServer(v *Executor, localJSON string) (string, int) {
+	raw, err := v.ExportProcess()
+	if err != nil {
+		logger.Warn("rehydrate: could not export server scheme: %v", err)
+		return localJSON, 0
+	}
+	obj := raw
+	if arr, ok := raw.([]any); ok && len(arr) > 0 {
+		obj = arr[0]
+	}
+	m, ok := obj.(map[string]any)
+	if !ok {
+		return localJSON, 0
+	}
+	server := schemeNodesFromDoc(m)
+	if len(server) == 0 {
+		return localJSON, 0
+	}
+	return rehydrateCoords(localJSON, server)
+}

--- a/plugins/corezoid/mcp-server/coords_test.go
+++ b/plugins/corezoid/mcp-server/coords_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func cNode(title string, objType int, x, y float64) map[string]any {
+	return map[string]any{
+		"title":     title,
+		"obj_type":  float64(objType),
+		"x":         x,
+		"y":         y,
+		"condition": map[string]any{"logics": []any{}, "semaphors": []any{}},
+	}
+}
+
+func cConv(nodes []map[string]any) string {
+	anyNodes := make([]any, len(nodes))
+	for i, n := range nodes {
+		anyNodes[i] = n
+	}
+	b, _ := json.Marshal(map[string]any{"scheme": map[string]any{"nodes": anyNodes}})
+	return string(b)
+}
+
+func coordOfTitle(convJSON, title string) (float64, float64) {
+	for _, n := range schemeNodesFromConv(convJSON) {
+		if t, _ := n["title"].(string); t == title {
+			x, _ := n["x"].(float64)
+			y, _ := n["y"].(float64)
+			return x, y
+		}
+	}
+	return -1, -1
+}
+
+func TestAnyNodeUnplaced(t *testing.T) {
+	all0 := cConv([]map[string]any{cNode("A", 1, 0, 0), cNode("B", 2, 0, 0)})
+	if !anyNodeUnplaced(all0) {
+		t.Fatal("all-at-origin scheme must report an unplaced node")
+	}
+	some := cConv([]map[string]any{cNode("A", 1, 100, 100), cNode("B", 2, 0, 0)})
+	if !anyNodeUnplaced(some) {
+		t.Fatal("a single unplaced node must be detected (partial loss)")
+	}
+	allPlaced := cConv([]map[string]any{cNode("A", 1, 100, 100), cNode("B", 2, 100, 300)})
+	if anyNodeUnplaced(allPlaced) {
+		t.Fatal("a fully placed scheme must report no unplaced node")
+	}
+	if anyNodeUnplaced(cConv(nil)) {
+		t.Fatal("empty scheme must report no unplaced node")
+	}
+}
+
+func TestRehydrate_FillsFromServerByTitle(t *testing.T) {
+	// local lost every coordinate; server has the real layout
+	local := cConv([]map[string]any{cNode("Start", 1, 0, 0), cNode("Work", 0, 0, 0), cNode("Done", 2, 0, 0)})
+	server := []map[string]any{cNode("Start", 1, 100, 100), cNode("Work", 0, 100, 300), cNode("Done", 2, 100, 500)}
+
+	out, n := rehydrateCoords(local, server)
+	if n != 3 {
+		t.Fatalf("expected 3 coordinates restored, got %d", n)
+	}
+	if x, y := coordOfTitle(out, "Work"); x != 100 || y != 300 {
+		t.Fatalf("Work not restored: got (%v,%v)", x, y)
+	}
+	if anyNodeUnplaced(out) {
+		t.Fatal("after re-hydrate no node should remain unplaced (baseLayout won't trigger)")
+	}
+}
+
+func TestRehydrate_PartialLoss(t *testing.T) {
+	// Only B lost its coordinates; A is intact; C is genuinely new (not on the
+	// server). Re-hydrate must restore B, keep A, and leave C unplaced.
+	local := cConv([]map[string]any{cNode("A", 1, 100, 100), cNode("B", 0, 0, 0), cNode("C", 0, 0, 0)})
+	server := []map[string]any{cNode("A", 1, 100, 100), cNode("B", 0, 100, 300)} // C absent on server
+	out, n := rehydrateCoords(local, server)
+	if n != 1 {
+		t.Fatalf("only the partially-lost node B should be restored, got %d", n)
+	}
+	if x, y := coordOfTitle(out, "B"); x != 100 || y != 300 {
+		t.Fatalf("B not restored: (%v,%v)", x, y)
+	}
+	for _, nd := range schemeNodesFromConv(out) {
+		if nd["title"] == "C" && (nd["x"].(float64) != 0 || nd["y"].(float64) != 0) {
+			t.Fatalf("genuinely-new node C must stay unplaced, got (%v,%v)", nd["x"], nd["y"])
+		}
+	}
+}
+
+func TestRehydrate_UntitledByOrdinal(t *testing.T) {
+	// two untitled end nodes, matched by obj_type + position
+	local := cConv([]map[string]any{cNode("", 1, 0, 0), cNode("", 2, 0, 0), cNode("", 2, 0, 0)})
+	server := []map[string]any{cNode("", 1, 50, 50), cNode("", 2, 50, 250), cNode("", 2, 400, 250)}
+	out, n := rehydrateCoords(local, server)
+	if n != 3 {
+		t.Fatalf("expected 3 untitled coords restored, got %d", n)
+	}
+	nodes := schemeNodesFromConv(out)
+	if nodes[2]["x"].(float64) != 400 {
+		t.Fatalf("second untitled end must take the 2nd server position (x=400), got %v", nodes[2]["x"])
+	}
+}
+
+func TestRehydrate_NeverOverwritesPlaced(t *testing.T) {
+	local := cConv([]map[string]any{cNode("A", 1, 700, 700), cNode("B", 2, 0, 0)})
+	server := []map[string]any{cNode("A", 1, 100, 100), cNode("B", 2, 100, 300)}
+	out, n := rehydrateCoords(local, server)
+	if n != 1 {
+		t.Fatalf("only the unplaced node should be filled, got %d", n)
+	}
+	if x, _ := coordOfTitle(out, "A"); x != 700 {
+		t.Fatalf("placed node A must keep its local coord 700, got %v", x)
+	}
+}
+
+func TestRehydrate_AmbiguousTitleNotImposed(t *testing.T) {
+	// two server nodes share a title → ambiguous → don't impose
+	local := cConv([]map[string]any{cNode("Dup", 0, 0, 0), cNode("Dup", 0, 0, 0)})
+	server := []map[string]any{cNode("Dup", 0, 100, 100), cNode("Dup", 0, 100, 300)}
+	_, n := rehydrateCoords(local, server)
+	if n != 0 {
+		t.Fatalf("ambiguous duplicate title must not be imposed, got %d filled", n)
+	}
+}
+
+func TestRehydrate_ServerUnplacedNothingToFill(t *testing.T) {
+	local := cConv([]map[string]any{cNode("A", 1, 0, 0)})
+	server := []map[string]any{cNode("A", 1, 0, 0)} // server also has no layout
+	_, n := rehydrateCoords(local, server)
+	if n != 0 {
+		t.Fatalf("nothing to restore when server is also unplaced, got %d", n)
+	}
+}

--- a/plugins/corezoid/mcp-server/layout.go
+++ b/plugins/corezoid/mcp-server/layout.go
@@ -25,6 +25,13 @@ const (
 	gridSnap  = 20  // grid the final coordinates snap to
 	spineX    = 600 // x of column 0 (the spine)
 	startOff  = 100 // extra x to centre a Start/End circle over the spine
+
+	// maxEngineLayoutNodes bounds the from-scratch push layout: at or above this
+	// size push falls back to the lean baseLayout grid instead of the full
+	// engine, so the automatic push path never spends the engine's O(n^2)
+	// overlap resolution on a very large new process. layout-process (invoked
+	// explicitly, where the user can wait) still runs the engine at any size.
+	maxEngineLayoutNodes = 250
 )
 
 // Fixed node footprints (px). Start/End render as a small circle with a CENTER
@@ -501,15 +508,61 @@ func placeNewNodes(nodes []map[string]interface{}) []string {
 		return newIDs[i] < newIDs[j]
 	})
 
+	// descendantsOf collects every node forward-reachable from root (root
+	// included), used to shift a subtree down when inserting a node above it.
+	descendantsOf := func(root string) map[string]bool {
+		seen := map[string]bool{root: true}
+		stack := []string{root}
+		for len(stack) > 0 {
+			cur := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			for _, e := range g.edges {
+				if e.src == cur && !seen[e.dst] {
+					seen[e.dst] = true
+					stack = append(stack, e.dst)
+				}
+			}
+		}
+		return seen
+	}
+	rebuildRects := func() {
+		placedRects = placedRects[:0]
+		for pid, p := range placed {
+			placedRects = append(placedRects, rectAt(nodeByID[pid], p.x, p.y))
+		}
+	}
+	// shiftSubtreeDown opens a one-row gap at minY by pushing root and its
+	// forward-reachable placed descendants at/below minY down by vStep. This is
+	// the "smooth expansion" when a node is inserted into the middle of a chain:
+	// the downstream part slides down in-style instead of the new node being
+	// nudged far away. Uniform translate — relative arrangement is preserved.
+	shiftSubtreeDown := func(root string, minY int) {
+		desc := descendantsOf(root)
+		for d := range desc {
+			p, ok := placed[d]
+			if !ok || p.y < minY {
+				continue
+			}
+			p.y += vStep
+			placed[d] = p
+			if nd := nodeByID[d]; nd != nil {
+				nd["x"] = float64(p.x)
+				nd["y"] = float64(p.y)
+			}
+		}
+		rebuildRects()
+	}
+
 	var notes []string
 	for _, id := range newIDs {
 		var target xy
 		set := false
+		insertBelowParent := false
 		// 1. primary down-child of a placed parent -> below the parent.
 		for _, s := range parents[id] {
 			if dt[s] == id {
 				if pp, ok := placed[s]; ok {
-					target, set = xy{pp.x, pp.y + vStep}, true
+					target, set, insertBelowParent = xy{pp.x, pp.y + vStep}, true, true
 					break
 				}
 			}
@@ -537,6 +590,19 @@ func placeNewNodes(nodes []map[string]interface{}) []string {
 		}
 
 		target = xy{snap(float64(target.x), gridSnap), snap(float64(target.y), gridSnap)}
+
+		// Smooth expansion: when inserting a node directly above its own placed
+		// down-child (a real "add a step in the chain"), push that child and its
+		// downstream subtree down to open a gap, instead of nudging the new node
+		// far below. Only the new node's own descendants at/below the slot move,
+		// so unrelated/parallel nodes stay put (incidental overlaps still nudge).
+		if insertBelowParent {
+			if c := dt[id]; c != "" {
+				if cp, ok := placed[c]; ok && cp.y == target.y {
+					shiftSubtreeDown(c, target.y)
+				}
+			}
+		}
 
 		nd := nodeByID[id]
 		intersectsPlaced := func(x, y int) bool {
@@ -618,7 +684,27 @@ func applyLayout(scheme map[string]interface{}, convType string) []string {
 		}
 	}
 	if allNew {
-		baseLayout(nodes)
+		// From-scratch process: use the full layout engine (the same waterfall /
+		// layered+error-rail / regions strategies the layout-process tool uses)
+		// rather than the lean baseLayout grid, so a new process gets a clean,
+		// readable default instead of a cramped one. computeLayout also sets the
+		// extra.modeForm collapse flags. This is the "place-new-nodes push hook"
+		// seam the engine was written for (see layout_engine.go).
+		// Use the full engine up to a bounded size; a very large new process
+		// falls back to the lean grid so push stays fast (see maxEngineLayoutNodes).
+		if len(nodes) <= maxEngineLayoutNodes {
+			e := &layoutEngine{density: "medium"}
+			if coords, rep := e.computeLayout(nodes); len(coords) > 0 {
+				for _, n := range nodes {
+					if p, ok := coords[nodeStr(n, "id")]; ok {
+						n["x"] = float64(p.X)
+						n["y"] = float64(p.Y)
+					}
+				}
+				return []string{fmt.Sprintf("layout: %s, positioned %d node(s)", rep.Strategy, len(nodes))}
+			}
+		}
+		baseLayout(nodes) // lean grid: engine unavailable/too large
 		return []string{fmt.Sprintf("layout: positioned %d new nodes", len(nodes))}
 	}
 	return placeNewNodes(nodes)

--- a/plugins/corezoid/mcp-server/layout_test.go
+++ b/plugins/corezoid/mcp-server/layout_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -123,28 +124,22 @@ func TestApplyLayoutAllNewLaysOut(t *testing.T) {
 	s, nodes := mk()
 	applyLayout(s, "process")
 
+	// A from-scratch process is laid out by the full engine (Fix 2). Assert the
+	// engine's guarantees rather than the old baseLayout grid: every node is
+	// placed off the origin, and no two node boxes overlap.
 	for _, nd := range nodes {
 		x, y := xy(nd)
 		if x == 0 && y == 0 {
 			t.Errorf("node %v still at origin", nd["id"])
 		}
-		if x == 0 {
-			t.Errorf("node %v has x==0 (expected >= spineX)", nd["id"])
-		}
-		if !onGrid(x) || !onGrid(y) {
-			t.Errorf("node %v off grid: (%v,%v)", nd["id"], x, y)
-		}
 	}
-	// Spine logic nodes sit in column 0 at x == spineX (600).
-	for _, id := range []string{"l1", "l2"} {
-		var found map[string]interface{}
-		for _, nd := range nodes {
-			if nd["id"] == id {
-				found = nd
+	for i := 0; i < len(nodes); i++ {
+		for j := i + 1; j < len(nodes); j++ {
+			xi, yi := xy(nodes[i])
+			xj, yj := xy(nodes[j])
+			if xi == xj && yi == yj {
+				t.Errorf("nodes %v and %v overlap at (%v,%v)", nodes[i]["id"], nodes[j]["id"], xi, yi)
 			}
-		}
-		if x, _ := xy(found); x != spineX {
-			t.Errorf("spine node %s x = %v, want %d", id, x, spineX)
 		}
 	}
 
@@ -226,6 +221,57 @@ func TestPreserveNudgesRectOverlap(t *testing.T) {
 	}
 }
 
+func TestPreserveInsertShiftsSubtree(t *testing.T) {
+	t.Setenv("COREZOID_AUTOLAYOUT", "")
+	// Placed chain P(600,200) -> C(600,400). Insert new N between them: P -> N -> C.
+	// N should take C's slot and C should slide down one step (smooth expansion),
+	// not have N nudged far below.
+	p := node("p", 0, 600, 200, goLogic("n"))
+	n := node("n", 0, 0, 0, goLogic("c")) // new; its own down-child is the placed C
+	c := node("c", 2, 600, 400)
+	sc := scheme(p, n, c)
+	applyLayout(sc, "process")
+
+	if x, y := xy(p); x != 600 || y != 200 {
+		t.Errorf("parent p moved to (%v,%v)", x, y)
+	}
+	if x, y := xy(n); x != 600 || y != 400 {
+		t.Errorf("inserted n = (%v,%v), want (600,400)", x, y)
+	}
+	if x, y := xy(c); x != 600 || y != 600 {
+		t.Errorf("child c not shifted down: (%v,%v), want (600,600)", x, y)
+	}
+	if anyIntersect(allRects(p, n, c)) {
+		t.Errorf("overlap after insert-shift")
+	}
+}
+
+func TestPreserveInsertLeavesParallelBranch(t *testing.T) {
+	t.Setenv("COREZOID_AUTOLAYOUT", "")
+	// P -> C -> D on the spine, plus a parallel branch B off P. Insert N above C:
+	// C and D (N's downstream) slide down; the parallel B must NOT move.
+	p := node("p", 0, 600, 200, goLogic("n"), condLogic("b"))
+	n := node("n", 0, 0, 0, goLogic("c")) // new
+	c := node("c", 0, 600, 400, goLogic("d"))
+	d := node("d", 2, 600, 600)
+	b := node("b", 2, 840, 400) // parallel branch target, not downstream of C
+	sc := scheme(p, n, c, d, b)
+	applyLayout(sc, "process")
+
+	if _, y := xy(c); y != 600 {
+		t.Errorf("c not shifted down: y=%v want 600", y)
+	}
+	if _, y := xy(d); y != 800 {
+		t.Errorf("d not shifted down: y=%v want 800", y)
+	}
+	if x, y := xy(b); x != 840 || y != 400 {
+		t.Errorf("parallel branch b moved to (%v,%v), want (840,400)", x, y)
+	}
+	if anyIntersect(allRects(p, n, c, d, b)) {
+		t.Errorf("overlap after insert-shift with parallel branch")
+	}
+}
+
 func TestPreservePushRoundTripUnchanged(t *testing.T) {
 	t.Setenv("COREZOID_AUTOLAYOUT", "")
 	// A small, fully-placed process (every node has non-(0,0) coords, with
@@ -281,9 +327,42 @@ func TestApplyLayoutMalformed(t *testing.T) {
 	applyLayout(map[string]interface{}{"nodes": "oops"}, "process")
 }
 
+func TestApplyLayoutLargeUsesFastPath(t *testing.T) {
+	t.Setenv("COREZOID_AUTOLAYOUT", "")
+	// A from-scratch process above maxEngineLayoutNodes must fall back to the
+	// lean baseLayout grid so push stays fast — not run the full engine.
+	const N = maxEngineLayoutNodes + 12
+	var nodes []map[string]interface{}
+	for i := 0; i < N; i++ {
+		id := fmt.Sprintf("n%03d", i)
+		switch {
+		case i == 0:
+			nodes = append(nodes, node(id, 1, 0, 0, goLogic("n001"))) // start
+		case i == N-1:
+			nodes = append(nodes, node(id, 2, 0, 0)) // final
+		default:
+			nodes = append(nodes, node(id, 0, 0, 0, goLogic(fmt.Sprintf("n%03d", i+1))))
+		}
+	}
+	applyLayout(scheme(nodes...), "process")
+
+	for _, nd := range nodes {
+		if x, y := xy(nd); x == 0 && y == 0 {
+			t.Fatalf("node %v left at origin — layout did not run", nd["id"])
+		}
+	}
+	// baseLayout keeps the spine chain in column 0 at spineX; the engine would not.
+	if x, _ := xy(nodes[1]); x != spineX {
+		t.Fatalf("large from-scratch process should use the baseLayout fast path (spine x=%d), got %v", spineX, x)
+	}
+}
+
 func TestSpineStraightCol0(t *testing.T) {
 	t.Setenv("COREZOID_AUTOLAYOUT", "")
-	// A spine A->B->C with branches hanging off each, all new -> baseLayout.
+	// A spine A->B->C with branches hanging off each. This exercises baseLayout
+	// directly (the from-scratch fallback): applyLayout's all-new path now uses
+	// the full engine (Fix 2), so baseLayout's straight-col-0 spine guarantee is
+	// asserted against baseLayout itself.
 	start := node("start", 1, 0, 0, goLogic("a"))
 	a := node("a", 0, 0, 0, goLogic("b"), condLogic("ba"))
 	ba := node("ba", 0, 0, 0)
@@ -291,8 +370,7 @@ func TestSpineStraightCol0(t *testing.T) {
 	bb := node("bb", 0, 0, 0)
 	c := node("c", 0, 0, 0, goLogic("end"))
 	end := node("end", 2, 0, 0)
-	s := scheme(start, a, ba, b, bb, c, end)
-	applyLayout(s, "process")
+	baseLayout([]map[string]interface{}{start, a, ba, b, bb, c, end})
 
 	for _, id := range []string{"a", "b", "c"} {
 		var found map[string]interface{}

--- a/plugins/corezoid/mcp-server/mcp_handlers_process.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_process.go
@@ -158,6 +158,24 @@ func handlePushProcess(ctx context.Context, args map[string]interface{}) (string
 		return fmt.Sprintf("Error loading JSON file: %v", err), true
 	}
 
+	// Coordinate re-hydration (see coords.go): if the process exists on the
+	// server and the local file lost any node coordinate (an edit dropped x/y,
+	// fully or partially), applyLayout below would move those nodes — and, if
+	// ALL are unplaced, re-lay-out the whole process. Refill lost coordinates
+	// from the server first so push preserves the arrangement; only genuinely-
+	// new nodes (absent on the server) stay unplaced and get placed normally.
+	var rehydrateNote string
+	if objID := extractObjIDFromJSON(jsonContent); objID != 0 && anyNodeUnplaced(jsonContent) {
+		if refilled, n := rehydrateCoordsFromServer(v, jsonContent); n > 0 {
+			// In-memory only: the refilled coordinates flow to the server via
+			// ProcessJSON below and are persisted to the file on success. We do
+			// NOT write the file here, so a later validation failure leaves the
+			// user's file untouched rather than silently baked with server coords.
+			jsonContent = refilled
+			rehydrateNote = fmt.Sprintf("Restored %d node coordinate(s) from the server — layout preserved.", n)
+		}
+	}
+
 	jsonContent1, messages := fixStruct(jsonContent, procID)
 	if len(messages) > 0 {
 		for _, msg := range messages {
@@ -234,6 +252,9 @@ func handlePushProcess(ctx context.Context, args map[string]interface{}) (string
 	}
 
 	result := fmt.Sprintf("Process deployed successfully, ProcessID: %d", procID)
+	if rehydrateNote != "" {
+		result += "\n" + rehydrateNote
+	}
 	if snapshotNote != "" {
 		result += "\n" + snapshotNote
 	}

--- a/plugins/corezoid/skills/corezoid-edit/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-edit/SKILL.md
@@ -47,7 +47,7 @@ Apply changes to `PROCESS_PATH`.
 - Every node that can fail must have `err_node_id` — point it **directly at a Final Error node** (`obj_type: 2`) unless the error path needs logic (reply to caller, retry routing). Never create an Escalation node (`obj_type: 3`) that only contains a bare `go` — that is a passthrough anti-pattern flagged by `lint-process`
 - Node IDs must be unique 24-character hex strings: `^[0-9a-f]{24}$`. **Always `pull-process` before editing** and reference only canonical, server-assigned IDs — IDs you invented in a previous push were reassigned by the server and no longer exist. New nodes added now get placeholder IDs that the server will likewise reassign on push. Existing nodes' IDs are preserved. See [Node ID Lifecycle](${CLAUDE_PLUGIN_ROOT}/docs/process/process-development-guide.md#node-id-lifecycle-server-assignment--stability-on-push).
 - Use descriptive node `title` values (e.g., "Call Payment Process", not "RPC")
-- Leave new nodes at placeholder coordinates `x: 0, y: 0` — `push-process` auto-places them near their graph neighbours (preserve mode: existing nodes keep their positions; error nodes land to the right of their parent). Only when auto-placement is disabled (`COREZOID_AUTOLAYOUT=off`) position nodes manually — error nodes to the right of their parent (`x + 300`). Do NOT re-layout the whole process unless the user asks — see the `corezoid-node-layout` skill's authorship policy
+- Leave new nodes at placeholder coordinates `x: 0, y: 0` — `push-process` auto-places them near their graph neighbours (preserve mode: existing nodes keep their positions; inserting a node above an existing one slides that node's downstream subtree down to open a gap; error nodes land to the right of their parent). **Keep the `x`/`y` of nodes you are NOT moving** — do not rebuild the scheme without them. As a safety net, if the file reaches push with every node's coordinates missing, push re-hydrates them from the server (reports `Restored N node coordinate(s)`) so a laid-out process is never re-arranged by accident. Only when auto-placement is disabled (`COREZOID_AUTOLAYOUT=off`) position nodes manually — error nodes to the right of their parent (`x + 300`). Do NOT re-layout the whole process unless the user asks — see the `corezoid-node-layout` skill's authorship policy
 
 ### Variables for constants
 
@@ -74,6 +74,7 @@ For complete JSON structures see `${CLAUDE_PLUGIN_ROOT}/docs/node-structures.md`
 
 ### Common pitfalls
 
+- **Regenerating the whole scheme instead of editing it in place** — make targeted edits to the pulled file (change the one node/logic you need). Do NOT rewrite every node from scratch: that drops the existing `x`/`y` (the `x:0,y:0` authoring habit is for *brand-new* nodes only), and a scheme where every node is at `0,0` forces `push-process` to re-lay-out the entire process, discarding its arrangement. push re-hydrates coordinates from the server as a safety net, but editing surgically is the right habit.
 - Using `"type": "call_process"` instead of `"type": "api_rpc"` — will fail validation
 - Missing `extra`/`extra_type` in Call a Process node — both required even if empty (`{}`)
 - Raw JSON objects as values in `extra` — must be stringified: `"{\"key\":\"val\"}"`


### PR DESCRIPTION
## Problem
`push-process` could destroy a hand-arranged layout. On push, `fixStruct`→`applyLayout` re-lays-out the whole scheme when **every** node is unplaced (`x==0 && y==0`), and re-places any single unplaced node otherwise. So an edit that dropped node coordinates — e.g. a scheme rebuilt without `x`/`y`, a habit the create skill's `x:0,y:0` authoring can bleed into edits — silently wiped a nice arrangement. Worse, the from-scratch path used a lean grid (`baseLayout`) that reads worse than the `layout-process` engine, so the re-arrangement also looked cramped.

Coordinates round-trip through `pull` fine (verified), so the loss is on the write side; the fix makes push resilient to it and closes the quality gap.

## What this does
- **Coordinate re-hydration** (`coords.go`): before layout, if the process exists on the server and any node arrives unplaced, refill the lost `x`/`y` from the process's current server scheme — matched by node title, or `obj_type`+ordinal for untitled nodes (Start/error finals). Handles full **and partial** loss; only genuinely-new nodes (absent on the server) stay unplaced and get placed normally. Reports `Restored N node coordinate(s)`.
- **Nicer default**: a from-scratch process is now laid out by the full `computeLayout` engine (waterfall / layered+error-rail / regions) instead of the lean `baseLayout` grid — the "place-new-nodes push hook" seam the engine was written for.
- **Smooth expansion**: inserting a node directly above its own placed down-child slides that child's downstream subtree down one row to open an in-style gap, instead of nudging the new node far below.
- **Skill guard** (`corezoid-edit`): edit the pulled scheme in place; never regenerate it without `x`/`y` (the `x:0,y:0` habit is for brand-new nodes only).

## Design notes (deliberate consequences)
- **An extra `ExportProcess` runs only when a node arrives unplaced** (a coordinate was lost, or a node was added) — never on a normal edit where all coordinates are intact. Correctness (never destroy a layout) is worth one download on those pushes.
- **Preserve mode still never moves a node you didn't touch**; the one intentional exception is the mid-insert subtree shift above, which moves only the new node's *own* downstream descendants (parallel/unrelated nodes stay put) to open the gap — an explicit "expand", not a re-arrange.
- **`baseLayout` is kept as a defensive fallback** (used if the engine ever returns no coordinates); it is no longer the primary from-scratch path.
- Re-hydrate matches by title / `obj_type`+ordinal and **skips ambiguous (duplicate-title) keys**, so a wrong match can never move a node.

## Testing
- Unit (`coords_test.go`, `layout_test.go`): re-hydrate by-title, untitled-ordinal, **partial loss**, never-overwrite-placed, ambiguous-skip, server-unplaced; engine default invariants; mid-insert subtree shift; parallel branch untouched; existing preserve invariants still green. `go build` / `vet` / `go test -race ./...` clean.
- Live E2E on the sandbox: `layout-process` arrange → push → pull (baseline); zero **all** coordinates → push reports `Restored 5`, coordinates identical to baseline (not mangled); zero **2** → `Restored 2`, preserved; add a node mid-process → existing nodes preserved exactly, new node placed with no overlap; fresh from-scratch push → engine layout (collapse flags set, not the lean grid). Artifacts cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)