### PR TITLE
fix(login): add prompt=login and validate token expiry on fresh OAuth grants

### DIFF
--- a/plugins/corezoid/mcp-server/mcp_handlers_auth.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_auth.go
@@ -511,6 +511,10 @@ func handleLogout(_ context.Context, _ map[string]interface{}) (string, bool) {
 	if err != nil {
 		credPath = "~/.corezoid/credentials"
 	}
+
+	// Snapshot accountURL before clearing so we can include the browser-logout hint.
+	_, _, _, snapAccountURL, _ := authSnapshot()
+
 	if err := deleteCredentials(); err != nil {
 		return fmt.Sprintf("Failed to remove credentials: %v", err), true
 	}
@@ -533,5 +537,16 @@ func handleLogout(_ context.Context, _ map[string]interface{}) (string, bool) {
 		apiLogin = ""
 		apiSecret = ""
 	})
-	return fmt.Sprintf("Logged out. ACCESS_TOKEN removed from %s.", credPath), false
+
+	browserHost := strings.TrimRight(snapAccountURL, "/")
+	if browserHost == "" {
+		browserHost = "https://account.corezoid.com"
+	}
+
+	return fmt.Sprintf(
+		"Logged out. ACCESS_TOKEN removed from %s.\n\n"+
+			"Important: your browser may still have an active SSO session at %s. "+
+			"If a subsequent login produces an already-expired token (\"exp\" in the past), "+
+			"you must also log out of that site in your browser before calling login again.",
+		credPath, browserHost), false
 }

--- a/plugins/corezoid/mcp-server/oauth.go
+++ b/plugins/corezoid/mcp-server/oauth.go
@@ -99,6 +99,11 @@ func oauthPKCEFlow(accountURL, clientID string) (*PKCEResult, error) {
 		"code_challenge":        {challenge},
 		"code_challenge_method": {"S256"},
 		"state":                 {state},
+		// prompt=login forces the authorization server to re-authenticate the user
+		// rather than silently reusing a stale browser SSO session whose token may
+		// already be expired.  Without this, repeated logout+login cycles can issue
+		// tokens pinned to a dead session's expiry (exp < now on arrival).
+		"prompt": {"login"},
 	}
 	authorizeURL := accountURL + "/oauth2/authorize"
 	tokenURL := accountURL + "/oauth2/token"
@@ -220,10 +225,39 @@ func oauthPKCEFlow(accountURL, clientID string) (*PKCEResult, error) {
 		return nil, fmt.Errorf("no token in OAuth response: %s", string(body))
 	}
 
+	expiry := parseJWTExpiry(accessToken)
+	if err := checkTokenExpiry(expiry, accountURL); err != nil {
+		return nil, err
+	}
+
 	return &PKCEResult{
 		AccessToken: accessToken,
-		ExpiresAt:   parseJWTExpiry(accessToken),
+		ExpiresAt:   expiry,
 	}, nil
+}
+
+// checkTokenExpiry returns a descriptive error when a freshly issued token is
+// already expired.  This happens when the browser silently reused a stale SSO
+// session: account.corezoid.com mints a new access token whose exp is pinned
+// to the dead session's original expiry (in the past), so exp < iat on arrival.
+// The plugin must not silently accept such a token — it will be rejected by
+// every downstream API.
+func checkTokenExpiry(expiry time.Time, accountURL string) error {
+	if expiry.IsZero() {
+		// Cannot determine expiry — optimistically allow and let the API reject.
+		return nil
+	}
+	if expiry.After(time.Now()) {
+		return nil
+	}
+	return fmt.Errorf(
+		"the access token just issued is already expired (exp=%s, now=%s UTC). "+
+			"This usually means the browser reused a stale SSO session. "+
+			"Please log out of %s in your browser, then call login again.",
+		expiry.UTC().Format("2006-01-02T15:04:05Z"),
+		time.Now().UTC().Format("2006-01-02T15:04:05Z"),
+		accountURL,
+	)
 }
 
 type accountClient struct {

--- a/plugins/corezoid/mcp-server/oauth_test.go
+++ b/plugins/corezoid/mcp-server/oauth_test.go
@@ -109,3 +109,52 @@ func TestOAuthPageHTML_Error(t *testing.T) {
 		t.Error("error page should contain error color")
 	}
 }
