### PR TITLE
fix(stub): preserve and gate call process stub mode

### DIFF
--- a/plugins/corezoid/docs/node-structures.md
+++ b/plugins/corezoid/docs/node-structures.md
@@ -316,7 +316,7 @@ Complete JSON structures for all node types used when modifying Corezoid process
 
 ---
 
-## Call a Process Node (`obj_type: 0`, `type: "api_rpc"`)
+## Call a Process Node (`obj_type: 0` or Stub-enabled `obj_type: 4`, `type: "api_rpc"`)
 
 ```json
 {
@@ -362,8 +362,22 @@ Complete JSON structures for all node types used when modifying Corezoid process
 - `extra` and `extra_type` are **required** (use `{}` if no params needed)
 - Keys in `extra` and `extra_type` must **match exactly**
 - Object values in `extra` must be stringified: `"{\"key\":\"value\"}"`
-- `group: "all"` — waits for the called process to reply
+- `group: "all"` sends all current task parameters to the called process;
+  `group: ""` sends only fields listed in `extra` / `extra_type`.
 - `err_node_id` is **required**
+- Stub/mock replies configured in the UI are stored under `condition.stub`.
+  Stub Mode is active only when the Call a Process node is saved as
+  `obj_type: 4`; with `obj_type: 0`, the runtime calls the real target process.
+  Stub conditions are evaluated against the parameters sent to the called
+  process, so use `group: "all"` or explicitly map the fields through `extra`.
+  Stub branches return `api_rpc_reply`; optional `go_if_const` branches inside
+  the stub do not use `to_node_id` because they select a mock reply, not a graph
+  route.
+- Treat active Stub Mode as a temporary development/integration mock. It
+  bypasses the real called process. `push-process` shows it as a warning on a
+  resolved mutable non-production-like stage, but blocks it on immutable,
+  production-like, or unknown stages unless `allow_active_stub_mode=true` is
+  passed after explicit confirmation.
 
 ---
 

--- a/plugins/corezoid/docs/nodes/call-process-node.md
+++ b/plugins/corezoid/docs/nodes/call-process-node.md
@@ -33,8 +33,8 @@
 ### Optional
 
 1. **Group** (String)
-   - Specifies how to handle multiple calls.
-   - Default: "all" (waits for all responses)
+   - In the UI this backs **Send all parameters**.
+   - `"all"` sends all current task parameters to the called process; `""` sends only `extra` / `extra_type`.
    - Example: `"group": "all"`
 2. **User ID** (Number)
    - User ID for authentication purposes.
@@ -53,9 +53,10 @@
 
 2. **obj_type** (Number)
 
-   - Must be `0` for logic nodes
+   - `0` for normal Call Process logic nodes
+   - `4` for Call Process nodes with Stub Mode enabled
    - Example: `"obj_type": 0`
-   - Validation: Must be exactly `0` for Call Process nodes
+   - Validation: Must be either `0`, or `4` for Stub-enabled Call Process nodes
 
 
 
@@ -96,8 +97,7 @@
    - Validation: Must be a 24-character hexadecimal string
 
 6. **group** (String)
-   - Controls how multiple calls are handled
-   - Default: `"all"` (waits for all responses)
+   - Controls whether the call sends all task parameters (`"all"`) or only `extra` / `extra_type` (`""`)
    - Example: `"group": "all"`
    - Validation: Must be one of the allowed values
 
@@ -141,6 +141,105 @@ The Call a Process Node uses the `api_rpc` type in its JSON configuration:
   "options": null
 }
 ```
+
+## Stub / Mock Replies
+
+The Corezoid UI can attach Stub replies to a Call Process node. In exported
+`.conv.json` files this is stored under `condition.stub`, not inside the
+`api_rpc` logic object. Stub Mode is enabled when the node is saved as
+`obj_type: 4`; if the same stub block is present on an `obj_type: 0` Call
+Process node, normal runtime calls the real target process.
+
+Use Stub Mode as a temporary placeholder while the called process is not ready,
+or as a controlled integration-test fixture. It must not be left enabled
+accidentally: while active, the node bypasses the real called process and
+returns the configured mock reply. That can hide integration failures, skip real
+side effects, and return fake success data in production. `push-process` treats
+active Stub Mode as a warning only when the target stage is resolved as mutable
+and non-production-like. It blocks immutable, production-like, or unknown
+stages unless `allow_active_stub_mode=true` is passed after explicitly
+confirming that deploying the mock behavior is intentional.
+
+Stub scenario conditions are evaluated against the parameters sent to the
+called process. To match on incoming task data, enable **Send all parameters**
+(`group: "all"`) or map the required fields through `extra` / `extra_type`.
+A task processed through Stub Mode receives `__logic_stub_mode__: true`.
+
+```json
+{
+  "obj_type": 4,
+  "condition": {
+    "logics": [
+      {
+        "type": "api_rpc",
+        "conv_id": 9876543,
+        "err_node_id": "error_node",
+        "extra": {},
+        "extra_type": {},
+        "group": "all"
+      },
+      {
+        "type": "go",
+        "to_node_id": "next_node"
+      }
+    ],
+    "semaphors": [],
+    "stub": {
+      "logics": [
+        [
+          {
+            "type": "go_if_const",
+            "conditions": [
+              {
+                "param": "{{mode}}",
+                "const": "error",
+                "fun": "eq",
+                "cast": "string"
+              }
+            ]
+          },
+          {
+            "type": "api_rpc_reply",
+            "mode": "key_value",
+            "res_data": {
+              "status": "error"
+            },
+            "res_data_type": {
+              "status": "string"
+            },
+            "throw_exception": true,
+            "exception_reason": "stub error"
+          }
+        ],
+        [
+          {
+            "type": "api_rpc_reply",
+            "mode": "keys",
+            "res_data": [
+              "stub_node_response"
+            ],
+            "res_data_type": {
+              "stub_node_response": "string"
+            },
+            "throw_exception": false
+          }
+        ]
+      ]
+    }
+  }
+}
+```
+
+Stub `go_if_const` blocks do not have `to_node_id`: they select which mock
+`api_rpc_reply` to return, rather than routing the task to another node.
+Branches are evaluated top-to-bottom. Multiple conditions inside one branch are
+ANDed. A final branch without `go_if_const` acts as the default response.
+`throw_exception: true` routes the caller through the Call Process `err_node_id`
+and puts `exception_reason` into `__conveyor_rpc_reply_return_description__`.
+For Stub `mode: "keys"`, the UI/export shape is `res_data` as an array of key
+names while `res_data_type` remains an object keyed by those names.
+Preserve `condition.stub` during pull/push round trips; otherwise a deploy can
+silently remove the mock behavior configured in the UI.
 
 ## Using Semaphores in Call Process Nodes
 
@@ -267,7 +366,7 @@ and includes the necessary error handling connection.
         "err_node_id": "error_condition_node", // ID for error handling (example uses "61d5499782ba963bce68a253")
         "extra": {}, // Parameters to pass (empty in this example)
         "extra_type": {}, // Data types for parameters (empty as 'extra' is empty)
-        "group": "all", // Wait for the called process to respond
+        "group": "all", // Send all current task parameters to the called process
         "conv_id": 1023395, // ID of the target Process to call
         "obj_to_id": null, // Not typically used for standard calls
         "user_id": 56171, // Internal user ID

--- a/plugins/corezoid/docs/process/process-json-validation.md
+++ b/plugins/corezoid/docs/process/process-json-validation.md
@@ -243,7 +243,12 @@ The schema enforces the following requirements:
 - Node IDs must be 24-character hexadecimal strings
 - Node IDs must be unique within the process
 - UUIDs must follow the UUID-v4 format
-- Node obj_type values must be within the allowed list [0,1,2,3]
+- Node obj_type values must be within the allowed list [0,1,2,3,4]
+- Active Call Process Stub Mode uses node `obj_type: 4`. It is valid JSON, but
+  it bypasses the real called process and returns temporary mock replies.
+  `push-process` shows it as a warning on a resolved mutable non-production-like
+  stage, and blocks immutable, production-like, or unknown stages unless
+  `allow_active_stub_mode=true` is passed.
 - Parent_id should be set to 0 for root level processes/folders unless specified otherwise
 - Use single backslash for escaping quotes in JSON strings (\" instead of \\")
 

--- a/plugins/corezoid/mcp-server/executor_nodes.go
+++ b/plugins/corezoid/mcp-server/executor_nodes.go
@@ -223,6 +223,11 @@ func (v *Executor) ModifyNodes(nodes []any) error {
 		if options != nil {
 			op["options"] = options
 		}
+		if condition, ok := nodeMap["condition"].(map[string]interface{}); ok {
+			if stub, ok := condition["stub"].(map[string]interface{}); ok {
+				op["stub"] = stub
+			}
+		}
 
 		ops = append(ops, op)
 	}

