### PR TITLE
fix(lint-process): block api_rpc_reply mismatches before push

### DIFF
--- a/plugins/corezoid/mcp-server/mcp_handlers_process.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_process.go
@@ -209,7 +209,8 @@ func handlePushProcess(ctx context.Context, args map[string]interface{}) (string
 	if lintRes, lintErr := lintProcess(filePath); lintErr == nil {
 		hard := len(lintRes.BrokenLinks) + len(lintRes.OldFormatNodes) +
 			len(lintRes.MissingDefaultGo) + len(lintRes.ShortTimers) +
-			len(lintRes.LiteralReplyValues) + len(lintRes.UnrepliedTerminals)
+			len(lintRes.RpcReplyMismatches) + len(lintRes.LiteralReplyValues) +
+			len(lintRes.UnrepliedTerminals)
 		advisory := len(lintRes.NoopConditions) + len(lintRes.UnusedSetParams) +
 			len(lintRes.OrphanedNodes) + len(lintRes.PassthroughEscalations) +
 			len(lintRes.SharedErrorClusters)

--- a/plugins/corezoid/mcp-server/mcp_handlers_test.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -43,7 +44,7 @@ func TestHandleToolCall_LintProcess_MissingArg(t *testing.T) {
 	// No process_path arg and no .conv.json in current dir.
 	dir := t.TempDir()
 	orig, _ := os.Getwd()
-	os.Chdir(dir) //nolint:errcheck
+	os.Chdir(dir)                        //nolint:errcheck
 	t.Cleanup(func() { os.Chdir(orig) }) //nolint:errcheck
 
 	result, isErr := handleToolCall(context.Background(), "lint-process", map[string]interface{}{})
@@ -98,6 +99,43 @@ func TestHandleToolCall_PushProcess_BadFilename(t *testing.T) {
 		t.Error("expected isError=true for filename without ID prefix")
 	}
 	_ = result
+}
+
+func TestHandlePushProcess_BlocksRpcReplyMismatch(t *testing.T) {
+	resetGlobals(t)
+
+	sample, err := os.ReadFile(filepath.Join("samples", "api_rpc_reply_mismatch.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	p := filepath.Join(dir, "123_rpc_reply_mismatch.conv.json")
+	if err := os.WriteFile(p, sample, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(orig) }) //nolint:errcheck
+
+	result, isErr := handlePushProcess(context.Background(), map[string]interface{}{
+		"process_path": filepath.Base(p),
+	})
+	if !isErr {
+		t.Fatalf("expected push-process to block RpcReplyMismatches, got success: %q", result)
+	}
+	for _, want := range []string{
+		"Push blocked: lint found",
+		"API_RPC_REPLY MISMATCHES",
+		`res_data key "status" has no matching res_data_type entry`,
+	} {
+		if !strings.Contains(result, want) {
+			t.Fatalf("expected result to contain %q, got:\n%s", want, result)
+		}
+	}
 }
 
 // ---- pull-process ----------------------------------------------------------

--- a/plugins/corezoid/mcp-server/samples/api_rpc_reply_mismatch.json
+++ b/plugins/corezoid/mcp-server/samples/api_rpc_reply_mismatch.json
@@ -1,8 +1,11 @@
 {
+  "conv_type": "process",
+  "description": "Lint fixture: api_rpc_reply has res_data without matching res_data_type.",
   "obj_type": 1,
   "obj_id": 0,
   "title": "RPC Reply Mismatch Process",
   "params": [],
+  "ref_mask": true,
   "scheme": {
     "nodes": [
       {
@@ -15,6 +18,7 @@
           "semaphors": []
         },
         "title": "Start",
+        "description": "",
         "x": 0, "y": 0,
         "extra": "{\"modeForm\":\"collapse\",\"icon\":\"\"}",
         "options": null
@@ -41,6 +45,7 @@
           "semaphors": []
         },
         "title": "Reply Node",
+        "description": "",
         "x": 300, "y": 0,
         "extra": "{\"modeForm\":\"expand\",\"icon\":\"\"}",
         "options": null
@@ -53,10 +58,17 @@
           "semaphors": []
         },
         "title": "Final",
+        "description": "",
         "x": 600, "y": 0,
         "extra": "{\"modeForm\":\"collapse\",\"icon\":\"success\"}",
         "options": null
       }
+    ],
+    "web_settings": [
+      [],
+      []
     ]
-  }
+  },
+  "status": "active",
+  "uuid": "4395ca9a-6041-43a3-b1fe-8cda363a6d9a"
 }


### PR DESCRIPTION
## Summary
- Rework the PR on top of current `main` to avoid duplicating the already-merged `RpcReplyMismatches` lint implementation.
- Promote existing `lintRes.RpcReplyMismatches` into the `push-process` hard lint gate, so a process with untyped `api_rpc_reply` data is blocked before deploy.
- Keep the existing broader lint coverage from `findRpcReplyMismatches`: `res_data` ↔ `res_data_type`, `extra` ↔ `extra_type`, and unused type keys in the existing report section.
- Make the existing `api_rpc_reply_mismatch` fixture schema-valid for `push-process`, then add a handler regression test that verifies `push-process` returns `Push blocked` with the existing `API_RPC_REPLY MISMATCHES` section.

## Context
The original version of this PR added a parallel `ResDataTypeMismatch` lint class. Current `main` already has the broader check from `61c5586` (`fix(lint-process): name untyped res_data keys in api_rpc_reply check`) via `findRpcReplyMismatches`.

The remaining bug was narrower: `lint-process` reported the mismatch, but `push-process` did not treat it as hard. That meant the plugin could still try to deploy a process shape that Corezoid rejects with the vague server error:

```text
invalid value res_data or res_data_type, or both
```

This revision keeps the single existing lint source of truth and only fixes the push gate.

## Checklist
- [x] No duplicate lint class or duplicate `FormatLintResult` section
- [x] No MCP tool, manifest, auth, or API behavior changes beyond the local pre-push gate
- [x] No version bump / CHANGELOG.md change included
- [x] No hardcoded credentials or environment-specific values
- [x] PR targets `main`

## Test plan
- `go test ./... -run 'TestHandlePushProcess_BlocksRpcReplyMismatch|TestLintProcess_RpcReplyMismatch|TestLintProcess_RpcReplyClean' -count=1`
- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `go test -race -coverprofile=coverage.out ./...`
- `go run . --version`