### PR TITLE
fix(mcp): send project_id in create-folder/create-process (#36)

### DIFF
--- a/plugins/corezoid/mcp-server/create_target_dx_test.go
+++ b/plugins/corezoid/mcp-server/create_target_dx_test.go
@@ -71,6 +71,71 @@ func TestCreateEmptyConv_SendsGivenFolderID(t *testing.T) {
 	}
 }
 
+// ---- project_id accompanies folder_id when creating in a subfolder --------------
+
+// On Corezoid v6.12.0 the server silently drops the new object at stage root
+// unless project_id is present alongside folder_id (issue #36). Both
+// CreateEmptyConv and CreateFolder must send project_id whenever the
+// executor knows its stage — otherwise create-folder / create-process into a
+// subfolder appear to succeed but land in the wrong place.
+
+func TestCreateEmptyConv_SendsProjectIDWhenStageKnown(t *testing.T) {
+	var gotProjectID interface{}
+	call := 0
+	_, e := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
+		call++
+		if call == 1 {
+			// GetProjectIDByStageID → ShowFolder(stageID)
+			return map[string]interface{}{
+				"request_proc": "ok",
+				"ops": []interface{}{map[string]interface{}{
+					"proc": "ok", "obj_id": float64(16089), "parent_obj_id": float64(4242),
+				}},
+			}
+		}
+		gotProjectID = ops[0]["project_id"]
+		return map[string]interface{}{
+			"request_proc": "ok",
+			"ops":          []interface{}{map[string]interface{}{"proc": "ok", "obj_id": float64(777)}},
+		}
+	})
+	e.StageID = 16089
+	if _, err := e.CreateEmptyConv(16091, "t", "", "process"); err != nil {
+		t.Fatalf("CreateEmptyConv: %v", err)
+	}
+	if got, ok := gotProjectID.(float64); !ok || int(got) != 4242 {
+		t.Errorf("project_id on the wire = %v, want 4242", gotProjectID)
+	}
+}
+
+func TestCreateFolder_SendsProjectIDWhenStageKnown(t *testing.T) {
+	var gotProjectID interface{}
+	call := 0
+	_, e := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
+		call++
+		if call == 1 {
+			return map[string]interface{}{
+				"request_proc": "ok",
+				"ops": []interface{}{map[string]interface{}{
+					"proc": "ok", "obj_id": float64(16089), "parent_obj_id": float64(4242),
+				}},
+			}
+		}
+		gotProjectID = ops[0]["project_id"]
+		return map[string]interface{}{
+			"request_proc": "ok",
+			"ops":          []interface{}{map[string]interface{}{"proc": "ok", "obj_id": float64(555)}},
+		}
+	})
+	e.StageID = 16089
+	if _, err := e.CreateFolder(16091, "v2", ""); err != nil {
+		t.Fatalf("CreateFolder: %v", err)
+	}
+	if got, ok := gotProjectID.(float64); !ok || int(got) != 4242 {
+		t.Errorf("project_id on the wire = %v, want 4242", gotProjectID)
+	}
+}
+
 // ---- the server's reason reaches the tool result -------------------------------
 
 // The server explains WHY a create failed ("Stage is immutable", access

--- a/plugins/corezoid/mcp-server/executor_folders.go
+++ b/plugins/corezoid/mcp-server/executor_folders.go
@@ -196,16 +196,22 @@ func (v *Executor) DeleteFolder(folderID int) error {
 
 // CreateFolder creates a new folder under parentFolderID and returns the new folder's obj_id.
 func (v *Executor) CreateFolder(parentFolderID int, title, desc string) (int, error) {
-	ops := []map[string]any{
-		{
-			"title":       title,
-			"description": desc,
-			"folder_id":   parentFolderID,
-			"company_id":  v.WorkspaceID,
-			"obj":         "folder",
-			"type":        "create",
-		},
+	createOp := map[string]any{
+		"title":       title,
+		"description": desc,
+		"folder_id":   parentFolderID,
+		"company_id":  v.WorkspaceID,
+		"obj":         "folder",
+		"type":        "create",
 	}
+	// v6.12.0 silently ignores folder_id when it points to a subfolder unless
+	// project_id is also present — the folder lands at stage root instead.
+	if v.StageID != 0 {
+		if projectID := v.GetProjectIDByStageID(v.StageID); projectID != 0 {
+			createOp["project_id"] = projectID
+		}
+	}
+	ops := []map[string]any{createOp}
 	response, err := v.req("json", ops)
 	if err != nil {
 		return 0, fmt.Errorf("CreateFolder request failed: %w", err)

--- a/plugins/corezoid/mcp-server/executor_process.go
+++ b/plugins/corezoid/mcp-server/executor_process.go
@@ -502,20 +502,26 @@ func (v *Executor) CreateEmptyConv(folderID int, title, desc, convType string) (
 	if convType == "" {
 		convType = "process"
 	}
-	ops := []map[string]any{
-		{
-			"title":       title,
-			"description": desc,
-			"folder_id":   folderID,
-			"company_id":  v.WorkspaceID,
-			"obj":         "conv",
-			"create_mode": "without_nodes",
-			"conv_type":   convType,
-			"type":        "create",
-			"obj_type":    0,
-			"status":      "active",
-		},
+	op := map[string]any{
+		"title":       title,
+		"description": desc,
+		"folder_id":   folderID,
+		"company_id":  v.WorkspaceID,
+		"obj":         "conv",
+		"create_mode": "without_nodes",
+		"conv_type":   convType,
+		"type":        "create",
+		"obj_type":    0,
+		"status":      "active",
 	}
+	// v6.12.0 silently ignores folder_id when it points to a subfolder unless
+	// project_id is also present — the process lands at stage root instead.
+	if v.StageID != 0 {
+		if projectID := v.GetProjectIDByStageID(v.StageID); projectID != 0 {
+			op["project_id"] = projectID
+		}
+	}
+	ops := []map[string]any{op}
 	if v.Debug {
 		logger.Debug("Sending create empty process request")
 	}


### PR DESCRIPTION
## Summary
- `CreateFolder` and `CreateEmptyConv` now attach `project_id` (resolved via `GetProjectIDByStageID(v.StageID)`) to the create op, guarded on a known `StageID`.
- Fixes the silent-drop-to-stage-root bug reported in #36: on Corezoid v6.12.0 the API returns `proc: ok` but ignores `folder_id` unless `project_id` is also present, so `create-folder`/`create-process` into a subfolder landed at the stage root.
- Sibling create paths in the same files (`CreateVariable`, `CreateAlias`, `CreateStageFolder`, ...) already resolved `project_id` the same way — these two were the outliers.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — full suite green
- [x] New tests `TestCreateEmptyConv_SendsProjectIDWhenStageKnown` and `TestCreateFolder_SendsProjectIDWhenStageKnown` assert `project_id` reaches the wire when `StageID` is set
- [ ] Manual smoke: `create-folder folder_name=v2 parent_path=<subfolder>` — folder must land inside the subfolder, not at stage root

Fixes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)