### PR TITLE
fix(mcp): derive create-alias stage from process, not frozen env

### DIFF
--- a/plugins/corezoid/mcp-server/executor_folders.go
+++ b/plugins/corezoid/mcp-server/executor_folders.go
@@ -679,6 +679,36 @@ func (v *Executor) GetProjectIDByStageID(folderID int) int {
 	return 0
 }
 
+// ResolveStageIDByFolder walks up from folderID until it hits a stage
+// (FolderInfo.ObjType == 3). folderID itself may already be the stage. Returns
+// 0 if the walk cannot find one within maxDepth or an API call fails — the
+// caller is expected to fall back to the env COREZOID_STAGE_ID or explicit
+// argument. Used by stage-scoped tools (create-alias, env-var ops) so they can
+// target the stage the process actually lives in instead of blindly trusting
+// the env value, which caused "Object is not in stage" when the two diverged.
+func (v *Executor) ResolveStageIDByFolder(folderID int) (int, error) {
+	const maxDepth = 20
+	if folderID == 0 {
+		return 0, fmt.Errorf("folder id is 0")
+	}
+	currentID := folderID
+	for i := 0; i < maxDepth; i++ {
+		info, err := v.ShowFolder(currentID)
+		if err != nil {
+			return 0, fmt.Errorf("show folder %d: %w", currentID, err)
+		}
+		// obj_type 3 is a stage (per FolderInfo doc), the top of the walk we care about.
+		if info.ObjType == 3 {
+			return info.ObjID, nil
+		}
+		if info.ParentObjID == 0 || info.ParentObjID == info.ObjID {
+			return 0, fmt.Errorf("folder %d has no stage ancestor within %d levels", folderID, i+1)
+		}
+		currentID = info.ParentObjID
+	}
+	return 0, fmt.Errorf("folder walk exceeded %d levels starting from %d", maxDepth, folderID)
+}
+
 
 // envVarProjectID resolves the project for a stage PRESERVING the underlying
 // failure — the bare "could not resolve project for stage N" hid the real

--- a/plugins/corezoid/mcp-server/mcp_handlers_process.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_process.go
@@ -744,8 +744,17 @@ func handleDeleteFolder(ctx context.Context, args map[string]interface{}) (strin
 }
 
 // handleCreateAlias creates a Corezoid alias (short_name → conv) pointing at