+
+func TestParseJWTExpiry_AlreadyExpired(t *testing.T) {
+	// Build a JWT whose exp is already in the past — simulates a token minted
+	// from a stale SSO session (the root cause of the reported login deadlock).
+	exp := time.Now().Add(-24 * time.Hour).Unix()
+	claims := map[string]interface{}{"exp": float64(exp)}
+	payload, _ := json.Marshal(claims)
+	encoded := base64.RawURLEncoding.EncodeToString(payload)
+	token := "header." + encoded + ".sig"
+
+	result := parseJWTExpiry(token)
+	if result.IsZero() {
+		t.Fatal("expected non-zero time for an expired JWT")
+	}
+	if !result.Before(time.Now()) {
+		t.Errorf("expected expiry in the past, got %v", result)
+	}
+}
+
+func TestCheckTokenExpiry_Future(t *testing.T) {
+	// A token with exp in the future — must not return an error.
+	expiry := time.Now().Add(time.Hour)
+	if err := checkTokenExpiry(expiry, "https://account.corezoid.com"); err != nil {
+		t.Errorf("unexpected error for future expiry: %v", err)
+	}
+}
+
+func TestCheckTokenExpiry_Past(t *testing.T) {
+	// A token with exp already in the past — must return an error containing
+	// the account URL so the user knows where to log out.
+	expiry := time.Now().Add(-time.Hour)
+	err := checkTokenExpiry(expiry, "https://account.corezoid.com")
+	if err == nil {
+		t.Fatal("expected error for already-expired token, got nil")
+	}
+	if !strings.Contains(err.Error(), "account.corezoid.com") {
+		t.Errorf("error should mention account URL, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "already expired") {
+		t.Errorf("error should mention 'already expired', got: %v", err)
+	}
+}
+
+func TestCheckTokenExpiry_Zero(t *testing.T) {
+	// Zero expiry means we could not parse it — should be allowed through.
+	if err := checkTokenExpiry(time.Time{}, "https://account.corezoid.com"); err != nil {
+		t.Errorf("zero expiry should not produce an error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- **`prompt=login` in authorize URL** — the `/oauth2/authorize` request now always includes `prompt=login`, forcing the authorization server to require real re-authentication instead of silently reusing a stale browser SSO session. Without this, repeated logout+login cycles could produce tokens whose `exp` was pinned to a dead session's expiry (in the past).
- **Token expiry guard** — new `checkTokenExpiry()` called immediately after token exchange. If `exp ≤ now` on a brand-new token, the plugin returns a clear error message with the account URL so the user knows to log out in the browser — it no longer silently saves the unusable token and reports "Setup complete".
- **Logout browser hint** — `handleLogout()` now appends a note explaining that the plugin only clears the local credential file and that the browser SSO session at the account site must also be cleared for a clean re-login.
- **Unit tests** — `TestParseJWTExpiry_AlreadyExpired`, `TestCheckTokenExpiry_Future`, `TestCheckTokenExpiry_Past`, `TestCheckTokenExpiry_Zero` cover the new guard function and the already-expired JWT scenario.

## Context

tool: login / logout (OAuth2 PKCE flow, corezoid MCP server) | version: 2.3.5 | install: 7947e988-7a2d-497a-9cf8-40226af050da

Root cause: `account.corezoid.com` accepts the OAuth code grant without `prompt=login`, so it silently reused a browser SSO session created ~2026-07-15 (expiring 2026-07-18). Every new access token was minted with `exp=1784379251` (a past timestamp) while `iat` updated to the current time. The plugin did not validate expiry, so it stored and reported the token as valid — but all Corezoid API calls (`admin.corezoid.com/api/2/json`) rejected it with "cookie or headers are not valid". The deadlock only broke after the user manually logged out of `account.corezoid.com` in the browser.

## Checklist

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all 47 s)
- [x] No version bump / CHANGELOG.md change included
- [x] No hardcoded credentials or private URLs
- [x] Manifest JSON files validated

## Test plan

- [ ] With a stale browser SSO session (exp in past): call `login` — expect error message mentioning "already expired" and account URL, not "Setup complete"
- [ ] After clearing browser session: call `login` — expect fresh token with future exp and "Setup complete"
- [ ] Call `logout` — verify response includes browser SSO session hint
- [ ] Unit tests: `go test ./... -run TestCheckTokenExpiry` — all pass