### PR TITLE
fix(run-sh): surface actionable error when asset download fails

### DIFF
--- a/plugins/corezoid/mcp-server/run.sh
+++ b/plugins/corezoid/mcp-server/run.sh
@@ -66,9 +66,12 @@ if [ -n "$VERSION" ] && { [ "$OS" = "darwin" ] || [ "$OS" = "linux" ]; } && \
         mv "$TMP_SUMS" "${CACHE_DIR}/checksums.txt"
       else
         rm -f "$TMP_BIN" "$TMP_SUMS"
+        echo "corezoid-mcp: warning: checksum mismatch for convctl v${VERSION} (${OS}-${ARCH}) — ignoring download" >&2
       fi
     else
       rm -f "$TMP_BIN" "$TMP_SUMS" 2>/dev/null
+      echo "corezoid-mcp: warning: no prebuilt binary found for v${VERSION} (${OS}-${ARCH})" >&2
+      echo "  Check that a GitHub release exists: https://github.com/corezoid/corezoid-ai-plugin/releases/tag/v${VERSION}" >&2
     fi
   fi
 
@@ -78,4 +81,10 @@ if [ -n "$VERSION" ] && { [ "$OS" = "darwin" ] || [ "$OS" = "linux" ]; } && \
 fi
 
 # Fallback: compile from source (requires Go)
+if ! command -v go >/dev/null 2>&1; then
+  echo "corezoid-mcp: error: no prebuilt binary for v${VERSION} on ${OS}-${ARCH} and 'go' was not found." >&2
+  echo "  → Update the plugin to the latest release: https://github.com/corezoid/corezoid-ai-plugin/releases/latest" >&2
+  echo "  → Or install Go to build from source: https://go.dev/dl/" >&2
+  exit 1
+fi
 cd "$SCRIPT_DIR" && exec go run . "$@"


### PR DESCRIPTION
## Summary
- `run.sh` now prints a warning to stderr when the prebuilt `convctl` binary cannot be downloaded (404 / network error), including the exact version attempted and a direct link to the GitHub release tag to help diagnose whether the release asset was ever published
- Checksum mismatch also surfaces a warning instead of silently discarding the download
- Before falling back to `go run .`, the script now checks whether `go` is on PATH; if it is not, it exits with a clear error message listing two actionable recovery paths: upgrade the plugin to a released version, or install Go

## Context
tool: mcp-server/run.sh | version: 2.3.5 | install: fa93e3b1-819c-4488-b91e-d91cc041fd91

Reported scenario: plugin v2.8.4 was installed in Codex; `run.sh` tried to download `convctl-darwin-amd64` from the v2.8.4 release (which had no uploaded assets), got HTTP 404, silently fell through to `go run .`, and then failed with the unhelpful `exec: go: not found`. Upgrading to v2.9.0 fixed it because that release has published binaries.

## Checklist
- [x] No version bump / CHANGELOG.md change included
- [x] No manifest files modified
- [x] No hardcoded credentials or private URLs
- [x] Shell-only change — no Go build required

## Test plan
- Simulate missing asset: set `VERSION` to a non-existent tag in a shell session; run `sh run.sh --help` — should print the new warning and the release URL, then attempt `go run .`
- Simulate missing asset + no Go: same setup with `PATH` stripped of `go`; should print the error block and exit 1 (no `exec: go: not found` noise)
- Happy path (current v2.9.0): binary downloads and verifies correctly — no new output
