### PR TITLE
fix(lint-process): name untyped res_data keys in api_rpc_reply check

### DIFF
--- a/plugins/corezoid/mcp-server/lint.go
+++ b/plugins/corezoid/mcp-server/lint.go
@@ -4,19 +4,34 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 )
 
 // LintResult holds the combined lint output
 type LintResult struct {
-	ProcessTitle    string
-	NoopConditions  []NoopCondition
-	UnusedSetParams []UnusedSetParam
-	OrphanedNodes   []OrphanedNode
-	TotalNodes      int
-	ReachableCount  int
-	SchemaValid     bool
-	SchemaError     string
+	ProcessTitle       string
+	NoopConditions     []NoopCondition
+	UnusedSetParams    []UnusedSetParam
+	OrphanedNodes      []OrphanedNode
+	RpcReplyMismatches []RpcReplyMismatch
+	TotalNodes         int
+	ReachableCount     int
+	SchemaValid        bool
+	SchemaError        string
+}
+
+// RpcReplyMismatch records an api_rpc_reply node where res_data/res_data_type
+// (or extra/extra_type) keys do not align, which the server rejects at commit
+// time with the vague message "invalid value res_data or res_data_type, or both".
+type RpcReplyMismatch struct {
+	NodeID      string
+	NodeTitle   string
+	DataField   string   // "res_data" or "extra"
+	TypeField   string   // "res_data_type" or "extra_type"
+	UntypedKeys []string // data keys with no matching type entry → server rejects these
+	UnusedTypes []string // type keys with no matching data entry → suspicious but not a hard error
+	Issue       string
 }
 
 type NoopCondition struct {
@@ -98,6 +113,7 @@ func lintProcess(filePath string) (*LintResult, error) {
 	typed := parseProcessNodes(nodes)
 	result.NoopConditions, result.UnusedSetParams = findNoopNodes(typed)
 	result.OrphanedNodes, result.ReachableCount = findOrphanedNodes(typed)
+	result.RpcReplyMismatches = findRpcReplyMismatches(typed)
 
 	schemaErr := ValidateJSONSchema(filePath, debug)
 	if schemaErr != nil {
@@ -343,6 +359,15 @@ func FormatLintResult(result *LintResult) string {
 		}
 	}
 
+	if len(result.RpcReplyMismatches) > 0 {
+		hasIssues = true
+		sb.WriteString(fmt.Sprintf("\n=== API_RPC_REPLY MISMATCHES (%d) ===\n", len(result.RpcReplyMismatches)))
+		for _, m := range result.RpcReplyMismatches {
+			sb.WriteString(fmt.Sprintf("  [%s] %s\n", m.NodeID, m.NodeTitle))
+			sb.WriteString(fmt.Sprintf("  Issue: %s\n", m.Issue))
+		}
+	}
+
 	if !hasIssues {
 		sb.WriteString("\nNo issues found.")
 	} else {
@@ -350,11 +375,97 @@ func FormatLintResult(result *LintResult) string {
 		if !result.SchemaValid {
 			schemaIssues = 1
 		}
-		total := len(result.NoopConditions) + len(result.UnusedSetParams) + len(result.OrphanedNodes) + schemaIssues
+		total := len(result.NoopConditions) + len(result.UnusedSetParams) + len(result.OrphanedNodes) + len(result.RpcReplyMismatches) + schemaIssues
 		sb.WriteString(fmt.Sprintf("\nTotal issues: %d\n", total))
 	}
 
 	return sb.String()
+}
+
+// findRpcReplyMismatches scans every api_rpc_reply logic in all nodes and
+// reports cases where data and type dictionaries do not align.  The server
+// enforces this alignment at commit time but only returns the generic message
+// "invalid value res_data or res_data_type, or both", making it hard to pinpoint
+// the offending key.  By catching the mismatch client-side we can name the exact
+// key so the author can fix it in one pass.
+func findRpcReplyMismatches(nodes []processNode) []RpcReplyMismatch {
+	var mismatches []RpcReplyMismatch
+	for _, n := range nodes {
+		for _, lg := range n.logics {
+			if t, _ := lg["type"].(string); t != "api_rpc_reply" {
+				continue
+			}
+			if m := checkDataTypeAlignment(n, lg, "res_data", "res_data_type"); m != nil {
+				mismatches = append(mismatches, *m)
+			}
+			if m := checkDataTypeAlignment(n, lg, "extra", "extra_type"); m != nil {
+				mismatches = append(mismatches, *m)
+			}
+		}
+	}
+	return mismatches
+}
+
+// checkDataTypeAlignment compares the keys of a data field (res_data or extra)
+// against the keys of its type companion (res_data_type or extra_type) in one
+// api_rpc_reply logic block.  Returns a mismatch descriptor when the sets differ,
+// or nil when they are consistent (including when neither field is present).
+func checkDataTypeAlignment(n processNode, lg map[string]interface{}, dataField, typeField string) *RpcReplyMismatch {
+	data, hasData := lg[dataField].(map[string]interface{})
+	typ, hasType := lg[typeField].(map[string]interface{})
+
+	if !hasData && !hasType {
+		return nil
+	}
+	if !hasData {
+		data = map[string]interface{}{}
+	}
+	if !hasType {
+		typ = map[string]interface{}{}
+	}
+
+	var untypedKeys []string
+	for k := range data {
+		if _, ok := typ[k]; !ok {
+			untypedKeys = append(untypedKeys, k)
+		}
+	}
+	sort.Strings(untypedKeys)
+
+	var unusedTypes []string
+	for k := range typ {
+		if _, ok := data[k]; !ok {
+			unusedTypes = append(unusedTypes, k)
+		}
+	}
+	sort.Strings(unusedTypes)
+
+	if len(untypedKeys) == 0 && len(unusedTypes) == 0 {
+		return nil
+	}
+
+	displayTitle := n.title
+	if displayTitle == "" {
+		displayTitle = "(untitled)"
+	}
+
+	var parts []string
+	for _, k := range untypedKeys {
+		parts = append(parts, fmt.Sprintf("%s key %q has no matching %s entry", dataField, k, typeField))
+	}
+	for _, k := range unusedTypes {
+		parts = append(parts, fmt.Sprintf("%s key %q has no matching %s entry", typeField, k, dataField))
+	}
+
+	return &RpcReplyMismatch{
+		NodeID:      n.id,
+		NodeTitle:   displayTitle,
+		DataField:   dataField,
+		TypeField:   typeField,
+		UntypedKeys: untypedKeys,
+		UnusedTypes: unusedTypes,
+		Issue:       strings.Join(parts, "; "),
+	}
 }
 
 // toMapSlice safely converts an interface{} to []map[string]interface{}

--- a/plugins/corezoid/mcp-server/lint_test.go
+++ b/plugins/corezoid/mcp-server/lint_test.go
@@ -104,6 +104,58 @@ func TestLintProcess_EmptyNodes(t *testing.T) {
 	}
 }
 
+// TestLintProcess_RpcReplyMismatch verifies that api_rpc_reply nodes with
+// res_data keys that have no matching res_data_type entry are reported with
+// the exact key name so the author can fix it in one pass.
+func TestLintProcess_RpcReplyMismatch(t *testing.T) {
+	result, err := lintProcess("samples/api_rpc_reply_mismatch.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.RpcReplyMismatches) == 0 {
+		t.Fatal("expected at least one RpcReplyMismatch, got none")
+	}
+	m := result.RpcReplyMismatches[0]
+	if m.NodeTitle != "Reply Node" {
+		t.Errorf("expected node title 'Reply Node', got %q", m.NodeTitle)
+	}
+	if m.DataField != "res_data" || m.TypeField != "res_data_type" {
+		t.Errorf("unexpected field names: DataField=%q TypeField=%q", m.DataField, m.TypeField)
+	}
+	if !sliceContains(m.UntypedKeys, "status") {
+		t.Errorf("expected untyped key 'status', got UntypedKeys=%v", m.UntypedKeys)
+	}
+	if sliceContains(m.UntypedKeys, "result") {
+		t.Errorf("'result' has a type entry and must not appear in UntypedKeys; got %v", m.UntypedKeys)
+	}
+	if !strings.Contains(m.Issue, `"status"`) {
+		t.Errorf("Issue message must name the offending key, got: %q", m.Issue)
+	}
+}
+
+// TestLintProcess_RpcReplyClean verifies that a well-aligned api_rpc_reply
+// node produces no RpcReplyMismatch entries.
+func TestLintProcess_RpcReplyClean(t *testing.T) {
+	result, err := lintProcess("samples/multi_action_logics.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.RpcReplyMismatches) != 0 {
+		t.Errorf("expected 0 RpcReplyMismatches for aligned node, got %d: %+v",
+			len(result.RpcReplyMismatches), result.RpcReplyMismatches)
+	}
+}
+
+// sliceContains reports whether target appears in ss.
+func sliceContains(ss []string, target string) bool {
+	for _, s := range ss {
+		if s == target {
+			return true
+		}
+	}
+	return false
+}
+
 // TestFormatLintResult_Golden compares FormatLintResult output against a golden file.
 // Run with -update to regenerate golden files.
 func TestFormatLintResult_Golden(t *testing.T) {

--- a/plugins/corezoid/mcp-server/samples/api_rpc_reply_mismatch.json
+++ b/plugins/corezoid/mcp-server/samples/api_rpc_reply_mismatch.json
@@ -1,0 +1,62 @@
+{
+  "obj_type": 1,
+  "obj_id": 0,
+  "title": "RPC Reply Mismatch Process",
+  "params": [],
+  "scheme": {
+    "nodes": [
+      {
+        "id": "aabbccddeeff001122330001",
+        "obj_type": 1,
+        "condition": {
+          "logics": [
+            {"type": "go", "to_node_id": "aabbccddeeff001122330002"}
+          ],
+          "semaphors": []
+        },
+        "title": "Start",
+        "x": 0, "y": 0,
+        "extra": "{\"modeForm\":\"collapse\",\"icon\":\"\"}",
+        "options": null
+      },
+      {
+        "id": "aabbccddeeff001122330002",
+        "obj_type": 0,
+        "condition": {
+          "logics": [
+            {
+              "type": "api_rpc_reply",
+              "mode": "key_value",
+              "res_data": {
+                "result": "{{data.result}}",
+                "status": "success"
+              },
+              "res_data_type": {
+                "result": "string"
+              },
+              "throw_exception": false
+            },
+            {"type": "go", "to_node_id": "aabbccddeeff001122330003"}
+          ],
+          "semaphors": []
+        },
+        "title": "Reply Node",
+        "x": 300, "y": 0,
+        "extra": "{\"modeForm\":\"expand\",\"icon\":\"\"}",
+        "options": null
+      },
+      {
+        "id": "aabbccddeeff001122330003",
+        "obj_type": 2,
+        "condition": {
+          "logics": [],
+          "semaphors": []
+        },
+        "title": "Final",
+        "x": 600, "y": 0,
+        "extra": "{\"modeForm\":\"collapse\",\"icon\":\"success\"}",
+        "options": null
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- `lint-process` now detects `api_rpc_reply` nodes where a `res_data` key has no matching `res_data_type` entry (and vice-versa for `extra`/`extra_type`)
- The error message names the exact offending key, e.g. `res_data key "status" has no matching res_data_type entry`, replacing the server's vague `"invalid value res_data or res_data_type, or both"`
- Covers all four variants: template value `{{...}}`, literal string, `mode:"key_value"`, and `mode:""`

## Context
tool: push-process / lint-process | version: 2.3.5 | install: a59a02de-521c-42ba-bbf8-5ab2bc5f5670

## Changes
- **`lint.go`**: Added `RpcReplyMismatch` struct and `RpcReplyMismatches []RpcReplyMismatch` field on `LintResult`; added `findRpcReplyMismatches()` and `checkDataTypeAlignment()` helpers; wired into `lintProcess()` and `FormatLintResult()`
- **`lint_test.go`**: Added `TestLintProcess_RpcReplyMismatch` (expects mismatch on `"status"`) and `TestLintProcess_RpcReplyClean` (expects no mismatch on aligned node)
- **`samples/api_rpc_reply_mismatch.json`**: New fixture — `res_data` has `result` (typed) and `status` (untyped), matching the exact pattern from the bug report

## Checklist
- [x] `go build` passes
- [x] `go vet` passes
- [x] All lint tests pass (`TestLintProcess_*`, `TestFormatLintResult_*`)
- [x] Pre-existing `TestSkillPathsExist` failure confirmed on `develop` before this PR (unrelated missing doc file)
- [x] No version bump / CHANGELOG.md change included
- [x] No credentials or private URLs

## Test plan
- Run `go test -run TestLintProcess_RpcReply -v` — both new tests pass
- Push a process with `res_data:{"result":"{{v}}","status":"ok"}` and `res_data_type:{"result":"string"}` — lint now reports: `res_data key "status" has no matching res_data_type entry`
- Push a process with aligned keys — lint reports no mismatch