-// the process whose ID is encoded in the file path. Requires a configured
-// COREZOID_STAGE_ID since aliases are stage-scoped.
+// the process whose ID is encoded in the file path.
+//
+// Aliases are stage-scoped, so we need to know which stage the target process
+// lives in. Resolution priority:
+//  1. explicit stage_id argument (belt-and-braces override for scripts);
+//  2. stage derived from the process file's parent_id (walk up folders until
+//     obj_type==3) — this is the correct answer for the target process and
+//     avoids the frozen-env failure mode where COREZOID_STAGE_ID pointed at a
+//     different project's stage and the server rejected with the cryptic
+//     "Object is not in stage";
+//  3. COREZOID_STAGE_ID from .env (legacy fallback for pre-parent_id files).
 func handleCreateAlias(ctx context.Context, args map[string]interface{}) (string, bool) {
 	filePath, err := resolveProcessPath(args, "process_path")
 	if err != nil {
@@ -762,13 +771,86 @@ func handleCreateAlias(ctx context.Context, args map[string]interface{}) (string
 	}
 
 	v := NewValidator(ctx, 0)
-	if v.StageID == 0 {
-		return "Error: COREZOID_STAGE_ID environment variable is not set or invalid", true
+
+	stageID, stageSrc, sErr := resolveAliasStageID(v, args, filePath)
+	if sErr != nil {
+		return "Error: " + sErr.Error(), true
 	}
-	aliasID, err := v.CreateAlias(shortName, procID, v.StageID)
+
+	aliasID, err := v.CreateAlias(shortName, procID, stageID)
 	if err != nil {
+		msg := err.Error()
+		if strings.Contains(strings.ToLower(msg), "object is not in stage") {
+			hint := fmt.Sprintf(" — the process (obj_id %d) does not live in stage %d (%s).", procID, stageID, stageSrc)
+			if v.StageID != 0 && v.StageID != stageID {
+				hint += fmt.Sprintf(" COREZOID_STAGE_ID is set to %d; that value was NOT used here.", v.StageID)
+			}
+			hint += " Pass an explicit stage_id, or pull-process this file again so its parent_id points at the current stage."
+			return fmt.Sprintf("Error creating alias: %s%s", msg, hint), true
+		}
 		return fmt.Sprintf("Error creating alias: %v", err), true
 	}
 
-	return fmt.Sprintf("Alias '%s' created successfully, AliasID: %d", shortName, aliasID), false
+	return fmt.Sprintf("Alias '%s' created successfully, AliasID: %d (stage %d, %s)", shortName, aliasID, stageID, stageSrc), false
+}
+
+// resolveAliasStageID picks the stage_id for a create-alias call. It returns
+// the resolved ID, a short label describing where it came from (for user
+// messages), and a hard error only if no source produced a usable stage.
+func resolveAliasStageID(v *Executor, args map[string]interface{}, filePath string) (int, string, error) {
+	if _, ok := args["stage_id"]; ok {
+		s, err := intArg(args, "stage_id")
+		if err != nil {
+			return 0, "", err
+		}
+		if s == 0 {
+			return 0, "", fmt.Errorf("stage_id argument is 0")
+		}
+		return s, "from stage_id argument", nil
+	}
+
+	if parentID, ok := readParentIDFromFile(filePath); ok && parentID != 0 {
+		stage, err := v.ResolveStageIDByFolder(parentID)
+		if err == nil && stage != 0 {
+			label := "derived from process parent_id"
+			if v.StageID != 0 && v.StageID != stage {
+				label = fmt.Sprintf("derived from process parent_id — overrides COREZOID_STAGE_ID=%d", v.StageID)
+			}
+			return stage, label, nil
+		}
+		if err != nil {
+			logger.Warn("create-alias: could not derive stage from parent_id %d: %v", parentID, err)
+		}
+	}
+
+	if v.StageID != 0 {
+		return v.StageID, "from COREZOID_STAGE_ID (fallback — process file had no parent_id)", nil
+	}
+	return 0, "", fmt.Errorf("could not resolve stage_id: process file has no parent_id, no stage_id argument was passed, and COREZOID_STAGE_ID is not set. Re-pull the process (so parent_id is written), pass stage_id explicitly, or set COREZOID_STAGE_ID.")
+}
+
+// readParentIDFromFile reads a .conv.json file just far enough to extract its
+// top-level parent_id. Returns (0, false) on any error — the caller is
+// expected to fall back gracefully; we never fail the tool because a file was
+// unparsable, that's the fallback's job.
+func readParentIDFromFile(filePath string) (int, bool) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return 0, false
+	}
+	var head struct {
+		ParentID interface{} `json:"parent_id"`
+	}
+	if err := json.Unmarshal(data, &head); err != nil {
+		return 0, false
+	}
+	switch p := head.ParentID.(type) {
+	case float64:
+		return int(p), p != 0
+	case string:
+		if n, err := strconv.Atoi(p); err == nil {
+			return n, n != 0
+		}
+	}
+	return 0, false
 }

--- a/plugins/corezoid/mcp-server/mcp_handlers_test.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -242,6 +245,169 @@ func TestHandleToolCall_CreateAlias_BadFilename(t *testing.T) {
 		t.Error("expected isError=true for bad filename")
 	}
 	_ = result
