### PR TITLE
fix: widen node x/y coordinate bounds in schema validation

### DIFF
--- a/plugins/corezoid/mcp-server/json-schema/node.json
+++ b/plugins/corezoid/mcp-server/json-schema/node.json
@@ -28,14 +28,14 @@
     },
     "x": {
       "type": "integer",
-      "minimum": -10000,
-      "maximum": 10000,
+      "minimum": -100000,
+      "maximum": 100000,
       "description": "X coordinate on canvas"
     },
     "y": {
       "type": "integer",
-      "minimum": -10000,
-      "maximum": 10000,
+      "minimum": -100000,
+      "maximum": 100000,
       "description": "Y coordinate on canvas"
     },
     "extra": {


### PR DESCRIPTION
## Problem

The `node.json` JSON schema used by `push-process`/`lint-process` capped node `x`/`y` coordinates at ±10000. Real-world processes that grow large over time (observed: a 760-node process) legitimately end up with nodes laid out well beyond that range (seen up to ~25500 / -10920 in one process).

This causes `push-process` to fail with a JSON schema validation error for such processes, even when called with `force: true` — the schema validation step runs before the lint-based blocking-issue override, so `force` cannot bypass it. In practice this means any legitimate edit (even an unrelated 5px nudge of a single node) to an existing large/sprawling process becomes undeployable.

## Fix

Widen the `x`/`y` bounds in `plugins/corezoid/mcp-server/json-schema/node.json` from ±10000 to ±100000, keeping a sanity bound in place while accommodating existing large processes.

## Test plan

- [x] Reproduced the failure against a real 760-node process with out-of-range `y` values; `push-process` failed pre-fix with the schema validation error shown above.
- [x] Applied the fix, reconnected the MCP server (recompiles via `go run .`), and re-ran `push-process` against the same process — deploy succeeded (schema validation passed; only pre-existing non-blocking lint advisories remained).
