### PR TITLE
docs(code-node-libraries): fix CryptoJS side-effect require examples

### DIFF
--- a/plugins/corezoid/docs/nodes/code-node-libraries.md
+++ b/plugins/corezoid/docs/nodes/code-node-libraries.md
@@ -29,6 +29,24 @@ function. These libraries provide functionality for cryptography, date manipulat
 | RC4         | `require("libs/rc4.js")`         | Implements the RC4 stream cipher                         |
 | Base64      | `require("libs/base64.js")`      | Provides Base64 encoding and decoding functions          |
 
+> **Important — CryptoJS libraries use global side-effect injection, not CommonJS exports.**
+> These libraries do **not** return a value from `require()`. Instead, calling `require()` attaches
+> the `CryptoJS` object to the global scope as a side effect. Do **not** assign the result of
+> `require()` to a variable — doing so creates a local variable that shadows the global `CryptoJS`
+> with `undefined`, causing a `TypeError` on any subsequent method call.
+>
+> **Correct pattern:**
+> ```javascript
+> require("libs/aes.js");        // side-effect: sets global CryptoJS
+> var encrypted = CryptoJS.AES.encrypt(...);  // use global directly
+> ```
+>
+> **Incorrect pattern (breaks with TypeError):**
+> ```javascript
+> var CryptoJS = require("libs/aes.js");  // ← CryptoJS is undefined here
+> var encrypted = CryptoJS.AES.encrypt(...);  // TypeError: Cannot read property 'encrypt' of undefined
+> ```
+
 ### Date and Time Libraries
 
 | Library             | Import Statement                         | Description                                                                       |
@@ -53,7 +71,7 @@ function. These libraries provide functionality for cryptography, date manipulat
 
 ```javascript
 
-  var CryptoJS = require("libs/sha1.js");
+  require("libs/sha1.js");  // sets global CryptoJS — do not assign
 
   // Create a SHA-1 hash
   var hash = CryptoJS.SHA1("message to hash").toString();
@@ -66,7 +84,7 @@ function. These libraries provide functionality for cryptography, date manipulat
 
 ```javascript
 
-  var CryptoJS = require("libs/md5.js");
+  require("libs/md5.js");  // sets global CryptoJS — do not assign
 
   // Create an MD5 hash
   var hash = CryptoJS.MD5(data.password).toString();
@@ -79,7 +97,7 @@ function. These libraries provide functionality for cryptography, date manipulat
 
 ```javascript
 
-  var CryptoJS = require("libs/aes.js");
+  require("libs/aes.js");  // sets global CryptoJS — do not assign
 
   // Encrypt
   var encrypted = CryptoJS.AES.encrypt(data.plaintext, data.secret_key).toString();
@@ -318,7 +336,7 @@ Set an appropriate timeout value based on the complexity of your code:
   try {
     // Require necessary libraries
     var moment = require("libs/moment.js");
-    var CryptoJS = require("libs/sha256.js");
+    require("libs/sha256.js");  // sets global CryptoJS — do not assign
 
     // Process dates
     var now = moment();


### PR DESCRIPTION
## Summary

- Remove incorrect `var CryptoJS = require(...)` assignment from all CryptoJS library examples (SHA-1, MD5, AES, and the complex-example section)
- Add an explanatory warning block in the Cryptographic Libraries table section that shows the correct vs. broken import pattern and explains the global side-effect loading model
- `libs/dateutils.js` already used the correct side-effect pattern; CryptoJS examples now match it

## Root cause

CryptoJS libraries in the Code node runtime do **not** implement CommonJS `module.exports` — they attach `CryptoJS` to the global scope as a side effect of `require()`. The documented examples used `var CryptoJS = require(...)`, which creates a local variable that shadows the global with `undefined`. Any subsequent call like `CryptoJS.AES.encrypt(...)` then throws `TypeError: Cannot read property 'encrypt' of undefined`, even though the library loaded successfully.

## Context

tool: api_code (Code node, lang=js) | version: 2.3.5 | install: 5205199f-7e45-4e69-9f55-45ab3982f971

Repro: process_id 1893736 (workspace aa077fc6-22e8-426f-bfdd-ceb5316ae182) — snapshots v1–2 show the broken pattern copied from docs; snapshots v5+ show the working workaround (require without assignment).

## Checklist

- [x] Documentation-only change — no build/test steps apply
- [x] All manifest JSON files validated (`python3 -m json.tool`) — no changes
- [x] No version bump / CHANGELOG.md change included
- [x] No credentials or private URLs introduced

## Test plan

- Open Code node, paste `require("libs/aes.js"); var enc = CryptoJS.AES.encrypt("hello", "key").toString(); data.enc = enc;` — confirm no TypeError
- Confirm `var CryptoJS = require("libs/aes.js"); CryptoJS.AES.encrypt(...)` still fails as expected (runtime behaviour unchanged; docs now warn against this pattern)