+}
+
+// TestHandleToolCall_CreateAlias_StageMismatchHint verifies that when the
+// server returns "Object is not in stage" (the exact failure mode from
+// issue #26), the tool surfaces a hint that explains stage_id derivation and
+// mentions the configured COREZOID_STAGE_ID when it was NOT used.
+func TestHandleToolCall_CreateAlias_StageMismatchHint(t *testing.T) {
+	resetGlobals(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Fail every op with the exact server phrase we want to detect.
+		json.NewEncoder(w).Encode(map[string]interface{}{ //nolint:errcheck
+			"request_proc": "ok",
+			"ops": []interface{}{map[string]interface{}{
+				"proc":        "error",
+				"description": "Object is not in stage",
+			}},
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	origAccount := accountURL
+	accountURL = srv.URL
+	t.Cleanup(func() { accountURL = origAccount })
+
+	apiURL = srv.URL
+	apiToken = "test-token"
+	workspaceID = "1"
+	stageID = 9026 // frozen (wrong) env stage — the bug from the issue
+
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(dir)                        //nolint:errcheck
+	t.Cleanup(func() { os.Chdir(orig) }) //nolint:errcheck
+
+	p := filepath.Join(dir, "123_proc.conv.json")
+	os.WriteFile(p, []byte(`{"obj_id":123}`), 0644) //nolint:errcheck
+
+	result, isErr := handleToolCall(context.Background(), "create-alias", map[string]interface{}{
+		"process_path": "123_proc.conv.json",
+		"short_name":   "my-alias",
+		"stage_id":     float64(10605), // explicit correct stage
+	})
+	if !isErr {
+		t.Fatalf("expected isError=true when server rejects with 'Object is not in stage', got %q", result)
+	}
+	if !strings.Contains(result, "Object is not in stage") {
+		t.Errorf("expected server error to be surfaced, got %q", result)
+	}
+	if !strings.Contains(result, "COREZOID_STAGE_ID is set to 9026") {
+		t.Errorf("expected hint mentioning frozen env stage, got %q", result)
+	}
+	if !strings.Contains(result, "stage 10605") {
+		t.Errorf("expected hint mentioning attempted stage, got %q", result)
+	}
+}
+
+// TestHandleToolCall_CreateAlias_UsesParentIDFromFile verifies that the tool
+// walks the process's parent_id chain (via ShowFolder) to find the correct
+// stage instead of blindly using COREZOID_STAGE_ID. This is the core fix for
+// issue #26.
+func TestHandleToolCall_CreateAlias_UsesParentIDFromFile(t *testing.T) {
+	resetGlobals(t)
+
+	// Mock server that answers ShowFolder + create_alias flows.
+	// parent_id 555 → stage 10605 (obj_type 3), and create_alias returns ok
+	// only when stage_id in the payload is 10605.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Ops []map[string]interface{} `json:"ops"`
+		}
+		json.NewDecoder(r.Body).Decode(&body) //nolint:errcheck
+		w.Header().Set("Content-Type", "application/json")
+
+		opsOut := make([]interface{}, 0, len(body.Ops))
+		for _, op := range body.Ops {
+			switch op["obj"] {
+			case "folder":
+				id, _ := op["obj_id"].(float64)
+				switch int(id) {
+				case 555: // subfolder → parent = stage
+					opsOut = append(opsOut, map[string]interface{}{
+						"proc":            "ok",
+						"obj_id":          float64(555),
+						"obj_type":        float64(0),
+						"parent_obj_id":   float64(10605),
+						"parent_obj_type": "folder",
+					})
+				case 10605: // the correct stage
+					opsOut = append(opsOut, map[string]interface{}{
+						"proc":            "ok",
+						"obj_id":          float64(10605),
+						"obj_type":        float64(3),
+						"parent_obj_id":   float64(7000),
+						"parent_obj_type": "project",
+					})
+				default:
+					// GetProjectIDByStageID walk (called by CreateAlias) also lands here.
+					opsOut = append(opsOut, map[string]interface{}{
+						"proc":            "ok",
+						"obj_id":          id,
+						"obj_type":        float64(3),
+						"parent_obj_id":   float64(7000),
+						"parent_obj_type": "project",
+					})
+				}
+			case "alias":
+				// Reject if the request tries to create in the wrong stage.
+				stage, _ := op["stage_id"].(float64)
+				if int(stage) != 10605 {
+					opsOut = append(opsOut, map[string]interface{}{
+						"proc":        "error",
+						"description": "Object is not in stage",
+					})
+					continue
+				}
+				opsOut = append(opsOut, map[string]interface{}{
+					"proc":   "ok",
+					"obj_id": float64(9999),
+				})
+			default:
+				opsOut = append(opsOut, map[string]interface{}{"proc": "ok"})
+			}
+		}
+		json.NewEncoder(w).Encode(map[string]interface{}{ //nolint:errcheck
+			"request_proc": "ok",
+			"ops":          opsOut,
+		})
+	}))
+	t.Cleanup(srv.Close)
+
+	origAccount := accountURL
+	accountURL = srv.URL
+	t.Cleanup(func() { accountURL = origAccount })
+
+	apiURL = srv.URL
+	apiToken = "test-token"
+	workspaceID = "1"
+	stageID = 9026 // wrong env stage — the frozen value from the issue
+
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(dir)                        //nolint:errcheck
+	t.Cleanup(func() { os.Chdir(orig) }) //nolint:errcheck
+
+	// parent_id 555 → stage 10605 (per the mock).
+	p := filepath.Join(dir, "123_proc.conv.json")
+	os.WriteFile(p, []byte(`{"obj_id":123,"parent_id":555}`), 0644) //nolint:errcheck
+
+	result, isErr := handleToolCall(context.Background(), "create-alias", map[string]interface{}{
+		"process_path": "123_proc.conv.json",
+		"short_name":   "my-alias",
+	})
+	if isErr {
+		t.Fatalf("expected success; alias should have been created in derived stage 10605, got error: %q", result)
+	}
+	if !strings.Contains(result, "AliasID: 9999") {
+		t.Errorf("expected AliasID in success message, got %q", result)
+	}
+	if !strings.Contains(result, "stage 10605") {
+		t.Errorf("expected derived stage 10605 in success message, got %q", result)
+	}
 }
 
 // ---- modify-task / delete-task argument validation -------------------------

