### PR TITLE
fix(lint-process): flag under-specified api logic nodes before push

### DIFF
--- a/plugins/corezoid/docs/nodes/api-call-node.md
+++ b/plugins/corezoid/docs/nodes/api-call-node.md
@@ -237,10 +237,13 @@ The API Call node undergoes validation during process commit with these checks:
 4. If `err_node_id` is specified, it must reference a valid node
 5. `max_threads` must be a positive integer if specified
 
-> Note: schema validation only enforces `type`, `method`, `url`, and `err_node_id`. Omitting the
-> other canonical fields is **not** caught client-side and makes the deploy fail at commit
-> (`no response from server`) — see
-> [Required node shape](#required-node-shape-author-the-full-canonical-api-logic).
+`lint-process` enforces the canonical field set locally before any server
+round-trip. A node missing `extra`, `extra_type`, `format`, `send_sys`,
+`debug_info`, `customize_response`, `rfc_format`, `cert_pem`, or `version` is
+reported as an **UNDERSPECIFIED API CALL NODE** with the exact missing field
+names — turning the ~15–20 s server hang into an immediate, actionable message.
+Fields already enforced by JSON schema (`extra_headers`, `max_threads`) continue
+to be caught by schema validation.
 
 ## Best Practices
 

--- a/plugins/corezoid/mcp-server/lint.go
+++ b/plugins/corezoid/mcp-server/lint.go
@@ -11,22 +11,23 @@ import (
 
 // LintResult holds the combined lint output
 type LintResult struct {
-	ProcessTitle           string
-	NoopConditions         []NoopCondition
-	UnusedSetParams        []UnusedSetParam
-	OrphanedNodes          []OrphanedNode
-	PassthroughEscalations []PassthroughEscalation
-	LiteralReplyValues     []LiteralReplyValue
-	SharedErrorClusters    []SharedErrorCluster
-	OldFormatNodes         []OldFormatNode
-	UnrepliedTerminals     []UnrepliedTerminal
-	MissingDefaultGo       []MissingDefaultGo
-	ShortTimers            []ShortTimer
-	BrokenLinks            []BrokenLink
-	TotalNodes             int
-	ReachableCount         int
-	SchemaValid            bool
-	SchemaError            string
+	ProcessTitle            string
+	NoopConditions          []NoopCondition
+	UnusedSetParams         []UnusedSetParam
+	OrphanedNodes           []OrphanedNode
+	PassthroughEscalations  []PassthroughEscalation
+	LiteralReplyValues      []LiteralReplyValue
+	SharedErrorClusters     []SharedErrorCluster
+	OldFormatNodes          []OldFormatNode
+	UnrepliedTerminals      []UnrepliedTerminal
+	MissingDefaultGo        []MissingDefaultGo
+	ShortTimers             []ShortTimer
+	BrokenLinks             []BrokenLink
+	UnderspecifiedAPINodes  []UnderspecifiedAPINode
+	TotalNodes              int
+	ReachableCount          int
+	SchemaValid             bool
+	SchemaError             string
 }
 
 type NoopCondition struct {
@@ -83,6 +84,24 @@ type LiteralReplyValue struct {
 	Title  string
 	Fields []string
 	Issue  string
+}
+
+// UnderspecifiedAPINode is an api logic node that is missing one or more fields
+// from the full canonical set the Corezoid commit service requires. Such nodes
+// pass JSON schema validation and the lint-process tool cleanly, but the server
+// cannot commit an under-specified api logic: it stops responding, and after
+// ~15–20 s push-process fails with "Error deploying process: failed to commit
+// changes: no response from server" — with no indication of the node or field at
+// fault. This failure mode has been reproduced in multiple independent sessions.
+//
+// The canonical fields beyond the schema-required subset are listed in
+// apiCanonicalFields. Finding any of them absent surfaces an actionable error
+// before the slow server round-trip.
+type UnderspecifiedAPINode struct {
+	NodeID        string
+	NodeTitle     string
+	MissingFields []string
+	Issue         string
 }
 
 // OldFormatNode is a node the platform's "Convert process to new format" dialog
@@ -189,6 +208,7 @@ func lintProcess(filePath string) (*LintResult, error) {
 	result.MissingDefaultGo = findMissingDefaultGo(typed)
 	result.ShortTimers = findShortTimers(typed)
 	result.BrokenLinks = findBrokenLinks(typed)
+	result.UnderspecifiedAPINodes = findUnderspecifiedAPINodes(typed)
 
 	schemaErr := ValidateJSONSchema(filePath, debug)
 	if schemaErr != nil {
@@ -896,6 +916,64 @@ func findLiteralReplyValues(nodes []processNode) []LiteralReplyValue {
 	return result
 }
 
+// apiCanonicalFields is the set of api logic fields that the Corezoid commit
+// service requires beyond those already enforced by the JSON schema (type,
+// method, url, extra_headers, max_threads, err_node_id). A node carrying only
+// the schema-required subset is "under-specified": the server commit hangs for
+// ~15–20 s then returns the generic "no response from server" error with no
+// indication of which node or field caused it.
+//
+// These fields must be PRESENT (the key must exist); the value may be the
+// zero/default for the type (e.g. empty {}, false, "" or 0).
+var apiCanonicalFields = []string{
+	"extra",
+	"extra_type",
+	"format",
+	"send_sys",
+	"debug_info",
+	"customize_response",
+	"rfc_format",
+	"cert_pem",
+	"version",
+}
+
+// findUnderspecifiedAPINodes scans every node for api logics that are missing
+// one or more fields from the canonical server-required set. A node that passes
+// schema validation but lacks these fields causes the server commit to hang
+// without a descriptive error (see UnderspecifiedAPINode doc comment).
+func findUnderspecifiedAPINodes(nodes []processNode) []UnderspecifiedAPINode {
+	var result []UnderspecifiedAPINode
+	for _, n := range nodes {
+		for _, lg := range n.logics {
+			if t, _ := lg["type"].(string); t != "api" {
+				continue
+			}
+			var missing []string
+			for _, field := range apiCanonicalFields {
+				if _, ok := lg[field]; !ok {
+					missing = append(missing, field)
+				}
+			}
+			if len(missing) == 0 {
+				continue
+			}
+			displayTitle := n.title
+			if displayTitle == "" {
+				displayTitle = "(untitled)"
+			}
+			result = append(result, UnderspecifiedAPINode{
+				NodeID:        n.id,
+				NodeTitle:     displayTitle,
+				MissingFields: missing,
+				Issue: fmt.Sprintf(
+					"api logic is missing canonical fields [%s] — the server commit hangs ~15–20 s then fails with \"no response from server\" instead of a descriptive error. Add the missing fields (copy the GET example from docs/nodes/api-call-node.md as a template)",
+					strings.Join(missing, ", ")),
+			})
+		}
+	}
+	return result
+}
+
 // describeLiteral renders a res_data value for the lint message ([], {}, 0, true, null).
 func describeLiteral(v interface{}) string {
 	b, err := json.Marshal(v)
@@ -1106,6 +1184,16 @@ func FormatLintResult(result *LintResult) string {
 		}
 	}
 
+	if len(result.UnderspecifiedAPINodes) > 0 {
+		hasIssues = true
+		sb.WriteString(fmt.Sprintf("\n=== UNDERSPECIFIED API CALL NODES (%d) — server commit hangs then \"no response from server\" ===\n", len(result.UnderspecifiedAPINodes)))
+		for _, ua := range result.UnderspecifiedAPINodes {
+			sb.WriteString(fmt.Sprintf("  [%s] %s\n", ua.NodeID, ua.NodeTitle))
+			sb.WriteString(fmt.Sprintf("  Missing: %s\n", strings.Join(ua.MissingFields, ", ")))
+			sb.WriteString(fmt.Sprintf("  Issue: %s\n", ua.Issue))
+		}
+	}
+
 	if !hasIssues {
 		sb.WriteString("\nNo issues found.")
 	} else {
@@ -1113,7 +1201,7 @@ func FormatLintResult(result *LintResult) string {
 		if !result.SchemaValid {
 			schemaIssues = 1
 		}
-		total := len(result.NoopConditions) + len(result.UnusedSetParams) + len(result.OrphanedNodes) + len(result.PassthroughEscalations) + len(result.LiteralReplyValues) + len(result.SharedErrorClusters) + len(result.OldFormatNodes) + len(result.UnrepliedTerminals) + len(result.MissingDefaultGo) + len(result.ShortTimers) + len(result.BrokenLinks) + schemaIssues
+		total := len(result.NoopConditions) + len(result.UnusedSetParams) + len(result.OrphanedNodes) + len(result.PassthroughEscalations) + len(result.LiteralReplyValues) + len(result.SharedErrorClusters) + len(result.OldFormatNodes) + len(result.UnrepliedTerminals) + len(result.MissingDefaultGo) + len(result.ShortTimers) + len(result.BrokenLinks) + len(result.UnderspecifiedAPINodes) + schemaIssues
 		sb.WriteString(fmt.Sprintf("\nTotal issues: %d\n", total))
 	}
 

--- a/plugins/corezoid/mcp-server/lint_api_contract_test.go
+++ b/plugins/corezoid/mcp-server/lint_api_contract_test.go
@@ -104,3 +104,110 @@ func TestLintProcess_APIWithServerMandatoryFieldsPasses(t *testing.T) {
 		t.Errorf("expected no schema error, got:\n%s", result.SchemaError)
 	}
 }
+
+// TestLintProcess_APIUnderspecified_Caught verifies that an api logic carrying only
+// the schema-required fields (type, method, url, extra_headers, max_threads,
+// err_node_id) but missing the canonical extras is caught by
+// findUnderspecifiedAPINodes. This is the exact "light" node shape that passes
+// schema validation yet causes push-process to hang 15–20 s and fail with the
+// opaque "no response from server".
+func TestLintProcess_APIUnderspecified_Caught(t *testing.T) {
+	path := apiContractProcess(t, map[string]interface{}{
+		"extra_headers": map[string]interface{}{},
+		"max_threads":   5,
+		// deliberately omits: extra, extra_type, format, send_sys, debug_info,
+		// customize_response, rfc_format, cert_pem, version
+	})
+	result, err := lintProcess(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.UnderspecifiedAPINodes) == 0 {
+		t.Fatal("expected UnderspecifiedAPINodes finding, got none")
+	}
+	for _, field := range apiCanonicalFields {
+		found := false
+		for _, n := range result.UnderspecifiedAPINodes {
+			for _, mf := range n.MissingFields {
+				if mf == field {
+					found = true
+					break
+				}
+			}
+			if found {
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected canonical field %q to be reported as missing", field)
+		}
+	}
+}
+
+// TestLintProcess_APIFullCanonical_NoUnderspecified verifies that a node carrying
+// the full canonical field set is NOT flagged by findUnderspecifiedAPINodes.
+func TestLintProcess_APIFullCanonical_NoUnderspecified(t *testing.T) {
+	path := apiContractProcess(t, map[string]interface{}{
+		"extra_headers":      map[string]interface{}{},
+		"max_threads":        5,
+		"extra":              map[string]interface{}{},
+		"extra_type":         map[string]interface{}{},
+		"format":             "",
+		"send_sys":           true,
+		"debug_info":         false,
+		"customize_response": false,
+		"rfc_format":         true,
+		"cert_pem":           "",
+		"version":            2,
+	})
+	result, err := lintProcess(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.UnderspecifiedAPINodes) != 0 {
+		t.Errorf("expected no UnderspecifiedAPINodes, got %d: %+v",
+			len(result.UnderspecifiedAPINodes), result.UnderspecifiedAPINodes)
+	}
+}
+
+// TestLintProcess_APIPartialCanonical_ReportsOnlyMissing verifies that a node
+// carrying only some canonical fields is flagged for the ones it is actually
+// missing, not the ones it already has.
+func TestLintProcess_APIPartialCanonical_ReportsOnlyMissing(t *testing.T) {
+	path := apiContractProcess(t, map[string]interface{}{
+		"extra_headers": map[string]interface{}{},
+		"max_threads":   5,
+		"extra":         map[string]interface{}{},
+		"extra_type":    map[string]interface{}{},
+		// format, send_sys, debug_info, customize_response, rfc_format, cert_pem, version absent
+	})
+	result, err := lintProcess(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.UnderspecifiedAPINodes) == 0 {
+		t.Fatal("expected UnderspecifiedAPINodes finding, got none")
+	}
+	node := result.UnderspecifiedAPINodes[0]
+	// extra and extra_type are present — must NOT appear in MissingFields
+	for _, present := range []string{"extra", "extra_type"} {
+		for _, mf := range node.MissingFields {
+			if mf == present {
+				t.Errorf("field %q is present in the logic but appears in MissingFields", present)
+			}
+		}
+	}
+	// format, send_sys etc. are absent — must appear in MissingFields
+	for _, absent := range []string{"format", "send_sys", "debug_info", "customize_response", "rfc_format", "cert_pem", "version"} {
+		found := false
+		for _, mf := range node.MissingFields {
+			if mf == absent {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected absent field %q in MissingFields, not found; got: %v", absent, node.MissingFields)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `lint-process` now flags `api` logic nodes that carry only the schema-required fields but are missing the canonical server-required extras (`extra`, `extra_type`, `format`, `send_sys`, `debug_info`, `customize_response`, `rfc_format`, `cert_pem`, `version`).
- Missing fields are reported in a new **UNDERSPECIFIED API CALL NODES** section that names each missing field and explains the consequence — turning a dead-end server hang into an immediate, actionable lint message.
- The `api-call-node.md` Validation Rules section is updated to document that lint now enforces the full canonical field set.

## Context

tool: push-process / lint-process | version: 2.3.5 | install: 278022ea-2291-4146-ba5f-44f47fc26b41

An API Call node written with only the JSON schema-required fields (`type`, `method`, `url`, `err_node_id` — plus `extra_headers` and `max_threads` which were added to the schema) passes client-side validation and `lint-process` cleanly, but the Corezoid commit service cannot process the under-specified logic. It stops responding, and after ~15–20 s `push-process` fails with:

```
Error deploying process: failed to commit changes: no response from server
```

…with no indication of which node or field caused the failure. This exact failure mode was reproduced independently in two separate sessions/projects.

## Implementation

The fix follows the same pattern as `findLiteralReplyValues()` — introduced earlier to catch the identical "silent server hang" failure mode on `api_rpc_reply` nodes: a dedicated scan function checks every `api` logic against the canonical field list and surfaces missing fields before any server round-trip.

`apiCanonicalFields` is the complement to the JSON schema `required` list: it holds the fields that the server commit service requires but that the schema does not enforce.

## Checklist

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (full suite, 55 s)
- [x] JSON manifests valid (python3 -m json.tool)
- [x] No version bump / CHANGELOG.md change included
- [x] No credentials or private URLs introduced

## Test plan

- `TestLintProcess_APIUnderspecified_Caught` — node with only schema-required fields → all 9 canonical extras reported as missing
- `TestLintProcess_APIFullCanonical_NoUnderspecified` — node with complete canonical set → no finding
- `TestLintProcess_APIPartialCanonical_ReportsOnlyMissing` — node with some canonical fields → only truly absent ones flagged
- Existing `TestLintProcess_APIMissingServerMandatoryFields` and `TestLintProcess_APIWithServerMandatoryFieldsPasses` continue to pass unchanged