--- a/plugins/corezoid/mcp-server/executor_nodes_stub_test.go
+++ b/plugins/corezoid/mcp-server/executor_nodes_stub_test.go
@@ -1,0 +1,331 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCreateNodes_PreservesStubObjType(t *testing.T) {
+	var captured []map[string]interface{}
+	_, e := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
+		captured = ops
+		return map[string]interface{}{
+			"request_proc": "ok",
+			"ops": []interface{}{
+				map[string]interface{}{
+					"proc":   "ok",
+					"id":     "bbbbbbbbbbbbbbbbbbbbbbbb",
+					"obj_id": "server-node-id",
+				},
+			},
+		}
+	})
+	e.ProcessID = 1891415
+	e.Version = 1
+
+	nodes := []any{
+		map[string]interface{}{
+			"id":          "bbbbbbbbbbbbbbbbbbbbbbbb",
+			"title":       "Call with Stub",
+			"description": "",
+			"obj_type":    float64(4),
+			"extra":       "{\"modeForm\":\"expand\",\"icon\":\"\"}",
+		},
+	}
+
+	if err := e.CreateNodesFromJSON(nodes); err != nil {
+		t.Fatalf("CreateNodesFromJSON returned error: %v", err)
+	}
+	if len(captured) != 1 {
+		t.Fatalf("expected 1 create op, got %d", len(captured))
+	}
+	if captured[0]["obj_type"] != float64(4) {
+		t.Fatalf("expected API create obj_type 4 for Stub Mode node, got %#v", captured[0]["obj_type"])
+	}
+	if e.NodeIDMap["bbbbbbbbbbbbbbbbbbbbbbbb"].Type != 4 {
+		t.Fatalf("expected local NodeIDMap to keep exported obj_type 4, got %d", e.NodeIDMap["bbbbbbbbbbbbbbbbbbbbbbbb"].Type)
+	}
+}
+
+func TestModifyNodes_PreservesConditionStub(t *testing.T) {
+	var captured []map[string]interface{}
+	_, e := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
+		captured = ops
+		return okResponse(ops)
+	})
+	e.ProcessID = 1891415
+	e.Version = 1
+
+	stub := map[string]interface{}{
+		"logics": []interface{}{
+			[]interface{}{
+				map[string]interface{}{
+					"type": "go_if_const",
+					"conditions": []interface{}{
+						map[string]interface{}{
+							"param": "{{mode}}",
+							"const": "error",
+							"fun":   "eq",
+							"cast":  "string",
+						},
+					},
+				},
+				map[string]interface{}{
+					"type":             "api_rpc_reply",
+					"mode":             "key_value",
+					"res_data":         map[string]interface{}{"status": "error"},
+					"res_data_type":    map[string]interface{}{"status": "string"},
+					"throw_exception":  true,
+					"exception_reason": "stub error",
+				},
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"type":            "api_rpc_reply",
+					"mode":            "key_value",
+					"res_data":        map[string]interface{}{"stub_node_response": "ok"},
+					"res_data_type":   map[string]interface{}{"stub_node_response": "string"},
+					"throw_exception": false,
+				},
+			},
+		},
+	}
+
+	nodes := []any{
+		map[string]interface{}{
+			"id":          "bbbbbbbbbbbbbbbbbbbbbbbb",
+			"title":       "Call with Stub",
+			"description": "",
+			"obj_type":    float64(4),
+			"x":           float64(100),
+			"y":           float64(300),
+			"extra":       "{\"modeForm\":\"expand\",\"icon\":\"\"}",
+			"options":     nil,
+			"condition": map[string]interface{}{
+				"logics": []interface{}{
+					map[string]interface{}{
+						"type":        "api_rpc",
+						"conv_id":     float64(123456),
+						"err_node_id": "dddddddddddddddddddddddd",
+						"extra":       map[string]interface{}{},
+						"extra_type":  map[string]interface{}{},
+						"group":       "",
+					},
+					map[string]interface{}{
+						"type":       "go",
+						"to_node_id": "cccccccccccccccccccccccc",
+					},
+				},
+				"semaphors": []interface{}{},
+				"stub":      stub,
+			},
+		},
+	}
+
+	if err := e.ModifyNodes(nodes); err != nil {
+		t.Fatalf("ModifyNodes returned error: %v", err)
+	}
+	if len(captured) != 1 {
+		t.Fatalf("expected 1 modify op, got %d", len(captured))
+	}
+	if captured[0]["obj_type"] != float64(4) {
+		t.Fatalf("expected API modify obj_type 4 for Stub Mode node, got %#v", captured[0]["obj_type"])
+	}
+	got, ok := captured[0]["stub"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected modify op to include stub, got %#v", captured[0])
+	}
+	if len(got["logics"].([]interface{})) != 2 {
+		t.Fatalf("expected 2 stub branches, got %#v", got["logics"])
+	}
+}
+
+func TestModifyNodes_TogglesStubModeWithExplicitObjType(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		objType float64
+	}{
+		{name: "enabled", objType: 4},
+		{name: "disabled_but_config_preserved", objType: 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var captured []map[string]interface{}
+			_, e := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
+				captured = ops
+				return okResponse(ops)
+			})
+			e.ProcessID = 1891415
+			e.Version = 1
+
+			nodes := []any{stubbedCallProcessNode(tc.objType)}
+			if err := e.ModifyNodes(nodes); err != nil {
+				t.Fatalf("ModifyNodes returned error: %v", err)
+			}
+			if len(captured) != 1 {
+				t.Fatalf("expected 1 modify op, got %d", len(captured))
+			}
+			if captured[0]["obj_type"] != tc.objType {
+				t.Fatalf("expected obj_type %.0f, got %#v", tc.objType, captured[0]["obj_type"])
+			}
+			if _, ok := captured[0]["stub"].(map[string]interface{}); !ok {
+				t.Fatalf("expected stub config to be preserved while switching mode, got %#v", captured[0])
+			}
+		})
+	}
+}
+
+func TestProcessJSON_CreatesStubbedProcessRoundTripPayload(t *testing.T) {
+	sample, err := os.ReadFile(filepath.Join("samples", "stubbed_api_rpc.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "stubbed_api_rpc.json")
+	if err := os.WriteFile(filePath, sample, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	serverIDs := map[string]string{
+		"aaaaaaaaaaaaaaaaaaaaaaaa": "111111111111111111111111",
+		"bbbbbbbbbbbbbbbbbbbbbbbb": "222222222222222222222222",
+		"cccccccccccccccccccccccc": "333333333333333333333333",
+		"dddddddddddddddddddddddd": "444444444444444444444444",
+	}
+	var createNodeOps []map[string]interface{}
+	var modifyNodeOps []map[string]interface{}
+	_, e := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
+		if len(ops) == 0 {
+			return okResponse(ops)
+		}
+		op := ops[0]
+		switch {
+		case op["type"] == "create" && op["obj"] == "conv":
+			return wrapOp(map[string]interface{}{"proc": "ok", "obj_id": float64(777)})
+		case op["type"] == "create" && op["obj"] == "node":
+			createNodeOps = append(createNodeOps, ops...)
+			results := make([]interface{}, len(ops))
+			for i, createOp := range ops {
+				localID, _ := createOp["id"].(string)
+				results[i] = map[string]interface{}{
+					"proc":   "ok",
+					"id":     localID,
+					"obj_id": serverIDs[localID],
+				}
+			}
+			return map[string]interface{}{"request_proc": "ok", "ops": results}
+		case op["type"] == "modify" && op["obj"] == "node":
+			modifyNodeOps = append(modifyNodeOps, ops...)
+			return okResponse(ops)
+		default:
+			return okResponse(ops)
+		}
+	})
+	e.Version = 1
+	e.WorkspaceID = "workspace"
+
+	if _, err := e.ProcessJSON(filePath, string(sample)); err != nil {
+		t.Fatalf("ProcessJSON returned error: %v", err)
+	}
+
+	var createdStub map[string]interface{}
+	for _, op := range createNodeOps {
+		if op["id"] == "bbbbbbbbbbbbbbbbbbbbbbbb" {
+			createdStub = op
+			break
+		}
+	}
+	if createdStub == nil {
+		t.Fatalf("expected Stub node create op, got %#v", createNodeOps)
+	}
+	if createdStub["obj_type"] != float64(4) {
+		t.Fatalf("expected Stub node create obj_type 4, got %#v", createdStub["obj_type"])
+	}
+
+	var modifiedStub map[string]interface{}
+	for _, op := range modifyNodeOps {
+		if op["obj_id"] == "222222222222222222222222" {
+			modifiedStub = op
+			break
+		}
+	}
+	if modifiedStub == nil {
+		t.Fatalf("expected Stub node modify op, got %#v", modifyNodeOps)
+	}
+	if modifiedStub["obj_type"] != float64(4) {
+		t.Fatalf("expected Stub node modify obj_type 4, got %#v", modifiedStub["obj_type"])
+	}
+	stub, ok := modifiedStub["stub"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected modify op to include stub config, got %#v", modifiedStub)
+	}
+	if branches, ok := stub["logics"].([]interface{}); !ok || len(branches) != 2 {
+		t.Fatalf("expected 2 stub branches in ProcessJSON payload, got %#v", stub["logics"])
+	}
+}
+
+func stubbedCallProcessNode(objType float64) map[string]interface{} {
+	stub := map[string]interface{}{
+		"logics": []interface{}{
+			[]interface{}{
+				map[string]interface{}{
+					"type": "go_if_const",
+					"conditions": []interface{}{
+						map[string]interface{}{
+							"param": "{{mode}}",
+							"const": "error",
+							"fun":   "eq",
+							"cast":  "string",
+						},
+					},
+				},
+				map[string]interface{}{
+					"type":             "api_rpc_reply",
+					"mode":             "key_value",
+					"res_data":         map[string]interface{}{"status": "error"},
+					"res_data_type":    map[string]interface{}{"status": "string"},
+					"throw_exception":  true,
+					"exception_reason": "stub error",
+				},
+			},
+			[]interface{}{
+				map[string]interface{}{
+					"type":            "api_rpc_reply",
+					"mode":            "key_value",
+					"res_data":        map[string]interface{}{"stub_node_response": "ok"},
+					"res_data_type":   map[string]interface{}{"stub_node_response": "string"},
+					"throw_exception": false,
+				},
+			},
+		},
+	}
+
+	return map[string]interface{}{
+		"id":          "bbbbbbbbbbbbbbbbbbbbbbbb",
+		"title":       "Call with Stub",
+		"description": "",
+		"obj_type":    objType,
+		"x":           float64(100),
+		"y":           float64(300),
+		"extra":       "{\"modeForm\":\"expand\",\"icon\":\"\"}",
+		"options":     nil,
+		"condition": map[string]interface{}{
+			"logics": []interface{}{
+				map[string]interface{}{
+					"type":        "api_rpc",
+					"conv_id":     float64(123456),
+					"err_node_id": "dddddddddddddddddddddddd",
+					"extra":       map[string]interface{}{},
+					"extra_type":  map[string]interface{}{},
+					"group":       "",
+				},
+				map[string]interface{}{
+					"type":       "go",
+					"to_node_id": "cccccccccccccccccccccccc",
+				},
+			},
+			"semaphors": []interface{}{},
+			"stub":      stub,
+		},
+	}
+}

--- a/plugins/corezoid/mcp-server/json-schema/logics/api_rpc.json
+++ b/plugins/corezoid/mcp-server/json-schema/logics/api_rpc.json
@@ -28,7 +28,7 @@
     "group": {
       "type": "string",
       "enum": ["all", ""],
-      "description": "Wait mode for the called process",
+      "description": "Call parameter mode used by the UI: \"all\" sends all task parameters to the called process; empty string sends only extra/extra_type fields",
       "default": "all"
     },
     "conv_id": {

--- a/plugins/corezoid/mcp-server/json-schema/logics/condition.json
+++ b/plugins/corezoid/mcp-server/json-schema/logics/condition.json
@@ -13,6 +13,9 @@
     },
     "semaphors": {
       "$ref": "#/definitions/semaphors"
+    },
+    "stub": {
+      "$ref": "#/definitions/stub"
     }
   },
   "examples": [

--- a/plugins/corezoid/mcp-server/json-schema/logics/stub.json
+++ b/plugins/corezoid/mcp-server/json-schema/logics/stub.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Node Stub Schema",
+  "description": "Schema for Corezoid node stub/mock replies stored under condition.stub",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["logics"],
+  "properties": {
+    "logics": {
+      "type": "array",
+      "description": "Alternative stub branches. A branch either returns api_rpc_reply directly or first evaluates go_if_const-style conditions without graph routing.",
+      "items": {
+        "oneOf": [
+          {
+            "type": "array",
+            "minItems": 1,
+            "maxItems": 1,
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["type", "mode", "res_data"],
+              "properties": {
+                "type": {
+                  "type": "string",
+                  "enum": ["api_rpc_reply"]
+                },
+                "mode": {
+                  "type": "string",
+                  "enum": ["key_value", "keys", ""]
+                },
+                "res_data": {
+                  "oneOf": [
+                    { "type": "object" },
+                    {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    }
+                  ]
+                },
+                "res_data_type": {
+                  "type": "object"
+                },
+                "throw_exception": {
+                  "type": "boolean"
+                },
+                "exception_reason": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
+            "items": [
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["type", "conditions"],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": ["go_if_const"]
+                  },
+                  "conditions": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "required": ["param", "const", "fun"],
+                      "properties": {
+                        "param": {
+                          "type": "string"
+                        },
+                        "const": {
+                          "type": "string"
+                        },
+                        "fun": {
+                          "type": "string",
+                          "enum": ["eq", "not_eq", "less", "more", "less_or_eq", "more_or_eq", "regexp"]
+                        },
+                        "cast": {
+                          "type": "string",
+                          "enum": ["string", "number", "boolean", "array", "object"]
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["type", "mode", "res_data"],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": ["api_rpc_reply"]
+                  },
+                  "mode": {
+                    "type": "string",
+                    "enum": ["key_value", "keys", ""]
+                  },
+                  "res_data": {
+                    "oneOf": [
+                      { "type": "object" },
+                      {
+                        "type": "array",
+                        "items": { "type": "string" }
+                      }
+                    ]
+                  },
+                  "res_data_type": {
+                    "type": "object"
+                  },
+                  "throw_exception": {
+                    "type": "boolean"
+                  },
+                  "exception_reason": {
+                    "type": "string"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/plugins/corezoid/mcp-server/json-schema/node.json
+++ b/plugins/corezoid/mcp-server/json-schema/node.json
@@ -12,8 +12,8 @@
     },
     "obj_type": {
       "type": "integer",
-      "enum": [0, 1, 2, 3],
-      "description": "Object type: 0 - Logic node, 1 - Start node, 2 - End node, 3 - Condition node"
+      "enum": [0, 1, 2, 3, 4],
+      "description": "Object type: 0 - Logic node, 1 - Start node, 2 - End node, 3 - Escalation node, 4 - Stub-enabled logic node"
     },
     "condition": {
       "$ref": "#/definitions/condition"

--- a/plugins/corezoid/mcp-server/lint.go
+++ b/plugins/corezoid/mcp-server/lint.go
@@ -25,6 +25,7 @@ type LintResult struct {
 	ShortTimers            []ShortTimer
 	BrokenLinks            []BrokenLink
 	UnderspecifiedAPINodes []UnderspecifiedAPINode
+	StubModeNodes          []StubModeNode
 	TotalNodes             int
 	ReachableCount         int
 	SchemaValid            bool
@@ -157,6 +158,16 @@ type ShortTimer struct {
 	Issue string
 }
 
+// StubModeNode records an active Call Process Stub Mode node. It is valid
+// Corezoid JSON, but it bypasses the real called process and returns mock
+// replies, so push-process may require an explicit allow_active_stub_mode confirmation.
+type StubModeNode struct {
+	ID       string
+	Title    string
+	Branches int
+	Issue    string
+}
+
 // processNode is the typed representation of a Corezoid node used throughout lint checks.
 type processNode struct {
 	id      string
@@ -164,6 +175,7 @@ type processNode struct {
 	objType float64
 	logics  []map[string]interface{}
 	sems    []map[string]interface{}
+	stub    map[string]interface{}
 }
 
 // parseProcessNodes decodes raw node interfaces into typed processNode values.
@@ -179,12 +191,14 @@ func parseProcessNodes(rawNodes []interface{}) []processNode {
 		title, _ := n["title"].(string)
 		objType, _ := n["obj_type"].(float64)
 		cond, _ := n["condition"].(map[string]interface{})
+		stub, _ := cond["stub"].(map[string]interface{})
 		nodes = append(nodes, processNode{
 			id:      id,
 			title:   title,
 			objType: objType,
 			logics:  toMapSlice(cond["logics"]),
 			sems:    toMapSlice(cond["semaphors"]),
+			stub:    stub,
 		})
 	}
 	return nodes
@@ -224,6 +238,7 @@ func lintProcess(filePath string) (*LintResult, error) {
 	result.ShortTimers = findShortTimers(typed)
 	result.BrokenLinks = findBrokenLinks(typed)
 	result.UnderspecifiedAPINodes = findUnderspecifiedAPINodes(typed)
+	result.StubModeNodes = findStubModeNodes(typed)
 
 	schemaErr := ValidateJSONSchema(filePath, debug)
 	if schemaErr != nil {
@@ -652,6 +667,33 @@ func findShortTimers(nodes []processNode) []ShortTimer {
 				Issue: fmt.Sprintf("time semaphor resolves to %g sec — below the server minimum of 30 sec; the deploy is rejected", v*mult),
 			})
 		}
+	}
+	return result
+}
+
+// findStubModeNodes flags active Call Process Stub Mode nodes. The presence of
+// condition.stub alone is not enough: live Corezoid runtime uses obj_type:4 as
+// the actual Stub Mode switch. With obj_type:0, the real process is called.
+func findStubModeNodes(nodes []processNode) []StubModeNode {
+	var result []StubModeNode
+	for _, n := range nodes {
+		if n.objType != 4 {
+			continue
+		}
+		title := n.title
+		if title == "" {
+			title = "(untitled)"
+		}
+		branches := 0
+		if raw, ok := n.stub["logics"].([]interface{}); ok {
+			branches = len(raw)
+		}
+		result = append(result, StubModeNode{
+			ID:       n.id,
+			Title:    title,
+			Branches: branches,
+			Issue:    "Stub Mode is active (obj_type:4): the Call Process node bypasses the real called process and returns configured mock replies. Use this only as a temporary development/integration placeholder; before production, disable Stub Mode (obj_type:0) or deploy with allow_active_stub_mode=true after explicit confirmation.",
+		})
 	}
 	return result
 }
@@ -1218,6 +1260,16 @@ func FormatLintResult(result *LintResult) string {
 		}
 	}
 
+	if len(result.StubModeNodes) > 0 {
+		hasIssues = true
+		sb.WriteString(fmt.Sprintf("\n=== ACTIVE STUB MODE NODES (%d) — temporary mock replies ===\n", len(result.StubModeNodes)))
+		for _, sm := range result.StubModeNodes {
+			sb.WriteString(fmt.Sprintf("  [%s] %s\n", sm.ID, sm.Title))
+			sb.WriteString(fmt.Sprintf("  Stub branches: %d\n", sm.Branches))
+			sb.WriteString(fmt.Sprintf("  Issue: %s\n", sm.Issue))
+		}
+	}
+
 	if !hasIssues {
 		sb.WriteString("\nNo issues found.")
 	} else {
@@ -1225,7 +1277,7 @@ func FormatLintResult(result *LintResult) string {
 		if !result.SchemaValid {
 			schemaIssues = 1
 		}
-		total := len(result.NoopConditions) + len(result.UnusedSetParams) + len(result.OrphanedNodes) + len(result.RpcReplyMismatches) + len(result.PassthroughEscalations) + len(result.LiteralReplyValues) + len(result.SharedErrorClusters) + len(result.OldFormatNodes) + len(result.UnrepliedTerminals) + len(result.MissingDefaultGo) + len(result.ShortTimers) + len(result.BrokenLinks) + len(result.UnderspecifiedAPINodes) + schemaIssues
+		total := len(result.NoopConditions) + len(result.UnusedSetParams) + len(result.OrphanedNodes) + len(result.RpcReplyMismatches) + len(result.PassthroughEscalations) + len(result.LiteralReplyValues) + len(result.SharedErrorClusters) + len(result.OldFormatNodes) + len(result.UnrepliedTerminals) + len(result.MissingDefaultGo) + len(result.ShortTimers) + len(result.BrokenLinks) + len(result.UnderspecifiedAPINodes) + len(result.StubModeNodes) + schemaIssues
 		sb.WriteString(fmt.Sprintf("\nTotal issues: %d\n", total))
 	}
 

--- a/plugins/corezoid/mcp-server/lint_test.go
+++ b/plugins/corezoid/mcp-server/lint_test.go
@@ -117,6 +117,84 @@ func TestLintProcess_LiteralReplyValues_CleanReply(t *testing.T) {
 	}
 }
 
+// TestLintProcess_StubbedApiRpcExport verifies that the plugin accepts the
+// Corezoid UI export shape for Call a Process stubs: obj_type:4 with
+// condition.stub.logics. Stub conditions intentionally omit to_node_id because
+// they select a mock api_rpc_reply instead of routing through the graph. The
+// fixture covers both key_value replies and the Stub-specific keys shape where
+// res_data is an array and res_data_type remains an object.
+func TestLintProcess_StubbedApiRpcExport(t *testing.T) {
+	result, err := lintProcess("samples/stubbed_api_rpc.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.SchemaValid {
+		t.Fatalf("expected schema-valid stubbed api_rpc export, got: %s", result.SchemaError)
+	}
+	if len(result.OrphanedNodes) != 0 {
+		t.Fatalf("expected no orphaned nodes, got %+v", result.OrphanedNodes)
+	}
+	if len(result.BrokenLinks) != 0 {
+		t.Fatalf("expected no broken links, got %+v", result.BrokenLinks)
+	}
+	if len(result.StubModeNodes) != 1 {
+		t.Fatalf("expected active Stub Mode finding, got %+v", result.StubModeNodes)
+	}
+	if result.StubModeNodes[0].Branches != 2 {
+		t.Fatalf("expected 2 stub branches, got %+v", result.StubModeNodes[0])
+	}
+}
+
+func TestLintProcess_InactiveStubConfigDoesNotWarn(t *testing.T) {
+	data, err := os.ReadFile("samples/stubbed_api_rpc.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	data = []byte(strings.Replace(string(data), `"obj_type": 4`, `"obj_type": 0`, 1))
+
+	f, err := os.CreateTemp("", "inactive-stub-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := lintProcess(f.Name())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.SchemaValid {
+		t.Fatalf("expected schema-valid inactive stub config, got: %s", result.SchemaError)
+	}
+	if len(result.StubModeNodes) != 0 {
+		t.Fatalf("expected no active Stub Mode finding for obj_type:0, got %+v", result.StubModeNodes)
+	}
+}
+
+func TestFormatLintResult_StubModeExplainsRisk(t *testing.T) {
+	result, err := lintProcess("samples/stubbed_api_rpc.json")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := FormatLintResult(result)
+	for _, want := range []string{
+		"ACTIVE STUB MODE NODES",
+		"temporary mock replies",
+		"bypasses the real called process",
+		"before production, disable Stub Mode",
+		"allow_active_stub_mode=true",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected Stub lint output to contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
 // TestLintProcess_MalformedJSON verifies graceful error on invalid JSON.
 func TestLintProcess_MalformedJSON(t *testing.T) {
 	f, err := os.CreateTemp("", "bad-*.json")
@@ -224,9 +302,9 @@ func sliceContains(ss []string, target string) bool {
 // Run with -update to regenerate golden files.
 func TestFormatLintResult_Golden(t *testing.T) {
 	cases := []struct {
-		name    string
-		sample  string
-		golden  string
+		name   string
+		sample string
+		golden string
 	}{
 		{"clean", "samples/valid_process.json", "testdata/golden/lint_clean.txt"},
 		{"orphaned", "samples/orphaned_node.json", "testdata/golden/lint_orphaned.txt"},

--- a/plugins/corezoid/mcp-server/main.go
+++ b/plugins/corezoid/mcp-server/main.go
@@ -55,9 +55,11 @@ var debug = debugFromEnv()
 // debugFromEnv reports whether COREZOID_DEBUG requests the detailed trace.
 // Split out so tests can exercise the wiring with t.Setenv.
 func debugFromEnv() bool { return os.Getenv("COREZOID_DEBUG") != "" }
+
 var apigwURL string
 var stageID int
 var insecureTLS bool
+
 // cachedProjectID is written once (protected by authStateMu) and then read-only.
 // Reset to 0 on every loadConfig so a workspace switch gets a fresh value.
 var cachedProjectID int
@@ -189,7 +191,7 @@ func loadConfig() {
 	stageID, _ = strconv.Atoi(os.Getenv("COREZOID_STAGE_ID"))
 	debug = debugFromEnv() // executor API trace; same switch as logger.IsDebug
 	insecureTLS = os.Getenv("COREZOID_INSECURE_TLS") != ""
-	cachedProjectID = 0              // reset on workspace switch so it is re-resolved
+	cachedProjectID = 0                // reset on workspace switch so it is re-resolved
 	os.Unsetenv("COREZOID_PROJECT_ID") // prevent stale process env from short-circuiting resolution
 	apiLogin = os.Getenv("API_LOGIN")
 	apiSecret = os.Getenv("API_SECRET")
@@ -332,6 +334,7 @@ var schemaDefinitions = []struct{ name, path string }{
 	{"process", "json-schema/process.json"},
 	{"node", "json-schema/node.json"},
 	{"condition", "json-schema/logics/condition.json"},
+	{"stub", "json-schema/logics/stub.json"},
 	{"logics", "json-schema/logics.json"},
 	{"semaphors", "json-schema/logics/semaphors.json"},
 	{"go", "json-schema/logics/go.json"},
@@ -493,6 +496,93 @@ func LoadBinFromFile(filePath string) (string, error) {
 	return string(fileContent), nil
 }
 
+func isProcessLogicObjType(objType int) bool {
+	return objType == 0 || objType == 4
+}
+
+func normalizeGoIfConstLogic(nodeID interface{}, logicMap map[string]interface{}, messages *[]string) {
+	funAliases := map[string]string{
+		"gte": "more_or_eq",
+		"lte": "less_or_eq",
+		"gt":  "more",
+		"lt":  "less",
+		"ne":  "not_eq",
+		"neq": "not_eq",
+	}
+	if conditions, ok := logicMap["conditions"].([]interface{}); ok {
+		for _, cond := range conditions {
+			if condMap, ok := cond.(map[string]interface{}); ok {
+				if fun, ok := condMap["fun"].(string); ok {
+					if replacement, found := funAliases[fun]; found {
+						condMap["fun"] = replacement
+						*messages = append(*messages,
+							fmt.Sprintf("go_if_const condition in node %v: \"fun\":\"%s\" replaced with \"fun\":\"%s\"", nodeID, fun, replacement))
+					}
+				}
+			}
+		}
+	}
+}
+
+func normalizeLogicForDeploy(nodeID interface{}, logicMap map[string]interface{}, messages *[]string) {
+	if convIDBin, ok := logicMap["conv_id"].(string); ok {
+		convID, err := strconv.Atoi(convIDBin)
+		if err == nil {
+			logicMap["conv_id"] = convID
+		}
+	}
+
+	logicType, _ := logicMap["type"].(string)
+	switch logicType {
+	case "go_if_const":
+		normalizeGoIfConstLogic(nodeID, logicMap, messages)
+	case "git_call", "api_git":
+		// git_call deploys via a separate container build (see BuildGitCallNodes).
+		// Mark the source valid so Commit accepts the node; the build runs
+		// between compile and commit.
+		if _, set := logicMap["code_error"]; !set {
+			logicMap["code_error"] = false
+		}
+	case "api":
+		if extra, ok := logicMap["extra"].(map[string]interface{}); ok {
+			if body, ok := extra["body"].(string); ok && len(extra) == 1 {
+				// then body to raw_body field and extra["body"] to delete
+				logicMap["raw_body"] = body
+				logicMap["format"] = "raw"
+				logicMap["extra"] = make(map[string]interface{})
+				logicMap["extra_type"] = make(map[string]interface{})
+				*messages = append(*messages,
+					fmt.Sprintf("Logic \"api\" in the node %v was fixed. If you need to pass a variable %s as the entire body part, Instead of \"extra\" and \"extra_type\" you need to use then fields: \"raw_body\":\"%s\", \"format\":\"raw\". I am already fixed it. You don't need to change anything anymore", nodeID, body, body))
+			}
+		} else {
+			logicMap["extra"] = make(map[string]interface{})
+			logicMap["extra_type"] = make(map[string]interface{})
+		}
+	}
+}
+
+func normalizeStubForDeploy(nodeID interface{}, condition map[string]interface{}, messages *[]string) {
+	stub, ok := condition["stub"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	branches, ok := stub["logics"].([]interface{})
+	if !ok {
+		return
+	}
+	for _, branch := range branches {
+		branchItems, ok := branch.([]interface{})
+		if !ok {
+			continue
+		}
+		for _, item := range branchItems {
+			if logicMap, ok := item.(map[string]interface{}); ok {
+				normalizeLogicForDeploy(nodeID, logicMap, messages)
+			}
+		}
+	}
+}
+
 func fixStruct(dataBin string, inProcessID int) (string, []string) {
 	messages := make([]string, 0)
 	var data map[string]interface{}
@@ -512,7 +602,7 @@ func fixStruct(dataBin string, inProcessID int) (string, []string) {
 		for _, node := range nodes {
 			if nodeMap, ok := node.(map[string]interface{}); ok {
 				objTypeF, _ := nodeMap["obj_type"].(float64)
-				if int(objTypeF) == 0 {
+				if isProcessLogicObjType(int(objTypeF)) {
 					//	for by logics
 					condition, ok := nodeMap["condition"].(map[string]interface{})
 					if !ok {
@@ -523,62 +613,11 @@ func fixStruct(dataBin string, inProcessID int) (string, []string) {
 					if logics, ok := condition["logics"].([]interface{}); ok {
 						for _, logic := range logics {
 							if logicMap, ok := logic.(map[string]interface{}); ok {
-								if convIDBin, ok := logicMap["conv_id"].(string); ok {
-									convID, err := strconv.Atoi(convIDBin)
-									if err == nil {
-										logicMap["conv_id"] = convID
-									}
-								}
-								if logicMap["type"] == "go_if_const" {
-									funAliases := map[string]string{
-										"gte": "more_or_eq",
-										"lte": "less_or_eq",
-										"gt":  "more",
-										"lt":  "less",
-										"ne":  "not_eq",
-										"neq": "not_eq",
-									}
-									if conditions, ok := logicMap["conditions"].([]interface{}); ok {
-										for _, cond := range conditions {
-											if condMap, ok := cond.(map[string]interface{}); ok {
-												if fun, ok := condMap["fun"].(string); ok {
-													if replacement, found := funAliases[fun]; found {
-														condMap["fun"] = replacement
-														messages = append(messages,
-															fmt.Sprintf("go_if_const condition in node %s: \"fun\":\"%s\" replaced with \"fun\":\"%s\"", nodeMap["id"], fun, replacement))
-													}
-												}
-											}
-										}
-									}
-								}
-								if logicMap["type"] == "git_call" || logicMap["type"] == "api_git" {
-									// git_call deploys via a separate container build (see BuildGitCallNodes).
-									// Mark the source valid so Commit accepts the node; the build runs
-									// between compile and commit.
-									if _, set := logicMap["code_error"]; !set {
-										logicMap["code_error"] = false
-									}
-								}
-								if logicMap["type"] == "api" {
-									if extra, ok := logicMap["extra"].(map[string]interface{}); ok {
-										if body, ok := extra["body"].(string); ok && len(extra) == 1 {
-											//	then body to raw_body field and extra["body"] to delete
-											logicMap["raw_body"] = body
-											logicMap["format"] = "raw"
-											logicMap["extra"] = make(map[string]interface{})
-											logicMap["extra_type"] = make(map[string]interface{})
-											messages = append(messages,
-												fmt.Sprintf("Logic \"api\" in the node %s was fixed. If you need to pass a variable %s as the entire body part, Instead of \"extra\" and \"extra_type\" you need to use then fields: \"raw_body\":\"%s\", \"format\":\"raw\". I am already fixed it. You don't need to change anything anymore", nodeMap["id"], body, body))
-										}
-									} else {
-										logicMap["extra"] = make(map[string]interface{})
-										logicMap["extra_type"] = make(map[string]interface{})
-									}
-								}
+								normalizeLogicForDeploy(nodeMap["id"], logicMap, &messages)
 							}
 						}
 					}
+					normalizeStubForDeploy(nodeMap["id"], condition, &messages)
 				}
 				if options, ok := nodeMap["options"].(map[string]interface{}); ok {
 					optionsStr, err := json.Marshal(options)

--- a/plugins/corezoid/mcp-server/main_helpers_test.go
+++ b/plugins/corezoid/mcp-server/main_helpers_test.go
@@ -301,3 +301,46 @@ func TestFixStruct_ConvIDStringToInt(t *testing.T) {
 		t.Errorf("expected conv_id: 12345 in output, got: %s", out)
 	}
 }
+
+func TestFixStruct_StubObjTypeLogicNormalized(t *testing.T) {
+	input := `{
+		"obj_id":1,
+		"scheme":{"nodes":[{
+			"id":"aabbcc001122334455667788",
+			"obj_type":4,
+			"condition":{
+				"logics":[{
+					"type":"api_rpc",
+					"conv_id":"12345",
+					"err_node_id":"bbbbcc001122334455667788",
+					"extra":{},
+					"extra_type":{},
+					"group":"all"
+				},{"type":"go","to_node_id":"cccccc001122334455667788"}],
+				"stub":{"logics":[[
+					{"type":"go_if_const","conditions":[{"param":"{{amount}}","const":"10","fun":"gt","cast":"number"}]},
+					{"type":"api_rpc_reply","mode":"key_value","res_data":{"status":"ok"},"res_data_type":{"status":"string"}}
+				]]}
+			}
+		}]}
+	}`
+	out, msgs := fixStruct(input, 1)
+	if strings.Contains(out, `"conv_id":"12345"`) {
+		t.Error("expected obj_type:4 conv_id to be integer, found string")
+	}
+	if !strings.Contains(out, `"conv_id": 12345`) {
+		t.Errorf("expected conv_id: 12345 in output, got: %s", out)
+	}
+	if !strings.Contains(out, `"fun": "more"`) {
+		t.Errorf("expected Stub go_if_const gt->more replacement, output: %s", out)
+	}
+	found := false
+	for _, m := range msgs {
+		if strings.Contains(m, `"fun":"gt" replaced with "fun":"more"`) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected Stub fun alias replacement message, got: %+v", msgs)
+	}
+}

--- a/plugins/corezoid/mcp-server/mcp_handlers_process.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_process.go
@@ -51,6 +51,124 @@ func extractProcessIDFromPath(filePath string) (int, string) {
 	return id, ""
 }
 
+type stubModeStagePolicy struct {
+	requiresConfirmation bool
+	reason               string
+}
+
+func extractParentIDFromJSON(jsonContent string) int {
+	var processData map[string]interface{}
+	if err := json.Unmarshal([]byte(jsonContent), &processData); err != nil {
+		return 0
+	}
+	if f, ok := processData["parent_id"].(float64); ok {
+		return int(f)
+	}
+	if i, ok := processData["parent_id"].(int); ok {
+		return i
+	}
+	return 0
+}
+
+func resolveStageAndProjectFromFolder(v *Executor, folderID int) (stage, project int, err error) {
+	if folderID == 0 {
+		return 0, 0, fmt.Errorf("process parent_id is missing")
+	}
+	const maxDepth = 20
+	currentID := folderID
+	for i := 0; i < maxDepth; i++ {
+		info, showErr := v.ShowFolder(currentID)
+		if showErr != nil {
+			return 0, 0, fmt.Errorf("show folder %d: %w", currentID, showErr)
+		}
+		if info.ParentObjType == "project" {
+			return info.ObjID, info.ParentObjID, nil
+		}
+		if info.ParentObjID == 0 || info.ParentObjID == currentID {
+			break
+		}
+		currentID = info.ParentObjID
+	}
+	return 0, 0, fmt.Errorf("could not find stage root while walking parents from folder %d", folderID)
+}
+
+func stageNameLooksProduction(title, shortName string) bool {
+	for _, value := range []string{title, shortName} {
+		normalized := strings.ToLower(strings.TrimSpace(value))
+		for _, token := range strings.FieldsFunc(normalized, func(r rune) bool {
+			return !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'))
+		}) {
+			switch token {
+			case "prod", "production", "preprod":
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func stubModeStagePolicyForPush(v *Executor, jsonContent string) stubModeStagePolicy {
+	if parentID := extractParentIDFromJSON(jsonContent); parentID != 0 && v.APIUrl != "" {
+		stageID, projectID, err := resolveStageAndProjectFromFolder(v, parentID)
+		if err != nil {
+			return stubModeStagePolicy{
+				requiresConfirmation: true,
+				reason:               fmt.Sprintf("target stage could not be resolved from process parent_id %d: %v", parentID, err),
+			}
+		}
+		return stubModePolicyForStage(v, stageID, projectID)
+	}
+
+	if v.StageID == 0 {
+		return stubModeStagePolicy{
+			requiresConfirmation: true,
+			reason:               "target stage is unknown because process parent_id could not be resolved and COREZOID_STAGE_ID is not configured",
+		}
+	}
+
+	projectID := v.GetProjectIDByStageID(v.StageID)
+	if projectID == 0 {
+		return stubModeStagePolicy{
+			requiresConfirmation: true,
+			reason:               fmt.Sprintf("target stage %d could not be resolved to a project", v.StageID),
+		}
+	}
+
+	return stubModePolicyForStage(v, v.StageID, projectID)
+}
+
+func stubModePolicyForStage(v *Executor, stageID, projectID int) stubModeStagePolicy {
+	immutable, _, title, shortName, err := v.stageInfo(stageID, projectID)
+	if err != nil {
+		return stubModeStagePolicy{
+			requiresConfirmation: true,
+			reason:               fmt.Sprintf("target stage %d metadata could not be read: %v", stageID, err),
+		}
+	}
+
+	stageLabel := fmt.Sprintf("stage %d", stageID)
+	if title != "" {
+		stageLabel += fmt.Sprintf(" (%q)", title)
+	}
+	if immutable {
+		return stubModeStagePolicy{
+			requiresConfirmation: true,
+			reason:               fmt.Sprintf("%s is immutable/read-only", stageLabel),
+		}
+	}
+	if stageNameLooksProduction(title, shortName) {
+		return stubModeStagePolicy{
+			requiresConfirmation: true,
+			reason:               fmt.Sprintf("%s looks production-like by title or short_name", stageLabel),
+		}
+	}
+
+	return stubModeStagePolicy{
+		requiresConfirmation: false,
+		reason:               fmt.Sprintf("%s is mutable and does not look production-like", stageLabel),
+	}
+}
+
 // handlePullProcess downloads a process by ID and writes its JSON to disk in
 // the folder that mirrors its parent_id chain, so re-pulling places the file
 // back where it lived.
@@ -221,10 +339,26 @@ func handlePushProcess(ctx context.Context, args map[string]interface{}) (string
 	// Structural lint gate: catch deploy-breaking / caller-breaking shapes
 	// offline before mutating the live process. Hard findings block the push;
 	// advisory findings (noop, unused set_param, orphans, passthrough, shared
-	// clusters) are surfaced but do not stop it. force=true overrides the block.
+	// clusters) are surfaced but do not stop it. force=true overrides generic
+	// hard findings. Active Stub Mode has its own stage-aware gate because it
+	// bypasses the real called process at runtime.
 	force, _ := args["force"].(bool)
+	allowStubMode, _ := args["allow_active_stub_mode"].(bool)
 	var lintNote string // advisory findings surfaced on a proceeding push (see below)
 	if lintRes, lintErr := lintProcess(filePath); lintErr == nil {
+		stubMode := len(lintRes.StubModeNodes)
+		if stubMode > 0 {
+			policy := stubModeStagePolicyForPush(v, jsonContent)
+			if policy.requiresConfirmation && !allowStubMode {
+				return fmt.Sprintf("Push blocked: active Stub Mode found in %d node(s). Stub replies bypass the real called process and are intended as temporary development/integration placeholders. Target policy: %s. Disable Stub Mode, or re-run with allow_active_stub_mode=true after explicit confirmation.\n\n%s",
+					stubMode, policy.reason, FormatLintResult(lintRes)), true
+			}
+			if allowStubMode {
+				fmt.Fprintf(os.Stderr, "[lint] %d active Stub Mode node(s) allowed with allow_active_stub_mode=true (%s)\n", stubMode, policy.reason)
+			} else {
+				fmt.Fprintf(os.Stderr, "[lint] %d active Stub Mode node(s) are warning-only for this push (%s)\n", stubMode, policy.reason)
+			}
+		}
 		hard := len(lintRes.BrokenLinks) + len(lintRes.OldFormatNodes) +
 			len(lintRes.MissingDefaultGo) + len(lintRes.ShortTimers) +
 			len(lintRes.RpcReplyMismatches) + len(lintRes.LiteralReplyValues) +
@@ -242,7 +376,7 @@ func handlePushProcess(ctx context.Context, args map[string]interface{}) (string
 		// The push proceeds. Surface any findings so the promise "advisory
 		// findings are shown but do not block" is actually kept — otherwise
 		// advisory-only issues would deploy silently and never be seen.
-		if hard+advisory > 0 {
+		if hard+advisory+stubMode > 0 {
 			lintNote = FormatLintResult(lintRes)
 		}
 	}
@@ -622,7 +756,6 @@ func handleCreateFolder(ctx context.Context, args map[string]interface{}) (strin
 	return fmt.Sprintf("Folder '%s' created in Corezoid folder #%d (%s) and saved to %s",
 		folderName, parentFolderID, parentResolvedFrom, filePath), false
 }
-
 
 // handleShowFolder returns metadata for a single folder (title, obj_type,
 // parent). Used to introspect folders without writing anything to disk.

--- a/plugins/corezoid/mcp-server/mcp_handlers_test.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -15,15 +16,25 @@ func resetGlobals(t *testing.T) {
 	origAPIURL := apiURL
 	origWorkspaceID := workspaceID
 	origStageID := stageID
+	origCachedProjectID := cachedProjectID
+	origProjectIDEnv, hadProjectIDEnv := os.LookupEnv("COREZOID_PROJECT_ID")
 	apiToken = ""
 	apiURL = ""
 	workspaceID = ""
 	stageID = 0
+	cachedProjectID = 0
+	os.Unsetenv("COREZOID_PROJECT_ID") //nolint:errcheck
 	t.Cleanup(func() {
 		apiToken = origAPIToken
 		apiURL = origAPIURL
 		workspaceID = origWorkspaceID
 		stageID = origStageID
+		cachedProjectID = origCachedProjectID
+		if hadProjectIDEnv {
+			os.Setenv("COREZOID_PROJECT_ID", origProjectIDEnv) //nolint:errcheck
+		} else {
+			os.Unsetenv("COREZOID_PROJECT_ID") //nolint:errcheck
+		}
 	})
 }
 
@@ -134,6 +145,341 @@ func TestHandlePushProcess_BlocksRpcReplyMismatch(t *testing.T) {
 	} {
 		if !strings.Contains(result, want) {
 			t.Fatalf("expected result to contain %q, got:\n%s", want, result)
+		}
+	}
+}
+
+func TestHandlePushProcess_BlocksActiveStubMode(t *testing.T) {
+	resetGlobals(t)
+
+	sample, err := os.ReadFile(filepath.Join("samples", "stubbed_api_rpc.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	p := filepath.Join(dir, "123_stubbed.conv.json")
+	if err := os.WriteFile(p, sample, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(orig) }) //nolint:errcheck
+
+	result, isErr := handlePushProcess(context.Background(), map[string]interface{}{
+		"process_path": filepath.Base(p),
+		"force":        true,
+	})
+	if !isErr {
+		t.Fatalf("expected push-process to block active Stub Mode, got success: %q", result)
+	}
+	for _, want := range []string{
+		"Push blocked: active Stub Mode found",
+		"allow_active_stub_mode=true",
+		"target stage is unknown",
+		"ACTIVE STUB MODE NODES",
+		"bypasses the real called process",
+	} {
+		if !strings.Contains(result, want) {
+			t.Fatalf("expected result to contain %q, got:\n%s", want, result)
+		}
+	}
+}
+
+func TestHandlePushProcess_BlocksActiveStubModeOnImmutableStage(t *testing.T) {
+	resetGlobals(t)
+	stageID = 999
+
+	sample, err := os.ReadFile(filepath.Join("samples", "stubbed_api_rpc.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sample = []byte(strings.Replace(string(sample), `"parent_id": 1`, `"parent_id": 321`, 1))
+
+	dir := t.TempDir()
+	p := filepath.Join(dir, "123_stubbed.conv.json")
+	if err := os.WriteFile(p, sample, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(orig) }) //nolint:errcheck
+
+	calls := 0
+	srv, _ := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
+		calls++
+		if len(ops) != 1 {
+			t.Fatalf("expected one op per call, got %#v", ops)
+		}
+		op := ops[0]
+		if op["type"] != "show" {
+			t.Fatalf("expected only read-only show calls before Stub block, got %#v", op)
+		}
+		switch op["obj"] {
+		case "folder":
+			if id, _ := op["obj_id"].(float64); int(id) != 321 {
+				t.Fatalf("expected policy to resolve stage from process parent_id 321, got show folder op %#v", op)
+			}
+			return wrapOp(map[string]interface{}{
+				"proc":            "ok",
+				"obj_id":          float64(321),
+				"obj_type":        float64(0),
+				"parent_obj_id":   float64(654),
+				"parent_obj_type": "project",
+			})
+		case "stage":
+			if id, _ := op["obj_id"].(float64); int(id) != 321 {
+				t.Fatalf("expected stageInfo for parent stage 321, got %#v", op)
+			}
+			return wrapOp(map[string]interface{}{
+				"proc":       "ok",
+				"immutable":  true,
+				"title":      "production",
+				"short_name": "prod",
+			})
+		default:
+			t.Fatalf("expected show folder or show stage, got %#v", op)
+		}
+		return wrapOp(map[string]interface{}{"proc": "error", "description": "unexpected op"})
+	})
+	setProjectAuth(t, srv.URL)
+
+	result, isErr := handlePushProcess(context.Background(), map[string]interface{}{
+		"process_path": filepath.Base(p),
+	})
+	if !isErr {
+		t.Fatalf("expected push-process to block active Stub Mode on immutable stage, got success: %q", result)
+	}
+	if calls != 2 {
+		t.Fatalf("expected two read-only stage policy calls and no deploy mutations, got %d calls", calls)
+	}
+	for _, want := range []string{
+		"Push blocked: active Stub Mode found",
+		"stage 321",
+		"immutable/read-only",
+		"allow_active_stub_mode=true",
+	} {
+		if !strings.Contains(result, want) {
+			t.Fatalf("expected result to contain %q, got:\n%s", want, result)
+		}
+	}
+}
+
+func TestHandlePushProcess_WarnsOnlyForDevelopStageStubMode(t *testing.T) {
+	resetGlobals(t)
+	stageID = 999
+
+	sample, err := os.ReadFile(filepath.Join("samples", "stubbed_api_rpc.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	sample = []byte(strings.Replace(string(sample), `"parent_id": 1`, `"parent_id": 321`, 1))
+
+	dir := t.TempDir()
+	p := filepath.Join(dir, "123_stubbed.conv.json")
+	if err := os.WriteFile(p, sample, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(orig) }) //nolint:errcheck
+
+	calls := 0
+	srv, _ := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
+		calls++
+		if len(ops) == 1 && ops[0]["type"] == "show" && ops[0]["obj"] == "folder" {
+			if id, _ := ops[0]["obj_id"].(float64); int(id) != 321 {
+				return wrapOp(map[string]interface{}{"proc": "error", "description": "stopped after Stub warning"})
+			}
+			return wrapOp(map[string]interface{}{
+				"proc":            "ok",
+				"obj_id":          float64(321),
+				"obj_type":        float64(0),
+				"parent_obj_id":   float64(654),
+				"parent_obj_type": "project",
+			})
+		}
+		if len(ops) == 1 && ops[0]["type"] == "show" && ops[0]["obj"] == "stage" {
+			return wrapOp(map[string]interface{}{
+				"proc":       "ok",
+				"immutable":  false,
+				"title":      "develop",
+				"short_name": "dev",
+			})
+		}
+		return wrapOp(map[string]interface{}{"proc": "error", "description": "stopped after Stub warning"})
+	})
+	setProjectAuth(t, srv.URL)
+
+	result, isErr := handlePushProcess(context.Background(), map[string]interface{}{
+		"process_path": filepath.Base(p),
+	})
+	if !isErr {
+		t.Fatalf("expected downstream deploy error from mock API, got success: %q", result)
+	}
+	if calls < 3 {
+		t.Fatalf("expected push-process to continue past Stub warning, got %d API call(s); result:\n%s", calls, result)
+	}
+	if strings.Contains(result, "Push blocked: active Stub Mode found") {
+		t.Fatalf("develop stage should not return the Stub block message, got:\n%s", result)
+	}
+	if !strings.Contains(result, "stopped after Stub warning") {
+		t.Fatalf("expected downstream mock API error, got:\n%s", result)
+	}
+}
+
+func TestStageNameLooksProduction(t *testing.T) {
+	for _, tc := range []struct {
+		title     string
+		shortName string
+		want      bool
+	}{
+		{title: "production", shortName: "p", want: true},
+		{title: "Release", shortName: "prod", want: true},
+		{title: "prod old", shortName: "p-old", want: true},
+		{title: "production mirror", shortName: "mirror", want: true},
+		{title: "pre production", shortName: "pre", want: true},
+		{title: "Product sandbox", shortName: "dev", want: false},
+		{title: "develop", shortName: "dev", want: false},
+	} {
+		if got := stageNameLooksProduction(tc.title, tc.shortName); got != tc.want {
+			t.Fatalf("stageNameLooksProduction(%q, %q) = %v, want %v", tc.title, tc.shortName, got, tc.want)
+		}
+	}
+}
+
+func TestResolveStageAndProjectFromFolder_WalksToStageRoot(t *testing.T) {
+	resetGlobals(t)
+
+	var seen []int
+	srv, e := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
+		if len(ops) != 1 || ops[0]["type"] != "show" || ops[0]["obj"] != "folder" {
+			t.Fatalf("expected show folder, got %#v", ops)
+		}
+		id, _ := ops[0]["obj_id"].(float64)
+		seen = append(seen, int(id))
+		switch int(id) {
+		case 111:
+			return wrapOp(map[string]interface{}{
+				"proc":            "ok",
+				"obj_id":          float64(111),
+				"obj_type":        float64(0),
+				"parent_obj_id":   float64(222),
+				"parent_obj_type": "folder",
+			})
+		case 222:
+			return wrapOp(map[string]interface{}{
+				"proc":            "ok",
+				"obj_id":          float64(222),
+				"obj_type":        float64(0),
+				"parent_obj_id":   float64(333),
+				"parent_obj_type": "project",
+			})
+		default:
+			return wrapOp(map[string]interface{}{"proc": "error", "description": "unexpected folder"})
+		}
+	})
+	e.APIUrl = srv.URL
+	e.WorkspaceID = "i260836082"
+	e.Token = "test-token"
+
+	stage, project, err := resolveStageAndProjectFromFolder(e, 111)
+	if err != nil {
+		t.Fatalf("resolveStageAndProjectFromFolder: %v", err)
+	}
+	if stage != 222 || project != 333 {
+		t.Fatalf("resolved stage/project = %d/%d, want 222/333", stage, project)
+	}
+	if strings.Join([]string{strconv.Itoa(seen[0]), strconv.Itoa(seen[1])}, ",") != "111,222" {
+		t.Fatalf("unexpected folder walk: %+v", seen)
+	}
+}
+
+func TestHandlePushProcess_AllowStubModeContinuesPastStubGate(t *testing.T) {
+	resetGlobals(t)
+
+	sample, err := os.ReadFile(filepath.Join("samples", "stubbed_api_rpc.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := t.TempDir()
+	p := filepath.Join(dir, "123_stubbed.conv.json")
+	if err := os.WriteFile(p, sample, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(orig) }) //nolint:errcheck
+
+	calls := 0
+	srv, _ := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
+		calls++
+		return wrapOp(map[string]interface{}{"proc": "error", "description": "stopped after stub gate"})
+	})
+	setProjectAuth(t, srv.URL)
+
+	result, isErr := handlePushProcess(context.Background(), map[string]interface{}{
+		"process_path":           filepath.Base(p),
+		"allow_active_stub_mode": true,
+	})
+	if !isErr {
+		t.Fatalf("expected downstream deploy error from mock API, got success: %q", result)
+	}
+	if calls == 0 {
+		t.Fatalf("expected push-process to continue to API after allow_active_stub_mode=true; result:\n%s", result)
+	}
+	if strings.Contains(result, "Push blocked: active Stub Mode found") {
+		t.Fatalf("allow_active_stub_mode=true should not return the Stub block message, got:\n%s", result)
+	}
+	if !strings.Contains(result, "stopped after stub gate") {
+		t.Fatalf("expected downstream mock API error, got:\n%s", result)
+	}
+}
+
+func TestPushProcessToolSchema_DocumentsStubModeConfirmation(t *testing.T) {
+	var pushTool *mcpTool
+	for i := range toolRegistry {
+		if toolRegistry[i].Name == "push-process" {
+			pushTool = &toolRegistry[i]
+			break
+		}
+	}
+	if pushTool == nil {
+		t.Fatal("push-process tool not found")
+	}
+	if !strings.Contains(pushTool.Description, "allow_active_stub_mode=true") {
+		t.Fatalf("expected push-process description to mention allow_active_stub_mode=true, got:\n%s", pushTool.Description)
+	}
+
+	inputSchema, ok := pushTool.InputSchema.(map[string]interface{})
+	if !ok {
+		t.Fatalf("unexpected push-process input schema: %#v", pushTool.InputSchema)
+	}
+	schema, ok := inputSchema["properties"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("unexpected push-process input schema: %#v", pushTool.InputSchema)
+	}
+	rawAllow, ok := schema["allow_active_stub_mode"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected allow_active_stub_mode property in push-process schema, got %#v", schema)
+	}
+	desc, _ := rawAllow["description"].(string)
+	for _, want := range []string{"Stub Mode", "obj_type:4", "temporary mock replies"} {
+		if !strings.Contains(desc, want) {
+			t.Fatalf("expected allow_active_stub_mode description to contain %q, got:\n%s", want, desc)
 		}
 	}
 }

--- a/plugins/corezoid/mcp-server/samples/stubbed_api_rpc.json
+++ b/plugins/corezoid/mcp-server/samples/stubbed_api_rpc.json
@@ -1,0 +1,137 @@
+{
+  "conv_type": "process",
+  "description": "Fixture: Call a Process node with Corezoid UI stub/mock replies.",
+  "obj_id": 1,
+  "obj_type": 1,
+  "params": [],
+  "parent_id": 1,
+  "ref_mask": true,
+  "scheme": {
+    "nodes": [
+      {
+        "condition": {
+          "logics": [
+            {
+              "to_node_id": "bbbbbbbbbbbbbbbbbbbbbbbb",
+              "type": "go"
+            }
+          ],
+          "semaphors": []
+        },
+        "description": "",
+        "extra": "{\"modeForm\":\"collapse\",\"icon\":\"\"}",
+        "id": "aaaaaaaaaaaaaaaaaaaaaaaa",
+        "obj_type": 1,
+        "options": null,
+        "title": "Start",
+        "x": 100,
+        "y": 100
+      },
+      {
+        "condition": {
+          "logics": [
+            {
+              "conv_id": 123456,
+              "err_node_id": "dddddddddddddddddddddddd",
+              "extra": {
+                "objId": "{{objId}}"
+              },
+              "extra_type": {
+                "objId": "string"
+              },
+              "group": "all",
+              "type": "api_rpc",
+              "user_id": 66423
+            },
+            {
+              "to_node_id": "cccccccccccccccccccccccc",
+              "type": "go"
+            }
+          ],
+          "semaphors": [],
+          "stub": {
+            "logics": [
+              [
+                {
+                  "conditions": [
+                    {
+                      "cast": "string",
+                      "const": "error",
+                      "fun": "eq",
+                      "param": "{{mode}}"
+                    }
+                  ],
+                  "type": "go_if_const"
+                },
+                {
+                  "exception_reason": "stub error",
+                  "mode": "key_value",
+                  "res_data": {
+                    "status": "error"
+                  },
+                  "res_data_type": {
+                    "status": "string"
+                  },
+                  "throw_exception": true,
+                  "type": "api_rpc_reply"
+                }
+              ],
+              [
+                {
+                  "mode": "keys",
+                  "res_data": [
+                    "stub_node_response"
+                  ],
+                  "res_data_type": {
+                    "stub_node_response": "string"
+                  },
+                  "throw_exception": false,
+                  "type": "api_rpc_reply"
+                }
+              ]
+            ]
+          }
+        },
+        "description": "",
+        "extra": "{\"modeForm\":\"expand\",\"icon\":\"\"}",
+        "id": "bbbbbbbbbbbbbbbbbbbbbbbb",
+        "obj_type": 4,
+        "options": null,
+        "title": "Call with Stub",
+        "x": 100,
+        "y": 300
+      },
+      {
+        "condition": {
+          "logics": [],
+          "semaphors": []
+        },
+        "description": "",
+        "extra": "{\"modeForm\":\"collapse\",\"icon\":\"success\"}",
+        "id": "cccccccccccccccccccccccc",
+        "obj_type": 2,
+        "options": "{\"save_task\":true}",
+        "title": "Final",
+        "x": 100,
+        "y": 500
+      },
+      {
+        "condition": {
+          "logics": [],
+          "semaphors": []
+        },
+        "description": "",
+        "extra": "{\"modeForm\":\"collapse\",\"icon\":\"error\"}",
+        "id": "dddddddddddddddddddddddd",
+        "obj_type": 2,
+        "options": null,
+        "title": "Error",
+        "x": 360,
+        "y": 300
+      }
+    ],
+    "web_settings": []
+  },
+  "status": "active",
+  "title": "Stubbed API RPC"
+}

--- a/plugins/corezoid/mcp-server/tools_registry.go
+++ b/plugins/corezoid/mcp-server/tools_registry.go
@@ -151,7 +151,7 @@ var toolRegistry = []mcpTool{
 	},
 	{
 		Name:        "push-process",
-		Description: "Validate and deploy a process file to Corezoid. Runs lint-process first and blocks the deploy on issues that would break it (broken node links, old-format nodes, RPC paths without reply, nodes missing a default go, sub-30s timers, literal reply values); advisory findings are shown but do not block. Pass force=true to deploy despite blocking lint issues. Note: the server regenerates node IDs on every push and the local file is rewritten in place with the server's canonical scheme — reference nodes by title when iterating, and re-read the file after a push instead of reusing old node IDs.",
+		Description: "Validate and deploy a process file to Corezoid. Runs lint-process first and blocks the deploy on issues that would break it (broken node links, old-format nodes, RPC paths without reply, nodes missing a default go, sub-30s timers, literal reply values); advisory findings are shown but do not block. Active Call Process Stub Mode (obj_type:4) is allowed as a warning only when the target stage is resolved as mutable and non-production-like; immutable/prod/unknown stages are blocked because Stub Mode bypasses the real called process. Pass allow_active_stub_mode=true only after explicit confirmation that the temporary mock behavior is intentional. Pass force=true to deploy despite other blocking lint issues. Note: the server regenerates node IDs on every push and the local file is rewritten in place with the server's canonical scheme — reference nodes by title when iterating, and re-read the file after a push instead of reusing old node IDs.",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
@@ -161,7 +161,11 @@ var toolRegistry = []mcpTool{
 				},
 				"force": map[string]interface{}{
 					"type":        "boolean",
-					"description": "Deploy even if the pre-push lint finds blocking issues. Advisory findings never block. Default false.",
+					"description": "Deploy even if the pre-push lint finds generic blocking issues. Does not confirm active Stub Mode; use allow_active_stub_mode for that. Advisory findings never block. Default false.",
+				},
+				"allow_active_stub_mode": map[string]interface{}{
+					"type":        "boolean",
+					"description": "Explicitly allow deploying active Call Process Stub Mode (obj_type:4) when the target stage is immutable, production-like, or cannot be resolved. Use only after confirming that temporary mock replies are intentionally being deployed.",
 				},
 			},
 			"required": []string{"process_path"},
@@ -191,7 +195,7 @@ var toolRegistry = []mcpTool{
 	},
 	{
 		Name:        "lint-process",
-		Description: "Validate process structure. Reports orphaned nodes, noop conditions, unused set_params, passthrough escalations, shared error clusters (an error node fed by several different failing nodes — each needs its own Reply/Error cluster), old-format nodes (obj_type:0 err_node_id targets, or action logic mixed with go_if_const — the UI would force-convert the process), finals reachable without api_rpc_reply in a process that replies elsewhere (an RPC caller would hang), nodes whose logics do not end with a default go and time semaphors under the 30s server minimum (both reject the deploy), and literal non-string values in api_rpc_reply res_data (a scheme shape that hangs the server commit on push).",
+		Description: "Validate process structure. Reports orphaned nodes, noop conditions, unused set_params, passthrough escalations, shared error clusters (an error node fed by several different failing nodes — each needs its own Reply/Error cluster), old-format nodes (obj_type:0 err_node_id targets, or action logic mixed with go_if_const — the UI would force-convert the process), finals reachable without api_rpc_reply in a process that replies elsewhere (an RPC caller would hang), nodes whose logics do not end with a default go and time semaphors under the 30s server minimum (both reject the deploy), literal non-string values in api_rpc_reply res_data (a scheme shape that hangs the server commit on push), and active Call Process Stub Mode nodes (obj_type:4) that bypass the real called process.",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{

--- a/plugins/corezoid/skills/corezoid-create/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-create/SKILL.md
@@ -71,7 +71,7 @@ Every process follows this base structure:
 |------|----------|------------|
 | Start | 1 | `go` |
 | Code Node | 0 | `api_code` |
-| Call a Process | 0 | `api_rpc` |
+| Call a Process | 0 (`4` only for active Stub Mode) | `api_rpc` |
 | API Call | 0 | `api` |
 | Condition (business flow) | 0 | `go_if_const` |
 | Reply to Process (success, via `go`) | 0 | `api_rpc_reply` |
@@ -126,6 +126,7 @@ Fill in `description` based on the requirements gathered in Step 1 (see Descript
   - **Never mix an action logic with `go_if_const` in one node** (e.g. `set_param` + a conditional branch). That is old format too — the UI converter splits it. Author it as two nodes: the action node's `go` → a separate Condition node. `lint-process` flags both old-format shapes.
   - Never create an Escalation node (`obj_type: 3`) that only contains a bare `go` — that is a passthrough anti-pattern flagged by `lint-process`.
 - **A process invoked via Call a Process (`api_rpc`) must execute `api_rpc_reply` on EVERY path — success included.** The caller's task waits in the Call node until the callee replies; a path that reaches a final without a Reply hangs the caller until its timeout semaphor. Put a collapsed success Reply right before the success final. `lint-process` flags finals reachable without a Reply in any process that replies elsewhere.
+- **Do not create active Stub Mode unless the user explicitly asks for a temporary mock.** Stub Mode is `obj_type: 4` plus `condition.stub`; it bypasses the called process and returns configured mock replies. Use it only while the target process is not ready or for controlled integration tests, and avoid production unless the user explicitly confirms `allow_active_stub_mode=true`.
 - All constants (URLs, tokens, IDs) must be Corezoid variables — never hardcoded:
   1. Check for existing variables: read `_ENV_VARS_.json` (from `pull-folder`) or `.processes/variables.json` (from this session)
   2. Create a new variable if needed: call MCP tool **`create-variable`** with `name`, `description`, `value`
@@ -138,6 +139,7 @@ Fill in `description` based on the requirements gathered in Step 1 (see Descript
 
 - Using `"type": "call_process"` instead of `"type": "api_rpc"` — will fail validation
 - Missing `extra`/`extra_type` in Call a Process node — both required even if empty (`{}`)
+- Leaving active Stub Mode (`obj_type: 4`) in a production path — it returns mock data instead of calling the real process
 - Raw JSON objects as values in `extra` — must be stringified: `"{\"key\":\"val\"}"`
 - Keys in `extra` and `extra_type` must match exactly
 - Missing `rfc_format: true`, `customize_response: true`, or `version: 2` in API Call node

--- a/plugins/corezoid/skills/corezoid-edit/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-edit/SKILL.md
@@ -65,7 +65,7 @@ See `${CLAUDE_PLUGIN_ROOT}/docs/variables-guide.md` for details.
 |------|----------|------------|
 | Start | 1 | `go` |
 | Code Node | 0 | `api_code` |
-| Call a Process | 0 | `api_rpc` |
+| Call a Process | 0 (`4` only for active Stub Mode) | `api_rpc` |
 | API Call | 0 | `api` |
 | Reply to Process | 0 (3 as `err_node_id` target) | `api_rpc_reply` |
 | End / Error | 2 | _(no logics)_ |
@@ -77,6 +77,7 @@ For complete JSON structures see `${CLAUDE_PLUGIN_ROOT}/docs/node-structures.md`
 - **Regenerating the whole scheme instead of editing it in place** — make targeted edits to the pulled file (change the one node/logic you need). Do NOT rewrite every node from scratch: that drops the existing `x`/`y` (the `x:0,y:0` authoring habit is for *brand-new* nodes only), and a scheme where every node is at `0,0` forces `push-process` to re-lay-out the entire process, discarding its arrangement. push re-hydrates coordinates from the server as a safety net, but editing surgically is the right habit.
 - Using `"type": "call_process"` instead of `"type": "api_rpc"` — will fail validation
 - Missing `extra`/`extra_type` in Call a Process node — both required even if empty (`{}`)
+- Treat active Stub Mode (`obj_type: 4` + `condition.stub`) as a temporary mock only: it bypasses the called process and can fake success. Preserve `condition.stub` during round trips, but do not leave `obj_type: 4` enabled on production paths unless the user explicitly confirms `allow_active_stub_mode=true`.
 - Raw JSON objects as values in `extra` — must be stringified: `"{\"key\":\"val\"}"`
 - Keys in `extra` and `extra_type` must match exactly
 

--- a/plugins/corezoid/skills/corezoid/SKILL.md
+++ b/plugins/corezoid/skills/corezoid/SKILL.md
@@ -83,7 +83,7 @@ Workspace
 | Start | 1 | `go` | Entry point |
 | Code Node | 0 | `api_code` | JS/Erlang code execution |
 | API Call | 0 | `api` | External HTTP request |
-| Call a Process | 0 | `api_rpc` | Invoke another process |
+| Call a Process | 0 (`4` when Stub Mode is active) | `api_rpc` | Invoke another process; Stub Mode returns configured mock replies instead |
 | Set Parameters | 0 | `set_param` | Variable assignment |
 | Condition | 0 | `go_if_const` | Branching logic (business flow; `3` when it is an `err_node_id` target) |
 | Reply to Process | 0 | `api_rpc_reply` | Return result to caller (`3` when it is an `err_node_id` target) |
@@ -96,6 +96,9 @@ Workspace
 - All constants (URLs, tokens, IDs) must use `{{env_var[@variable-name]}}` — never hardcoded
 - `extra` and `extra_type` keys must match exactly
 - Object values in `extra` must be stringified JSON strings
+- Active Call Process Stub Mode is `obj_type: 4` plus `condition.stub`; `obj_type: 0` with the same `condition.stub` is inactive and calls the real target process.
+- Use Stub Mode only as a temporary placeholder while the called process is not ready, or as a controlled integration-test fixture. It bypasses the real called process and can hide side effects or fake success in production.
+- `push-process` treats active Stub Mode as warning-only on a resolved mutable non-production-like stage, but blocks immutable, production-like, or unknown stages unless `allow_active_stub_mode=true` is passed after explicit confirmation.
 
 ## Common Operations
 


### PR DESCRIPTION
## Summary

- Add first-class support for Corezoid UI Call Process Stub Mode exports: `obj_type: 4` with `condition.stub.logics`.
- Preserve Stub Mode configuration during pull/push round trips by sending the UI-compatible top-level `stub` payload in node modify ops.
- Teach schema/fixStruct/lint about Stub branches, including Stub `go_if_const` branches without `to_node_id`, `key_value` replies, `keys` replies, typed mock values, and exception replies.
- Add a stage-aware `push-process` safety gate: active Stub Mode is warning-only on a resolved mutable non-production-like stage, but immutable/prod/unknown targets are blocked unless `allow_active_stub_mode=true` is passed after explicit confirmation.
- Update MCP tool descriptions, docs, and core Corezoid skills so agents understand what Stub Mode is, when to use it, and when it is unsafe.

## Context

Call Process Stub Mode is a temporary mock/placeholder for a called process that is not ready yet, or a controlled integration-test fixture. While active, the node does **not** call the real target process; it returns configured mock replies instead. That is useful during development, but dangerous in production because it can hide integration failures, skip real side effects, and return fake success data.

Live investigation showed these Corezoid runtime rules:

- `obj_type: 4` is the actual active Stub Mode switch.
- `condition.stub` alone is not active; with `obj_type: 0`, runtime calls the real target process.
- Stub conditions are evaluated against parameters sent to the called process, so `group: "all"` matters for matching incoming task fields.
- Stub `throw_exception: true` routes through the Call Process `err_node_id`.
- Stub `mode: "keys"` uses the UI/export shape where `res_data` is an array and `res_data_type` remains an object keyed by those names.

Before this change, the plugin schema did not model that shape and `push-process` did not have a dedicated Stub safety gate.

## Safety / Design

- `force=true` does not confirm Stub Mode. `allow_active_stub_mode=true` is intentionally separate and explicit.
- The stage policy resolves the target stage from the process file's `parent_id` by walking folder parents to the stage root, instead of trusting a potentially stale `COREZOID_STAGE_ID`.
- If the target stage cannot be resolved, the gate blocks conservatively.
- Mutable non-production-like stages are warning-only to keep dev/test workflows practical.
- Immutable stages and stages whose title/short name contains production-like tokens (`prod`, `production`, `preprod`) require explicit confirmation.
- No manifest or version files are changed.

## Checklist

- [x] Conventional commit format: `fix(stub): preserve and gate call process stub mode`
- [x] PR targets `main`
- [x] No merge commits in `origin/main..HEAD`
- [x] No credentials, `.env`, private URLs, or hardcoded user paths added
- [x] No plugin manifest/version bump included
- [x] Core docs and agent-facing skills updated together

## Test plan

- `python3 scripts/check-skills-sync.py`
- `python3 -m json.tool` over plugin/marketplace manifests, new Stub schema, changed schemas, and Stub sample fixture
- `sh -n plugins/corezoid/mcp-server/run.sh`
- `git diff --check`
- tracked secret check: `git ls-files | grep -E '\.env$|credentials\.(json|yaml|yml)$'`
- `go build ./...`
- `go vet ./...`
- `go test ./...`
- `go test -race -coverprofile=/tmp/corezoid-stub-coverage.out ./...` (61.3% coverage)
- `go run . --version`
- Live smoke on a sandbox `develop` stage (`immutable: no`): pushing an active Stub process without `allow_active_stub_mode` proceeds as warning-only and still prints the active Stub lint section.

New regression coverage includes:

- Schema-valid Stub export fixture with active `obj_type: 4`
- Inactive `condition.stub` with `obj_type: 0` does not warn
- `ModifyNodes` preserves/toggles Stub Mode and sends top-level `stub`
- Full `ProcessJSON` round trip for a Stubbed Call Process node
- `push-process` blocks active Stub Mode on unknown/immutable targets
- `push-process` allows warning-only Stub Mode on resolved mutable develop targets
- Stage policy resolves the actual stage from process `parent_id`, including nested folders
- `force=true` does not bypass Stub Mode; only `allow_active_stub_mode=true` does