--- a/plugins/corezoid/mcp-server/tools_registry.go
+++ b/plugins/corezoid/mcp-server/tools_registry.go
@@ -375,7 +375,7 @@ var toolRegistry = []mcpTool{
 	},
 	{
 		Name:        "create-alias",
-		Description: "Create a short alias for a Corezoid process.",
+		Description: "Create a short alias for a Corezoid process. Aliases are stage-scoped; the stage is derived from the process file's parent_id (walking up folders until a stage is reached), so a stale COREZOID_STAGE_ID in .env no longer produces the cryptic \"Object is not in stage\" error. Pass stage_id explicitly to override.",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
@@ -386,6 +386,10 @@ var toolRegistry = []mcpTool{
 				"short_name": map[string]interface{}{
 					"type":        "string",
 					"description": "Short alias name for the process",
+				},
+				"stage_id": map[string]interface{}{
+					"type":        "integer",
+					"description": "Optional. Stage the alias should be created in. Defaults to the stage derived from the process file's parent_id, then to COREZOID_STAGE_ID from .env.",
 				},
 			},
 			"required": []string{"process_path", "short_name"},


### PR DESCRIPTION
## Summary
- Fixes #26. `create-alias` no longer blindly trusts `COREZOID_STAGE_ID` snapshotted at MCP spawn — when that value pointed at another project's stage, the server rejected with the cryptic `Object is not in stage`.
- The stage is now derived from the process file's `parent_id`, walking up the folder chain (`ShowFolder`) until it hits a stage (`obj_type == 3`). This lands the alias in the stage the process actually lives in.
- Adds an optional `stage_id` parameter to `create-alias` as an explicit override (issue's suggestion #2).
- On a stage-mismatch server error, the message now names the attempted stage, its source, and the configured `COREZOID_STAGE_ID` when it was NOT used (issue's suggestion #3).

Resolution priority for the alias stage:
1. explicit `stage_id` argument;
2. derived from the process file's `parent_id`;
3. `COREZOID_STAGE_ID` from `.env` (legacy fallback for pre-`parent_id` files).

The `obj_to_id`/`obj_to_type: "conv"` contract mentioned in the issue was already correct in `Executor.CreateAlias`, so no change there.

## Test plan
- [x] `go vet ./...` clean
- [x] `go test -race ./...` — full suite passes (76.5s)
- [x] New `TestHandleToolCall_CreateAlias_UsesParentIDFromFile` verifies the alias is created in the derived stage (`10605`) even when `COREZOID_STAGE_ID=9026`
- [x] New `TestHandleToolCall_CreateAlias_StageMismatchHint` verifies the improved error surfaces both attempted and configured stages
- [ ] Manual: repeat the field scenario from the issue (process in project stage `10605`, env `COREZOID_STAGE_ID=9026`) — expect a successful alias without touching `.env`

🤖 Generated with [Claude Code](https://claude.com/claude-code)