### PR TITLE
fix(pull-process): sanitize path-illegal chars in filenames

### DIFF
--- a/plugins/corezoid/mcp-server/executor_folders.go
+++ b/plugins/corezoid/mcp-server/executor_folders.go
@@ -252,7 +252,7 @@ func (v *Executor) resolveFolderPathFromAPI(folderID int) (string, error) {
 		if info.ObjType == 3 || (v.StageID != 0 && info.ObjID == v.StageID) {
 			break
 		}
-		safeName := strings.ReplaceAll(info.Title, " ", "_")
+		safeName := sanitizeFileSegment(info.Title)
 		segments = append(segments, segment{id: info.ObjID, title: safeName})
 		if info.ParentObjID == 0 || info.ParentObjID == currentID {
 			break

--- a/plugins/corezoid/mcp-server/mcp_handlers_process.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_process.go
@@ -18,6 +18,27 @@ import (
 // handlers that resolve a process ID from a file path.
 var reProcessIDFromFilename = regexp.MustCompile(`^(\d+)_`)
 
+// sanitizeFileSegment converts a raw Corezoid title into a safe filename or
+// directory-name segment. It replaces spaces AND every character that is either
+// a path separator on any supported OS or illegal in Windows filenames with an
+// underscore. This means a title like "/chat_v2" becomes "_chat_v2", which
+// matches the server-side naming that pull-folder already produces.
+//
+// Characters replaced: space  /  \  :  *  ?  "  <  >  |
+func sanitizeFileSegment(title string) string {
+	const illegal = ` /\:*?"<>|`
+	var b strings.Builder
+	b.Grow(len(title))
+	for _, r := range title {
+		if strings.ContainsRune(illegal, r) {
+			b.WriteByte('_')
+		} else {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
 // extractProcessIDFromPath returns the numeric process ID encoded in the
 // filename, or an error message describing the expected format.
 func extractProcessIDFromPath(filePath string) (int, string) {
@@ -58,7 +79,7 @@ func handlePullProcess(ctx context.Context, args map[string]interface{}) (string
 	fileName := fmt.Sprintf("%d.conv.json", processID)
 	if m, ok := procInfo.(map[string]interface{}); ok {
 		if title, _ := m["title"].(string); title != "" {
-			safeName := strings.ReplaceAll(title, " ", "_")
+			safeName := sanitizeFileSegment(title)
 			fileName = fmt.Sprintf("%d_%s.conv.json", processID, safeName)
 		}
 	}
@@ -481,7 +502,7 @@ func createConv(ctx context.Context, args map[string]interface{}, convType strin
 		return fmt.Sprintf("Error marshaling process: %v", err), true
 	}
 
-	safeName := strings.ReplaceAll(processName, " ", "_")
+	safeName := sanitizeFileSegment(processName)
 	fileName := fmt.Sprintf("%d_%s.json", processID, safeName)
 	filePath := filepath.Join(folderPath, fileName)
 	if err := os.WriteFile(filePath, data, 0644); err != nil {
@@ -516,7 +537,7 @@ func handleCreateFolder(ctx context.Context, args map[string]interface{}) (strin
 		return fmt.Sprintf("Error creating folder '%s': %v", folderName, err), true
 	}
 
-	safeName := strings.ReplaceAll(folderName, " ", "_")
+	safeName := sanitizeFileSegment(folderName)
 	dirName := fmt.Sprintf("%d_%s", newFolderID, safeName)
 	dirPath := filepath.Join(parentPath, dirName)
 	if err := os.MkdirAll(dirPath, 0755); err != nil {


### PR DESCRIPTION
## Summary

- Added `sanitizeFileSegment()` helper that replaces spaces **and** path-illegal characters (`/`, `\`, `:`, `*`, `?`, `"`, `<`, `>`, `|`) with `_`
- Replaced the space-only `strings.ReplaceAll(title, " ", "_")` sanitizer with the new helper in all four affected call sites:
  - `handlePullProcess` — process title → `.conv.json` filename
  - `createConv` (backing `create-process`) — process name → `.json` filename
  - `handleCreateFolder` — folder name → directory and `.folder.json` filename
  - `resolveFolderPathFromAPI` in `executor_folders.go` — parent folder titles used as directory path segments during `pull-process`

Before this fix, a title like `/chat_v2` caused `open ...10552_\chat_v2.conv.json: The system cannot find the path specified` because the `/` was treated as a path separator, creating a phantom subdirectory. After this fix, `/chat_v2` → `_chat_v2`, producing `10552__chat_v2.conv.json` — matching what `pull-folder` (server-side sanitized) already outputs.

## Context

tool: pull-process (also create-process, create-folder) | version: 2.3.5 | install: ce85b612-663c-46df-a59c-e8ccaddb917a

Affected process IDs reported: 10552 (`/chat_v2`), 23998 (`/auth`), 27734 (`/las_menu`).

## Checklist

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (53s, all ok)
- [x] No version bump / CHANGELOG.md change included
- [x] No credentials or private URLs added

## Test plan

- Pull process 10552 (title `/chat_v2`) — expect file written as `10552__chat_v2.conv.json`
- Pull process 23998 (title `/auth`) — expect `23998__auth.conv.json`
- `create-process` with name `/las_menu` — expect `<id>__las_menu.json`
- `create-folder` with name `/handlers` — expect directory `<id>__handlers/`