### PR TITLE
feat(git): add Corezoid git-mirror context integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,7 @@ plugins/corezoid/
     corezoid-access/                — Share processes/folders, manage groups/API keys
     corezoid-retro/                 — End-of-session retrospective: route learnings to CLAUDE.md, feedback, settings, or memory
     corezoid-feedback/              — Collect and submit bug reports / improvement requests to the Corezoid team
+    corezoid-git-context/           — Analyse session changes and update _ext/docs/*.md in the Corezoid git mirror
     marketplace-publish-validation/ — Pre-publication checklist for the Corezoid marketplace
   docs/
     nodes/                        — Per-node-type documentation (24 node types)

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The plugin bundles a Go MCP server that exposes Corezoid operations as MCP tools
 | `corezoid-feedback`            | "report a bug", "this is broken", "send feedback" | Collect and submit bug reports / improvement requests |
 | `marketplace-publish-validation` | "publish to marketplace", "check before publish" | Pre-publication checklist for Corezoid marketplace |
 | `corezoid-gitcall`             | "git call", "gitcall", "run my code", "custom code node", "python/go/php in a process" | Custom code (Python/Go/Java/PHP/JS/…) as a git_call step — parsing, libraries, crypto, attachments; handles the container build on push |
+| `corezoid-git-context`         | after a substantial session, "update git context", "sync context" | Analyse session changes and update `_ext/docs/*.md` in the Corezoid git mirror |
 
 ## Design philosophy
 
@@ -277,6 +278,10 @@ validation errors, and summarize what each process does.
 | `list-snapshots`    | List all snapshots for a process with version, title, author and creation time |
 | `delete-snapshot`   | Delete a snapshot by its obj_id |
 | `get-snapshot`      | Get the node list of a specific snapshot for diff comparison |
+| `git-pull-context`  | Clone or pull the Corezoid git mirror into `.git-context/` |
+| `git-push-context`  | Commit and push `_ext/` changes to the git mirror  |
+| `read-context-file` | Read a file from `.git-context/`                   |
+| `update-context-file` | Write or append to a file inside `_ext/`         |
 
 ## Feedback
 

--- a/plugins/corezoid/mcp-server/git-sync-local.go
+++ b/plugins/corezoid/mcp-server/git-sync-local.go
@@ -1,0 +1,408 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+const (
+	mirrorBeginMarker = "<!-- BEGIN corezoid-mirror (auto-generated, do not edit inside) -->"
+	mirrorEndMarker   = "<!-- END corezoid-mirror -->"
+)
+
+// isLocalOnlyContext returns true when .git-context/.git exists but has no
+// remote configured — i.e. the plugin is running in offline / local mode.
+func isLocalOnlyContext(ctx context.Context, contextDir string) bool {
+	out, err := runGit(ctx, contextDir, "remote", "-v")
+	return err == nil && strings.TrimSpace(out) == ""
+}
+
+// detectStageName scans workDir for a directory whose name starts with
+// "<stageID>_" and ends with ".stage", ".folder", or ".project" and returns
+// the part between them (e.g. "1511196_develop.stage" → "develop").
+// Falls back to the numeric stage ID as a string if nothing is found.
+func detectStageName(workDir string, stageID int) string {
+	prefix := fmt.Sprintf("%d_", stageID)
+	entries, _ := os.ReadDir(workDir)
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		for _, sfx := range []string{".stage", ".folder", ".project"} {
+			if strings.HasSuffix(name, sfx) {
+				// "<stageID>_<name>.stage" → "<name>"
+				return name[len(prefix) : len(name)-len(sfx)]
+			}
+		}
+	}
+	return fmt.Sprintf("%d", stageID)
+}
+
+// initLocalGitContext creates (or ensures) the .git-context/ structure for
+// local / offline mode:
+//   - stages/<stageID>_<name>/_ext/docs/
+//   - git init (if not already present)
+//   - an initial empty commit so git-stash works later
+//
+// Returns the relative stage path (e.g. "stages/1511196_develop").
+func initLocalGitContext(ctx context.Context) (string, error) {
+	sid := func() int {
+		authStateMu.RLock()
+		defer authStateMu.RUnlock()
+		return stageID
+	}()
+	if sid == 0 {
+		return "", fmt.Errorf("COREZOID_STAGE_ID not set")
+	}
+
+	workDir, _ := os.Getwd()
+	stageName := detectStageName(workDir, sid)
+	stagePath := fmt.Sprintf("stages/%d_%s", sid, stageName)
+	contextDir := gitContextDir()
+
+	// Create directory structure.
+	extDocsDir := filepath.Join(contextDir, filepath.FromSlash(stagePath), "_ext", "docs")
+	if err := os.MkdirAll(extDocsDir, 0755); err != nil {
+		return "", fmt.Errorf("cannot create local context dirs: %w", err)
+	}
+
+	gitDir := filepath.Join(contextDir, ".git")
+	if _, err := os.Stat(gitDir); err != nil {
+		// Fresh init.
+		if out, err := runGit(ctx, contextDir, "init"); err != nil {
+			return "", fmt.Errorf("git init failed: %s", out)
+		}
+		// Configure a local identity so commits work on unconfigured machines.
+		runGit(ctx, contextDir, "config", "user.email", "corezoid-plugin@local") //nolint:errcheck
+		runGit(ctx, contextDir, "config", "user.name", "Corezoid Plugin")        //nolint:errcheck
+		// Empty initial commit so there's always a HEAD to diff/branch/reset against.
+		if out, err := runGit(ctx, contextDir, "commit", "--allow-empty", "-m", "init: local git context"); err != nil {
+			return "", fmt.Errorf("initial commit failed: %s", out)
+		}
+		if err := ensureGitignoreEntry(workDir, ".git-context/"); err != nil {
+			logger.Warn("git-pull-context: could not update project .gitignore: %v", err)
+		}
+	}
+
+	logger.Info("git-pull-context: local context ready at %s", stagePath)
+	return stagePath, nil
+}
+
+// processEntry holds minimal metadata extracted from a .conv.json file.
+type processEntry struct {
+	Title string
+	ObjID int
+	Path  string // relative to workDir, forward slashes
+}
+
+// scanProcessFiles walks workDir and collects all .conv.json process entries.
+func scanProcessFiles(workDir string) []processEntry {
+	var entries []processEntry
+	filepath.WalkDir(workDir, func(path string, d os.DirEntry, err error) error { //nolint:errcheck
+		if err != nil || d.IsDir() || !strings.HasSuffix(d.Name(), ".conv.json") {
+			return nil
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil
+		}
+		var meta struct {
+			Title string `json:"title"`
+			ObjID int    `json:"obj_id"`
+		}
+		if jsonErr := json.Unmarshal(data, &meta); jsonErr != nil {
+			return nil
+		}
+		rel, _ := filepath.Rel(workDir, path)
+		entries = append(entries, processEntry{
+			Title: meta.Title,
+			ObjID: meta.ObjID,
+			Path:  filepath.ToSlash(rel),
+		})
+		return nil
+	})
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Path < entries[j].Path })
+	return entries
+}
+
+// docFileOrder defines the canonical order and section titles for _ext/docs/ files,
+// matching the format the git mirror bot uses for Developer Notes.
+var docFileOrder = []struct{ file, title string }{
+	{"context.md", "Context"},
+	{"invariants.md", "Invariants"},
+	{"decisions.md", "Decisions"},
+	{"dependencies.md", "Dependencies"},
+	{"issues.md", "Issues"},
+}
+
+// buildMirrorBlock generates the corezoid-mirror CLAUDE.md block.
+// It assembles Developer Notes from _ext/docs/*.md (matching mirror-bot format),
+// followed by the process index. Both sections live inside the mirror markers so
+// the real mirror bot will overwrite cleanly when Gitea becomes available.
+func buildMirrorBlock(stageID int, stageName, extDocsDir string, processes []processEntry) string {
+	var sb strings.Builder
+	sb.WriteString(mirrorBeginMarker + "\n")
+
+	// --- Developer Notes from _ext/docs/ ---
+	var notesSB strings.Builder
+	for _, df := range docFileOrder {
+		data, err := os.ReadFile(filepath.Join(extDocsDir, df.file))
+		if err != nil || strings.TrimSpace(string(data)) == "" {
+			continue // skip missing or empty files — no empty section headers
+		}
+		notesSB.WriteString(fmt.Sprintf("### %s\n\n", df.title))
+		notesSB.WriteString(strings.TrimRight(string(data), "\n") + "\n\n")
+	}
+	if notesSB.Len() > 0 {
+		sb.WriteString("## Developer Notes\n\n")
+		sb.WriteString(notesSB.String())
+	}
+
+	// --- Process index ---
+	sb.WriteString(fmt.Sprintf("## Stage %d_%s process index\n\n", stageID, stageName))
+	for _, p := range processes {
+		title := p.Title
+		if title == "" {
+			title = fmt.Sprintf("Process %d", p.ObjID)
+		}
+		sb.WriteString(fmt.Sprintf("- %s  `%s`  (id %d)\n", title, p.Path, p.ObjID))
+	}
+	sb.WriteString(mirrorEndMarker + "\n")
+	return sb.String()
+}
+
+// injectMirrorBlock replaces the corezoid-mirror block inside existing content,
+// or prepends a new block if none is present.
+// Content outside the markers (e.g. Developer Notes added by the skill) is preserved.
+func injectMirrorBlock(existing, newBlock string) string {
+	start := strings.Index(existing, mirrorBeginMarker)
+	end := strings.Index(existing, mirrorEndMarker)
+	if start != -1 && end != -1 && end > start {
+		before := existing[:start]
+		after := strings.TrimPrefix(existing[end+len(mirrorEndMarker):], "\n")
+		return before + newBlock + "\n" + after
+	}
+	return newBlock + "\n" + existing
+}
+
+// generateLocalCLAUDEMD scans local .conv.json files and writes a CLAUDE.md
+// into .git-context/<stagePath>/ and into the project root.
+// Commits the result to the local repo.
+func generateLocalCLAUDEMD(ctx context.Context, stagePath string) error {
+	sid := func() int {
+		authStateMu.RLock()
+		defer authStateMu.RUnlock()
+		return stageID
+	}()
+
+	workDir, _ := os.Getwd()
+	contextDir := gitContextDir()
+	stageName := detectStageName(workDir, sid)
+
+	extDocsDir := filepath.Join(contextDir, filepath.FromSlash(stagePath), "_ext", "docs")
+	processes := scanProcessFiles(workDir)
+	newBlock := buildMirrorBlock(sid, stageName, extDocsDir, processes)
+
+	stageClaudeFile := filepath.Join(contextDir, filepath.FromSlash(stagePath), "CLAUDE.md")
+	rootClaude := filepath.Clean(filepath.Join(contextDir, "..", "CLAUDE.md"))
+
+	// Merge against the actual project-root CLAUDE.md (not the stage-tracked
+	// copy) — that's the file we're about to overwrite, so it's the one whose
+	// outside-marker content must be preserved. injectMirrorBlock replaces
+	// only the mirror block, keeping anything a developer added outside it.
+	var existing string
+	if data, err := os.ReadFile(rootClaude); err == nil {
+		existing = string(data)
+	}
+	merged := injectMirrorBlock(existing, newBlock)
+
+	if err := os.WriteFile(stageClaudeFile, []byte(merged), 0644); err != nil {
+		return fmt.Errorf("cannot write stage CLAUDE.md: %w", err)
+	}
+
+	// Copy to project root so Claude Code picks it up as context.
+	if err := os.WriteFile(rootClaude, []byte(merged), 0644); err != nil {
+		logger.Warn("git-pull-context: could not write CLAUDE.md to project root: %v", err)
+	}
+
+	// Commit only if something changed.
+	runGit(ctx, contextDir, "add", filepath.Join(filepath.FromSlash(stagePath), "CLAUDE.md")) //nolint:errcheck
+	if _, noChanges := runGit(ctx, contextDir, "diff", "--cached", "--quiet"); noChanges != nil {
+		runGit(ctx, contextDir, "commit", "-m", //nolint:errcheck
+			fmt.Sprintf("docs: regenerate CLAUDE.md for stage %d", sid))
+	}
+
+	logger.Info("git-pull-context: local CLAUDE.md written (%d processes, docs=%s)",
+		len(processes), extDocsDir)
+	return nil
+}
+
+// getDefaultBranch queries the remote for its HEAD branch name (master/main/…).
+func getDefaultBranch(ctx context.Context, dir string) string {
+	out, err := runGit(ctx, dir, "remote", "show", "origin")
+	if err != nil {
+		return "master"
+	}
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "HEAD branch:") {
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) == 2 {
+				return strings.TrimSpace(parts[1])
+			}
+		}
+	}
+	return "master"
+}
+
+// reconnectToGitea transitions .git-context/ from local-only mode to a real
+// Gitea remote:
+//  1. Add remote + fetch (validates connectivity)
+//  2. Back up the full offline history (branch) and snapshot _ext/ on disk —
+//     `git stash` alone is not enough here because gitPushContext commits
+//     _ext/ edits straight to HEAD in local mode, so by the time we reconnect
+//     there is usually nothing left uncommitted for stash to catch.
+//  3. Reset hard to remote state
+//  4. Restore _ext/ from the on-disk snapshot (not stash pop)
+//  5. Push merged _ext/ to remote
+//
+// The backup branch is kept (not deleted) so a user can recover anything the
+// _ext/-only snapshot didn't cover (e.g. they'd committed outside _ext/ by hand).
+func reconnectToGitea(ctx context.Context, repoURL, gLogin, gSecret string) error {
+	targetDir := gitContextDir()
+
+	// Add remote (plain URL — no credentials embedded, see runGitAuthed).
+	if out, err := runGit(ctx, targetDir, "remote", "add", "origin", repoURL); err != nil {
+		return fmt.Errorf("remote add failed: %s", out)
+	}
+
+	// Fetch — proves Gitea is reachable.
+	if out, err := runGitAuthed(ctx, targetDir, gLogin, gSecret, "fetch", "origin"); err != nil {
+		runGit(ctx, targetDir, "remote", "remove", "origin") //nolint:errcheck (rollback)
+		return fmt.Errorf("fetch failed: %s", out)
+	}
+
+	branch := getDefaultBranch(ctx, targetDir)
+
+	// Preserve the entire offline history under a recovery branch before
+	// discarding it from the working branch — reset --hard below would
+	// otherwise drop every commit made while offline, not just uncommitted
+	// edits.
+	backupBranch := fmt.Sprintf("corezoid-local-backup-%s", strings.TrimSpace(headShortSHA(ctx, targetDir)))
+	if out, err := runGit(ctx, targetDir, "branch", backupBranch, "HEAD"); err != nil {
+		logger.Warn("git-pull-context: could not create backup branch %s before reconnect: %s", backupBranch, out)
+	}
+
+	// Snapshot the current _ext/ tree from disk. This captures both committed
+	// and uncommitted offline edits, unlike `git stash` which only sees
+	// uncommitted changes.
+	extDir := filepath.Join(targetDir, "_ext")
+	snapshotDir, snapErr := os.MkdirTemp("", "corezoid-ext-snapshot-*")
+	hasSnapshot := false
+	if snapErr != nil {
+		logger.Warn("git-pull-context: could not create temp dir for _ext/ snapshot: %v", snapErr)
+	} else {
+		defer os.RemoveAll(snapshotDir)
+		if _, statErr := os.Stat(extDir); statErr == nil {
+			if err := copyDirRecursive(extDir, snapshotDir); err != nil {
+				logger.Warn("git-pull-context: could not snapshot _ext/ before reconnect: %v", err)
+			} else {
+				hasSnapshot = true
+			}
+		}
+	}
+
+	// Reset to remote — take authoritative mirror state.
+	if out, err := runGit(ctx, targetDir, "reset", "--hard", "origin/"+branch); err != nil {
+		return fmt.Errorf("reset to remote failed: %s", out)
+	}
+
+	// Restore the offline _ext/ snapshot over the freshly-reset tree.
+	if hasSnapshot {
+		if err := os.RemoveAll(extDir); err != nil && !os.IsNotExist(err) {
+			logger.Warn("git-pull-context: could not clear _ext/ before restore: %v", err)
+		}
+		if err := copyDirRecursive(snapshotDir, extDir); err != nil {
+			logger.Warn("git-pull-context: could not restore _ext/ snapshot after reconnect (offline history is still available on branch %s): %v", backupBranch, err)
+		}
+	}
+
+	// Push merged _ext/ if anything changed.
+	runGit(ctx, targetDir, "add", "_ext/") //nolint:errcheck
+	if _, noChanges := runGit(ctx, targetDir, "diff", "--cached", "--quiet"); noChanges != nil {
+		runGit(ctx, targetDir, "commit", "-m", "docs: merge local offline context on reconnect") //nolint:errcheck
+	}
+	if gitHasUnpushedCommits(ctx, targetDir) {
+		if out, err := runGitAuthed(ctx, targetDir, gLogin, gSecret, "push", "origin", branch); err != nil {
+			logger.Warn("git-pull-context: reconnect push failed: %s", out)
+		}
+	}
+
+	logger.Info("git-pull-context: reconnected to Gitea (branch=%s, offline history backed up to %s)", branch, backupBranch)
+	return nil
+}
+
+// headShortSHA returns the short SHA of HEAD, used to make backup branch
+// names unique across repeated reconnect attempts. Falls back to "unknown".
+func headShortSHA(ctx context.Context, dir string) string {
+	out, err := runGit(ctx, dir, "rev-parse", "--short", "HEAD")
+	if err != nil {
+		return "unknown"
+	}
+	return strings.TrimSpace(out)
+}
+
+// copyDirRecursive copies the contents of src into dst, creating dst if
+// needed. Used to snapshot/restore _ext/ around a `git reset --hard` where
+// git's own stash/checkout machinery isn't reliable for already-committed
+// content (see reconnectToGitea).
+func copyDirRecursive(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, relErr := filepath.Rel(src, path)
+		if relErr != nil {
+			return relErr
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0755)
+		}
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0755); err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, 0644)
+	})
+}
+
+// resolveExtConflicts auto-resolves merge conflicts in _ext/ by taking the
+// remote version for every conflicted file. The skill will reconcile any lost
+// local content on the next session run.
+func resolveExtConflicts(ctx context.Context, dir string) {
+	conflicted, err := runGit(ctx, dir, "diff", "--name-only", "--diff-filter=U")
+	if err != nil {
+		return
+	}
+	for _, f := range strings.Split(strings.TrimSpace(conflicted), "\n") {
+		if f == "" || !strings.HasPrefix(filepath.ToSlash(f), "_ext/") {
+			continue
+		}
+		runGit(ctx, dir, "checkout", "--theirs", "--", f) //nolint:errcheck
+		runGit(ctx, dir, "add", "--", f)                  //nolint:errcheck
+		logger.Warn("git-pull-context: conflict in %s auto-resolved (remote wins) — skill will reconcile next session", f)
+	}
+}

--- a/plugins/corezoid/mcp-server/git-sync-local.go
+++ b/plugins/corezoid/mcp-server/git-sync-local.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -272,23 +273,31 @@ func getDefaultBranch(ctx context.Context, dir string) string {
 //     _ext/ edits straight to HEAD in local mode, so by the time we reconnect
 //     there is usually nothing left uncommitted for stash to catch.
 //  3. Reset hard to remote state
-//  4. Restore _ext/ from the on-disk snapshot (not stash pop)
+//  4. Merge the on-disk _ext/ snapshot into the freshly-reset tree (not stash
+//     pop, and not a blind overwrite either — see mergeExtSnapshot): files
+//     that only existed locally are restored, files identical on both sides
+//     are left alone, and files that genuinely conflict keep the remote
+//     version in place while the local version is saved alongside instead of
+//     being silently discarded.
 //  5. Push merged _ext/ to remote
 //
 // The backup branch is kept (not deleted) so a user can recover anything the
 // _ext/-only snapshot didn't cover (e.g. they'd committed outside _ext/ by hand).
-func reconnectToGitea(ctx context.Context, repoURL, gLogin, gSecret string) error {
+// Returns a human-readable summary (reconnect result + any conflicts found) so
+// callers can surface it all the way to the MCP tool response, not just the
+// server log.
+func reconnectToGitea(ctx context.Context, repoURL, gLogin, gSecret string) (string, error) {
 	targetDir := gitContextDir()
 
 	// Add remote (plain URL — no credentials embedded, see runGitAuthed).
 	if out, err := runGit(ctx, targetDir, "remote", "add", "origin", repoURL); err != nil {
-		return fmt.Errorf("remote add failed: %s", out)
+		return "", fmt.Errorf("remote add failed: %s", out)
 	}
 
 	// Fetch — proves Gitea is reachable.
 	if out, err := runGitAuthed(ctx, targetDir, gLogin, gSecret, "fetch", "origin"); err != nil {
 		runGit(ctx, targetDir, "remote", "remove", "origin") //nolint:errcheck (rollback)
-		return fmt.Errorf("fetch failed: %s", out)
+		return "", fmt.Errorf("fetch failed: %s", out)
 	}
 
 	branch := getDefaultBranch(ctx, targetDir)
@@ -323,16 +332,16 @@ func reconnectToGitea(ctx context.Context, repoURL, gLogin, gSecret string) erro
 
 	// Reset to remote — take authoritative mirror state.
 	if out, err := runGit(ctx, targetDir, "reset", "--hard", "origin/"+branch); err != nil {
-		return fmt.Errorf("reset to remote failed: %s", out)
+		return "", fmt.Errorf("reset to remote failed: %s", out)
 	}
 
-	// Restore the offline _ext/ snapshot over the freshly-reset tree.
+	// Merge the offline _ext/ snapshot into the freshly-reset (remote) tree.
+	var conflicts []string
 	if hasSnapshot {
-		if err := os.RemoveAll(extDir); err != nil && !os.IsNotExist(err) {
-			logger.Warn("git-pull-context: could not clear _ext/ before restore: %v", err)
-		}
-		if err := copyDirRecursive(snapshotDir, extDir); err != nil {
-			logger.Warn("git-pull-context: could not restore _ext/ snapshot after reconnect (offline history is still available on branch %s): %v", backupBranch, err)
+		var mergeErr error
+		conflicts, mergeErr = mergeExtSnapshot(snapshotDir, extDir)
+		if mergeErr != nil {
+			logger.Warn("git-pull-context: could not merge _ext/ snapshot after reconnect (offline history is still available on branch %s): %v", backupBranch, mergeErr)
 		}
 	}
 
@@ -347,8 +356,59 @@ func reconnectToGitea(ctx context.Context, repoURL, gLogin, gSecret string) erro
 		}
 	}
 
-	logger.Info("git-pull-context: reconnected to Gitea (branch=%s, offline history backed up to %s)", branch, backupBranch)
-	return nil
+	msg := fmt.Sprintf("reconnected to Gitea (branch=%s, offline history backed up to %s)", branch, backupBranch)
+	if len(conflicts) > 0 {
+		msg += fmt.Sprintf("\n%d file(s) in _ext/ changed on the remote while offline and conflict with your local edits — remote version kept, local version saved alongside as '<file>.local-conflict' (full offline history is on branch %s):\n  - %s",
+			len(conflicts), backupBranch, strings.Join(conflicts, "\n  - "))
+	}
+	logger.Info("git-pull-context: %s", msg)
+	return msg, nil
+}
+
+// mergeExtSnapshot restores snapshotDir (the pre-reconnect local _ext/ state)
+// into extDir (the just-reset, remote _ext/ state), file by file:
+//   - a file that only exists locally is restored as-is (pure local addition)
+//   - a file that exists in both and is byte-identical is left alone
+//   - a file that exists in both and differs is a genuine conflict: the remote
+//     version stays in place (consistent with "remote wins" everywhere else in
+//     the mirror), the local version is written alongside as
+//     "<file>.local-conflict" instead of being silently discarded, and its
+//     path is returned so the caller can surface it instead of only logging it.
+func mergeExtSnapshot(snapshotDir, extDir string) ([]string, error) {
+	var conflicts []string
+	err := filepath.WalkDir(snapshotDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(snapshotDir, path)
+		if relErr != nil {
+			return relErr
+		}
+		localData, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		remotePath := filepath.Join(extDir, rel)
+		remoteData, remoteErr := os.ReadFile(remotePath)
+		switch {
+		case os.IsNotExist(remoteErr):
+			if err := os.MkdirAll(filepath.Dir(remotePath), 0755); err != nil {
+				return err
+			}
+			return os.WriteFile(remotePath, localData, 0644)
+		case remoteErr != nil:
+			return remoteErr
+		case bytes.Equal(localData, remoteData):
+			return nil
+		default:
+			conflicts = append(conflicts, filepath.ToSlash(rel))
+			return os.WriteFile(remotePath+".local-conflict", localData, 0644)
+		}
+	})
+	return conflicts, err
 }
 
 // headShortSHA returns the short SHA of HEAD, used to make backup branch
@@ -387,22 +447,4 @@ func copyDirRecursive(src, dst string) error {
 		}
 		return os.WriteFile(target, data, 0644)
 	})
-}
-
-// resolveExtConflicts auto-resolves merge conflicts in _ext/ by taking the
-// remote version for every conflicted file. The skill will reconcile any lost
-// local content on the next session run.
-func resolveExtConflicts(ctx context.Context, dir string) {
-	conflicted, err := runGit(ctx, dir, "diff", "--name-only", "--diff-filter=U")
-	if err != nil {
-		return
-	}
-	for _, f := range strings.Split(strings.TrimSpace(conflicted), "\n") {
-		if f == "" || !strings.HasPrefix(filepath.ToSlash(f), "_ext/") {
-			continue
-		}
-		runGit(ctx, dir, "checkout", "--theirs", "--", f) //nolint:errcheck
-		runGit(ctx, dir, "add", "--", f)                  //nolint:errcheck
-		logger.Warn("git-pull-context: conflict in %s auto-resolved (remote wins) — skill will reconcile next session", f)
-	}
 }

--- a/plugins/corezoid/mcp-server/git-sync.go
+++ b/plugins/corezoid/mcp-server/git-sync.go
@@ -169,6 +169,31 @@ func runGit(ctx context.Context, dir string, args ...string) (string, error) {
 	return string(out), err
 }
 
+// stripEnvKeys returns env with any existing entries for the given keys
+// removed. Go's exec.Cmd (and the underlying getenv-style lookups many
+// programs, including git, perform) resolves duplicate keys to the *first*
+// match — so simply appending our own GIT_CONFIG_* entries after os.Environ()
+// is not enough if the invoking shell/IDE already sets one of them: git would
+// read that pre-existing entry and silently ignore our Basic-auth header,
+// failing with a confusing 401 instead of authenticating.
+func stripEnvKeys(env []string, keys ...string) []string {
+	out := env[:0:0] // fresh backing array — never mutate the caller's slice in place
+	for _, kv := range env {
+		key, _, _ := strings.Cut(kv, "=")
+		skip := false
+		for _, k := range keys {
+			if key == k {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			out = append(out, kv)
+		}
+	}
+	return out
+}
+
 // runGitAuthed runs a git command with per-invocation HTTP Basic auth for the
 // Corezoid git mirror, for network operations (clone/fetch/pull/push) against
 // a credential-free URL (see buildGitRepoURL).
@@ -184,6 +209,8 @@ func runGitAuthed(ctx context.Context, dir, login, secret string, args ...string
 	cmd.Dir = dir
 	env := append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
 	if login != "" || secret != "" {
+		// Strip any pre-existing GIT_CONFIG_* entries first — see stripEnvKeys.
+		env = stripEnvKeys(env, "GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0")
 		encoded := base64.StdEncoding.EncodeToString([]byte(login + ":" + secret))
 		env = append(env,
 			"GIT_CONFIG_COUNT=1",
@@ -374,7 +401,27 @@ func gitPushContext(ctx context.Context, commitMsg string) (string, error) {
 	localOnly := isLocalOnlyContext(ctx, targetDir)
 
 	if !localOnly {
-		// Sync with remote first (--autostash handles local modifications).
+		// Defensive: revert any non-_ext/ working-tree modifications to HEAD
+		// before the pull. --autostash below stashes ALL uncommitted changes
+		// (index + worktree), not just _ext/ — if a non-_ext/ file were
+		// modified (nothing in normal operation should touch .git-context/
+		// outside _ext/, but this guards against it regardless), autostash
+		// would scoop it up too, and a stash-pop conflict after the rebase
+		// would leave the repo half-rebased *before* the non-_ext/
+		// safety-unstage step below ever gets a chance to run. Reverting
+		// first means autostash only ever has to carry _ext/ changes through
+		// the rebase, which is the one case it's meant to handle.
+		if out, err := runGit(ctx, targetDir, "diff", "HEAD", "--name-only"); err == nil {
+			for _, f := range strings.Split(strings.TrimSpace(out), "\n") {
+				if f == "" || strings.HasPrefix(filepath.ToSlash(f), "_ext/") {
+					continue
+				}
+				runGit(ctx, targetDir, "checkout", "HEAD", "--", f) //nolint:errcheck
+				logger.Warn("git-push-context: reverted unexpected non-_ext/ working-tree change to %q before pull", f)
+			}
+		}
+
+		// Sync with remote first (--autostash handles local _ext/ modifications).
 		if out, err := runGitAuthed(ctx, targetDir, gLogin, gSecret, "pull", "--rebase", "--autostash", "origin"); err != nil {
 			return "", fmt.Errorf("git pull before push failed: %s", maskSecret(out, gSecret))
 		}

--- a/plugins/corezoid/mcp-server/git-sync.go
+++ b/plugins/corezoid/mcp-server/git-sync.go
@@ -221,11 +221,12 @@ func gitPullContext(ctx context.Context) (string, error) {
 				if projectID := resolveProjectID(ctx); projectID != 0 {
 					repoURL, buildErr := buildGitRepoURL(gURL, gCompany, strconv.Itoa(projectID))
 					if buildErr == nil {
-						if reconnErr := reconnectToGitea(ctx, repoURL, gLogin, gSecret); reconnErr != nil {
+						reconnMsg, reconnErr := reconnectToGitea(ctx, repoURL, gLogin, gSecret)
+						if reconnErr != nil {
 							logger.Warn("git-pull-context: reconnect attempt failed: %v — staying in local mode", reconnErr)
 							return "local mode (Gitea still unavailable)", nil
 						}
-						return "reconnected to Gitea and merged local context", nil
+						return reconnMsg, nil
 					}
 				}
 			}

--- a/plugins/corezoid/mcp-server/git-sync.go
+++ b/plugins/corezoid/mcp-server/git-sync.go
@@ -1,0 +1,442 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// gitContextDir returns the path to .git-context/ inside the current working dir.
+func gitContextDir() string {
+	cwd, _ := os.Getwd()
+	return filepath.Join(cwd, ".git-context")
+}
+
+// ensureGitignoreEntry appends entry to <workDir>/.gitignore if not already
+// present, creating the file if needed. .git-context/ nests its own .git
+// directory with a Basic-auth header configured per-invocation (see
+// runGitAuthed) — nothing secret is written to it, but it's still project
+// working state that shouldn't be committed into the user's own repo, so we
+// gitignore it defensively the first time it's created.
+func ensureGitignoreEntry(workDir, entry string) error {
+	path := filepath.Join(workDir, ".gitignore")
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	content := string(data)
+	for _, line := range strings.Split(content, "\n") {
+		if strings.TrimSpace(line) == entry {
+			return nil // already present
+		}
+	}
+	if content != "" && !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+	content += entry + "\n"
+	return os.WriteFile(path, []byte(content), 0644)
+}
+
+// deriveGitURL computes COREZOID_GIT_URL from the Corezoid account host.
+//
+// Formula (see Gitea-URL-Formula.md):
+//
+//  1. apex  = last 2 domain labels of host  (e.g. "corezoid.com")
+//  2. prefix = labels before apex           (e.g. ["admin","dev"])
+//  3. Inspect first label of prefix:
+//     - "admin" or "corezoid" (exact)     → drop it entirely
+//     - starts with "admin-"              → strip "admin-", keep remainder
+//     - starts with "corezoid-"           → strip "corezoid-", keep remainder
+//     - anything else                     → return error (caller silently skips)
+//  4. env = join(remaining labels, ".")   or "prod" if nothing remains
+//  5. COREZOID_GIT_URL = https://git-{env}.{env}.{apex}/corezoid-{env}
+//
+// Examples:
+//
+//	admin.dev.corezoid.com     → https://git-dev.dev.corezoid.com/corezoid-dev
+//	admin-pre.corezoid.com     → https://git-pre.pre.corezoid.com/corezoid-pre
+//	admin.corezoid.com         → https://git-prod.prod.corezoid.com/corezoid-prod
+//	corezoid.leobank.az        → https://git-prod.prod.leobank.az/corezoid-prod
+//	corezoid-lq.leobank.az     → https://git-lq.lq.leobank.az/corezoid-lq
+//	corezoid.staging.liobank.vn → https://git-staging.staging.liobank.vn/corezoid-staging
+func deriveGitURL(rawAccountURL string) (string, error) {
+	if rawAccountURL == "" {
+		return "", fmt.Errorf("ACCOUNT_URL is empty")
+	}
+	if !strings.Contains(rawAccountURL, "://") {
+		rawAccountURL = "https://" + rawAccountURL
+	}
+	u, err := url.Parse(rawAccountURL)
+	if err != nil || u.Host == "" {
+		return "", fmt.Errorf("invalid ACCOUNT_URL %q", rawAccountURL)
+	}
+	host := u.Hostname() // strip port if any
+
+	labels := strings.Split(host, ".")
+	if len(labels) < 2 {
+		return "", fmt.Errorf("cannot derive git URL from host %q: need at least 2 labels", host)
+	}
+
+	// apex = last 2 labels
+	apex := strings.Join(labels[len(labels)-2:], ".")
+	// prefix = everything before apex
+	prefixLabels := labels[:len(labels)-2]
+
+	var env string
+	if len(prefixLabels) == 0 {
+		// bare apex (e.g. "corezoid.com") — treat as prod
+		env = "prod"
+	} else {
+		first := prefixLabels[0]
+		var rest []string
+
+		switch {
+		case first == "admin" || first == "corezoid":
+			rest = prefixLabels[1:]
+		case strings.HasPrefix(first, "admin-"):
+			rest = append([]string{first[len("admin-"):]}, prefixLabels[1:]...)
+		case strings.HasPrefix(first, "corezoid-"):
+			rest = append([]string{first[len("corezoid-"):]}, prefixLabels[1:]...)
+		default:
+			return "", fmt.Errorf("cannot derive git URL from host %q: first label %q does not match admin/corezoid pattern", host, first)
+		}
+
+		if len(rest) == 0 {
+			env = "prod"
+		} else {
+			env = strings.Join(rest, ".")
+		}
+	}
+
+	gitHost := fmt.Sprintf("git-%s.%s.%s", env, env, apex)
+	org := fmt.Sprintf("corezoid-%s", env)
+	return fmt.Sprintf("https://%s/%s", gitHost, org), nil
+}
+
+// buildGitRepoURL constructs the (credential-free) HTTPS clone URL for the
+// project-level mirror repo (layout=project).
+// Format: https://<host>/<org>/c-<companyID>-p-<projectID>.git
+//
+// Normalisation rules:
+//   - If base has no scheme (e.g. "git-pre.pre.corezoid.com/corezoid-pre"), prepend "https://".
+//   - companyID/projectID may arrive with their "c-"/"p-" prefix already attached,
+//     or bare; either way the repo name is always "c-<id>-p-<id>" (strip any
+//     existing prefix before re-adding it, to avoid double "c-c-"/"p-p-...").
+//
+// Credentials are deliberately NOT embedded in this URL — a credentialed URL
+// passed to `git clone`/`git remote add` gets written verbatim into
+// .git-context/.git/config and stays there in plaintext indefinitely. Callers
+// authenticate per-invocation via runGitAuthed instead (login/secret are the
+// client's own Corezoid API key — the same credentials used for the Corezoid
+// API, not a bot token). The mirror's nginx auth-gw validates them against
+// capi and enforces read-only access except under _ext/** (ext_push=true).
+func buildGitRepoURL(base, companyID, projectID string) (string, error) {
+	if !strings.Contains(base, "://") {
+		base = "https://" + base
+	}
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", fmt.Errorf("invalid COREZOID_GIT_URL %q: %w", base, err)
+	}
+	rawCompanyID := strings.TrimPrefix(companyID, "c-")
+	rawProjectID := strings.TrimPrefix(projectID, "p-")
+	u.Path = strings.TrimRight(u.Path, "/") + fmt.Sprintf("/c-%s-p-%s.git", rawCompanyID, rawProjectID)
+	return u.String(), nil
+}
+
+// maskSecret replaces the secret in any string (e.g. git output) to prevent leaks.
+func maskSecret(s, secret string) string {
+	if secret == "" {
+		return s
+	}
+	return strings.ReplaceAll(s, secret, "***")
+}
+
+// runGit runs a git command in dir and returns combined output.
+// GIT_TERMINAL_PROMPT=0 prevents interactive credential prompts.
+func runGit(ctx context.Context, dir string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// runGitAuthed runs a git command with per-invocation HTTP Basic auth for the
+// Corezoid git mirror, for network operations (clone/fetch/pull/push) against
+// a credential-free URL (see buildGitRepoURL).
+//
+// The credential is passed via GIT_CONFIG_COUNT/KEY/VALUE environment
+// variables rather than a `-c http.extraHeader=...` CLI flag or a URL-embedded
+// user:pass — both of those get written to .git-context/.git/config by
+// `clone`/`remote add` and persist on disk indefinitely. An env var is
+// process-scoped: it is never written to any git config file and does not
+// appear in the command's argv (so it doesn't show up in `ps`/cmdline output).
+func runGitAuthed(ctx context.Context, dir, login, secret string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	cmd.Dir = dir
+	env := append(os.Environ(), "GIT_TERMINAL_PROMPT=0")
+	if login != "" || secret != "" {
+		encoded := base64.StdEncoding.EncodeToString([]byte(login + ":" + secret))
+		env = append(env,
+			"GIT_CONFIG_COUNT=1",
+			"GIT_CONFIG_KEY_0=http.extraHeader",
+			"GIT_CONFIG_VALUE_0=Authorization: Basic "+encoded,
+		)
+	}
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	return string(out), err
+}
+
+// gitPullContext syncs .git-context/ with the Corezoid git mirror.
+//
+// Mode selection (in order):
+//  1. .git exists + has remote  → git pull --rebase --autostash  (online, normal)
+//  2. .git exists + no remote   → try reconnectToGitea(); if Gitea still down → local mode
+//  3. .git missing + URL known  → git clone; if clone fails → local mode fallback
+//  4. .git missing + no URL     → local mode (offline from the start)
+//
+// Local mode creates a minimal local git repo so _ext/docs/ and CLAUDE.md are
+// maintained without Gitea. CLAUDE.md is (re)generated after pull-folder writes
+// the .conv.json files via generateLocalCLAUDEMD().
+func gitPullContext(ctx context.Context) (string, error) {
+	gURL, gLogin, gSecret, gCompany, _ := gitConfigSnapshot()
+
+	targetDir := gitContextDir()
+	gitDir := filepath.Join(targetDir, ".git")
+
+	if _, err := os.Stat(gitDir); err == nil {
+		// .git exists.
+		if isLocalOnlyContext(ctx, targetDir) {
+			// Was in local mode — try to reconnect if we now have a URL.
+			if gURL != "" && gLogin != "" && gSecret != "" && gCompany != "" {
+				if projectID := resolveProjectID(ctx); projectID != 0 {
+					repoURL, buildErr := buildGitRepoURL(gURL, gCompany, strconv.Itoa(projectID))
+					if buildErr == nil {
+						if reconnErr := reconnectToGitea(ctx, repoURL, gLogin, gSecret); reconnErr != nil {
+							logger.Warn("git-pull-context: reconnect attempt failed: %v — staying in local mode", reconnErr)
+							return "local mode (Gitea still unavailable)", nil
+						}
+						return "reconnected to Gitea and merged local context", nil
+					}
+				}
+			}
+			return "local mode (no Gitea URL available)", nil
+		}
+
+		// Normal online pull.
+		out, err := runGitAuthed(ctx, targetDir, gLogin, gSecret, "pull", "--rebase", "--autostash", "origin")
+		if err != nil {
+			return "", fmt.Errorf("git pull failed: %s", maskSecret(out, gSecret))
+		}
+		return fmt.Sprintf("Git context updated (%s)", maskSecret(strings.TrimSpace(out), gSecret)), nil
+	}
+
+	// No .git yet — try to clone from Gitea if we have a URL.
+	if gURL != "" && gLogin != "" && gSecret != "" && gCompany != "" {
+		if projectID := resolveProjectID(ctx); projectID != 0 {
+			repoURL, buildErr := buildGitRepoURL(gURL, gCompany, strconv.Itoa(projectID))
+			if buildErr == nil {
+				// m4: clean up incomplete .git-context/ before cloning.
+				if _, dirErr := os.Stat(targetDir); dirErr == nil {
+					os.RemoveAll(targetDir) //nolint:errcheck
+				}
+				if err := os.MkdirAll(filepath.Dir(targetDir), 0755); err != nil {
+					return "", fmt.Errorf("cannot create parent directory: %w", err)
+				}
+				out, cloneErr := runGitAuthed(ctx, "", gLogin, gSecret, "clone", "-q", repoURL, targetDir)
+				if cloneErr == nil {
+					if err := ensureGitignoreEntry(filepath.Dir(targetDir), ".git-context/"); err != nil {
+						logger.Warn("git-pull-context: could not update project .gitignore: %v", err)
+					}
+					return fmt.Sprintf("Git context cloned to %s", targetDir), nil
+				}
+				// Clone failed — Gitea unreachable, fall through to local mode.
+				logger.Warn("git-pull-context: Gitea clone failed (%s) — switching to local mode",
+					maskSecret(strings.TrimSpace(out), gSecret))
+			}
+		} else {
+			logger.Warn("git-pull-context: cannot resolve project ID for stage — switching to local mode")
+		}
+	}
+
+	// Local mode fallback.
+	localPath, initErr := initLocalGitContext(ctx)
+	if initErr != nil {
+		return "", fmt.Errorf("cannot initialize local git context: %w", initErr)
+	}
+	return fmt.Sprintf("local mode initialized (%s)", localPath), nil
+}
+
+// findGitStagePath walks .git-context/ and returns the path of the stage
+// directory whose numeric prefix matches stageID.
+//
+// The mirror repo is now cloned at the project level
+// (c-<companyID>-p-<projectID>), so the standard tree layout is:
+//
+//	stages/<stageID>_<Name>/
+//
+// which is the same root-level layout used by local/offline mode. The older
+// company-root layout (projects/<projectID>_<Name>/stages/<stageID>_<Name>/)
+// is still checked as a fallback for repos mirrored before the project-level
+// clone change.
+//
+// The returned path is relative to contextDir (e.g. "stages/456_Bar").
+// If no match is found an empty string is returned without error — the stage
+// may not yet be mirrored (new stage, no committed processes).
+func findGitStagePath(contextDir string, stageID int) (string, error) {
+	if stageID == 0 {
+		return "", nil
+	}
+	prefix := fmt.Sprintf("%d_", stageID)
+
+	// 1. Check stages/ at root level — standard project-level clone layout,
+	//    also used by local / offline mode.
+	stagesDir := filepath.Join(contextDir, "stages")
+	if entries, err := os.ReadDir(stagesDir); err == nil {
+		for _, e := range entries {
+			if e.IsDir() && strings.HasPrefix(e.Name(), prefix) {
+				return filepath.ToSlash("stages/" + e.Name()), nil
+			}
+		}
+	}
+
+	// 2. Walk projects/*/stages/ — legacy fallback for company-root mirror clones.
+	projectsRoot := filepath.Join(contextDir, "projects")
+	var found string
+	err := filepath.WalkDir(projectsRoot, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		if filepath.Base(filepath.Dir(path)) == "stages" && strings.HasPrefix(d.Name(), prefix) {
+			found = path
+			return filepath.SkipAll
+		}
+		return nil
+	})
+	if err != nil {
+		return "", fmt.Errorf("error scanning git context for stage %d: %w", stageID, err)
+	}
+	if found == "" {
+		return "", nil
+	}
+	rel, err := filepath.Rel(contextDir, found)
+	if err != nil {
+		return "", err
+	}
+	return filepath.ToSlash(rel), nil
+}
+
+// gitPushContext stages _ext/ changes and commits them.
+// Handles four cases:
+//  1. Local-only mode (no remote configured) → stage + commit only, never push
+//  2. New local edits in _ext/ (online) → stage + commit + push
+//  3. Already-committed but unpushed commits (online) → push directly
+//  4. Nothing to commit/push → return informational message (not an error)
+//
+// Safety: only _ext/ files are ever staged; any accidentally staged non-_ext/
+// files are silently unstaged before the commit so the pre-receive hook cannot
+// reject the push.
+func gitPushContext(ctx context.Context, commitMsg string) (string, error) {
+	targetDir := gitContextDir()
+
+	if _, err := os.Stat(filepath.Join(targetDir, ".git")); err != nil {
+		return "", fmt.Errorf("git context not initialised — run git-pull-context first")
+	}
+
+	// M1: get login/secret for per-invocation auth and to mask the secret in
+	// all git output returned to the caller.
+	_, gLogin, gSecret, _, _ := gitConfigSnapshot()
+
+	if commitMsg == "" {
+		commitMsg = fmt.Sprintf("docs: update _ext/ after task session %s",
+			time.Now().UTC().Format("2006-01-02T15:04:05Z"))
+	}
+
+	// Local-only mode has no "origin" to sync with or push to — attempting
+	// `pull ... origin` here would fail immediately (unknown remote) and
+	// abort before ever committing, silently dropping local _ext/ edits and
+	// preventing regenerateLocalCLAUDEMDIfNeeded (called by the handler only
+	// on success) from ever running. So skip remote sync/push entirely and
+	// just commit locally.
+	localOnly := isLocalOnlyContext(ctx, targetDir)
+
+	if !localOnly {
+		// Sync with remote first (--autostash handles local modifications).
+		if out, err := runGitAuthed(ctx, targetDir, gLogin, gSecret, "pull", "--rebase", "--autostash", "origin"); err != nil {
+			return "", fmt.Errorf("git pull before push failed: %s", maskSecret(out, gSecret))
+		}
+	}
+
+	// Stage _ext/ — the only zone we are allowed to write.
+	runGit(ctx, targetDir, "add", "_ext/") //nolint:errcheck (_ext/ may not exist yet)
+
+	// Safety: unstage any non-_ext/ files that may have been added accidentally.
+	// The server-side pre-receive hook would reject the entire push otherwise.
+	if staged, err := runGit(ctx, targetDir, "diff", "--cached", "--name-only"); err == nil {
+		for _, f := range strings.Split(strings.TrimSpace(staged), "\n") {
+			if f == "" {
+				continue
+			}
+			if !strings.HasPrefix(filepath.ToSlash(f), "_ext/") {
+				runGit(ctx, targetDir, "reset", "HEAD", "--", f) //nolint:errcheck
+				logger.Warn("git-push-context: unstaged non-_ext/ file %q — only _ext/** is writable", f)
+			}
+		}
+	}
+
+	// Check for staged changes.
+	_, noStaged := runGit(ctx, targetDir, "diff", "--cached", "--quiet")
+	hasStaged := noStaged != nil
+
+	// Check for already-committed but unpushed commits (fixes: push after manual commit).
+	hasUnpushed := gitHasUnpushedCommits(ctx, targetDir)
+
+	if !hasStaged && !hasUnpushed {
+		if localOnly {
+			return "No changes in _ext/ to commit (local mode — no remote configured, nothing to push)", nil
+		}
+		return "No changes in _ext/ to push (nothing staged, nothing unpushed)", nil
+	}
+
+	if hasStaged {
+		if out, err := runGit(ctx, targetDir, "commit", "-m", commitMsg); err != nil {
+			return "", fmt.Errorf("git commit failed: %s", out)
+		}
+	}
+
+	if localOnly {
+		return fmt.Sprintf("Committed locally (offline mode — no remote configured, nothing pushed): %s", commitMsg), nil
+	}
+
+	out, err := runGitAuthed(ctx, targetDir, gLogin, gSecret, "push", "origin")
+	if err != nil {
+		return "", fmt.Errorf("git push failed: %s", maskSecret(out, gSecret))
+	}
+	return fmt.Sprintf("Git context pushed: %s", maskSecret(strings.TrimSpace(out), gSecret)), nil
+}
+
+// gitHasUnpushedCommits returns true if there are commits in HEAD not yet
+// pushed to the upstream tracking branch.
+func gitHasUnpushedCommits(ctx context.Context, dir string) bool {
+	// @{u} resolves to the upstream tracking branch (works for master/main/any branch).
+	out, err := runGit(ctx, dir, "rev-list", "--count", "@{u}..HEAD")
+	if err != nil {
+		// m2: log so silent skips are observable (e.g. detached HEAD, no upstream).
+		logger.Warn("git-push-context: could not check unpushed commits (%v) — assuming none", err)
+		return false
+	}
+	n, _ := strconv.Atoi(strings.TrimSpace(out))
+	return n > 0
+}

--- a/plugins/corezoid/mcp-server/git-sync_test.go
+++ b/plugins/corezoid/mcp-server/git-sync_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -198,6 +200,116 @@ func TestMergeExtSnapshot_MixedTree(t *testing.T) {
 	}
 	if got := readFile(t, filepath.Join(extDir, "issues.md.local-conflict")); got != "local version" {
 		t.Errorf("expected local version saved alongside, got %q", got)
+	}
+}
+
+// TestStripEnvKeys pins the fix for a bug where runGitAuthed appended its own
+// GIT_CONFIG_* entries on top of os.Environ() without removing any
+// pre-existing entries of the same name. Go's exec.Cmd (and git itself)
+// resolves duplicate env keys to the first match, so a pre-existing
+// GIT_CONFIG_COUNT from the invoking shell/IDE would silently shadow ours and
+// git would never see the injected Basic-auth header.
+func TestStripEnvKeys(t *testing.T) {
+	env := []string{
+		"PATH=/usr/bin",
+		"GIT_CONFIG_COUNT=2",
+		"GIT_CONFIG_KEY_0=some.other.key",
+		"GIT_CONFIG_VALUE_0=whatever",
+		"HOME=/home/user",
+	}
+	got := stripEnvKeys(env, "GIT_CONFIG_COUNT", "GIT_CONFIG_KEY_0", "GIT_CONFIG_VALUE_0")
+
+	want := []string{"PATH=/usr/bin", "HOME=/home/user"}
+	if len(got) != len(want) {
+		t.Fatalf("stripEnvKeys() = %v, want %v", got, want)
+	}
+	for i, kv := range want {
+		if got[i] != kv {
+			t.Errorf("stripEnvKeys()[%d] = %q, want %q", i, got[i], kv)
+		}
+	}
+}
+
+// TestStripEnvKeys_DoesNotMutateInput guards against the shared-backing-array
+// footgun: stripEnvKeys must return a fresh slice, never overwrite entries of
+// the slice the caller passed in (which for runGitAuthed is os.Environ()'s
+// backing data).
+func TestStripEnvKeys_DoesNotMutateInput(t *testing.T) {
+	env := []string{"A=1", "GIT_CONFIG_COUNT=1", "B=2"}
+	envCopy := append([]string(nil), env...)
+
+	_ = stripEnvKeys(env, "GIT_CONFIG_COUNT")
+
+	for i := range env {
+		if env[i] != envCopy[i] {
+			t.Errorf("stripEnvKeys mutated its input at index %d: got %q, want %q", i, env[i], envCopy[i])
+		}
+	}
+}
+
+// TestGitPushContext_RevertsNonExtChangesBeforePull pins the fix for a bug
+// where `pull --rebase --autostash` ran before the non-_ext/ safety-unstage
+// step. If .git-context/ had an uncommitted non-_ext/ modification (nothing
+// in normal operation should cause this, but the guard is defensive),
+// --autostash would scoop it up along with the intended _ext/ change; a
+// stash-pop conflict after the rebase could then leave the repo half-rebased
+// before the safety-unstage ever ran. gitPushContext now reverts non-_ext/
+// working-tree changes to HEAD before the pull, so autostash only ever has
+// to carry the _ext/ change through the rebase.
+func TestGitPushContext_RevertsNonExtChangesBeforePull(t *testing.T) {
+	ctx := context.Background()
+
+	// Bare "origin" — a local path is enough to exercise pull/push without
+	// any network dependency.
+	bareDir := t.TempDir()
+	if out, err := runGit(ctx, "", "init", "--bare", bareDir); err != nil {
+		t.Fatalf("bare init failed: %s", out)
+	}
+
+	// Working clone that will become .git-context/.
+	projectDir := t.TempDir()
+	contextDir := filepath.Join(projectDir, ".git-context")
+	if out, err := runGit(ctx, "", "clone", bareDir, contextDir); err != nil {
+		t.Fatalf("clone failed: %s", out)
+	}
+	runGit(ctx, contextDir, "config", "user.email", "test@example.com") //nolint:errcheck
+	runGit(ctx, contextDir, "config", "user.name", "Test")              //nolint:errcheck
+	runGit(ctx, contextDir, "checkout", "-b", "main")                   //nolint:errcheck
+
+	// Initial commit: a tracked non-_ext/ file (stands in for CLAUDE.md) plus
+	// an _ext/ file, pushed to origin with upstream tracking set.
+	writeFile(t, filepath.Join(contextDir, "CLAUDE.md"), "original content")
+	writeFile(t, filepath.Join(contextDir, "_ext", "docs", "context.md"), "initial docs")
+	runGit(ctx, contextDir, "add", "-A")               //nolint:errcheck
+	runGit(ctx, contextDir, "commit", "-m", "initial") //nolint:errcheck
+	if out, err := runGit(ctx, contextDir, "push", "-u", "origin", "main"); err != nil {
+		t.Fatalf("initial push failed: %s", out)
+	}
+
+	// Simulate an accidental uncommitted non-_ext/ modification sitting in
+	// the working tree — the scenario the fix guards against.
+	writeFile(t, filepath.Join(contextDir, "CLAUDE.md"), "ACCIDENTAL LOCAL EDIT")
+
+	// A legitimate _ext/ change to push.
+	writeFile(t, filepath.Join(contextDir, "_ext", "docs", "context.md"), "updated docs")
+
+	chdirWithCleanup(t, projectDir)
+
+	msg, err := gitPushContext(ctx, "test commit")
+	if err != nil {
+		t.Fatalf("gitPushContext failed: %v (%s)", err, msg)
+	}
+
+	if got := readFile(t, filepath.Join(contextDir, "CLAUDE.md")); got != "original content" {
+		t.Errorf("expected non-_ext/ working-tree edit to be reverted to HEAD before pull, got %q", got)
+	}
+
+	pushed, err := runGit(ctx, bareDir, "show", "HEAD:_ext/docs/context.md")
+	if err != nil {
+		t.Fatalf("could not read pushed content from origin: %v (%s)", err, pushed)
+	}
+	if strings.TrimSpace(pushed) != "updated docs" {
+		t.Errorf("expected _ext/ change to be pushed to origin, got %q", pushed)
 	}
 }
 

--- a/plugins/corezoid/mcp-server/git-sync_test.go
+++ b/plugins/corezoid/mcp-server/git-sync_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestDeriveGitURL(t *testing.T) {
+	tests := []struct {
+		accountURL string
+		want       string
+		wantErr    bool
+	}{
+		// Table from Gitea-URL-Formula.md
+		{
+			accountURL: "https://admin.dev.corezoid.com",
+			want:       "https://git-dev.dev.corezoid.com/corezoid-dev",
+		},
+		{
+			accountURL: "https://admin-pre.corezoid.com",
+			want:       "https://git-pre.pre.corezoid.com/corezoid-pre",
+		},
+		{
+			accountURL: "https://admin.corezoid.com",
+			want:       "https://git-prod.prod.corezoid.com/corezoid-prod",
+		},
+		{
+			accountURL: "https://corezoid.leobank.az",
+			want:       "https://git-prod.prod.leobank.az/corezoid-prod",
+		},
+		{
+			accountURL: "https://corezoid-lq.leobank.az",
+			want:       "https://git-lq.lq.leobank.az/corezoid-lq",
+		},
+		{
+			accountURL: "https://corezoid.staging.liobank.vn",
+			want:       "https://git-staging.staging.liobank.vn/corezoid-staging",
+		},
+		{
+			accountURL: "https://corezoid.tezbank.uz",
+			want:       "https://git-prod.prod.tezbank.uz/corezoid-prod",
+		},
+		{
+			accountURL: "https://corezoid-ach.tezbank.uz",
+			want:       "https://git-ach.ach.tezbank.uz/corezoid-ach",
+		},
+		// No scheme — should still work
+		{
+			accountURL: "admin.dev.corezoid.com",
+			want:       "https://git-dev.dev.corezoid.com/corezoid-dev",
+		},
+		// Unknown first label — should error
+		{
+			accountURL: "https://account.corezoid.com",
+			wantErr:    true,
+		},
+		// Empty input — should error
+		{
+			accountURL: "",
+			wantErr:    true,
+		},
+		// Only 1 label — should error
+		{
+			accountURL: "https://localhost",
+			wantErr:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.accountURL, func(t *testing.T) {
+			got, err := deriveGitURL(tc.accountURL)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("deriveGitURL(%q) = %q, want error", tc.accountURL, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("deriveGitURL(%q) unexpected error: %v", tc.accountURL, err)
+				return
+			}
+			if got != tc.want {
+				t.Errorf("deriveGitURL(%q)\n got  %q\n want %q", tc.accountURL, got, tc.want)
+			}
+		})
+	}
+}

--- a/plugins/corezoid/mcp-server/git-sync_test.go
+++ b/plugins/corezoid/mcp-server/git-sync_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
+	"sort"
 	"testing"
 )
 
@@ -83,4 +86,136 @@ func TestDeriveGitURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestMergeExtSnapshot_LocalOnlyFileIsRestored pins that a file present only
+// in the pre-reconnect local snapshot (not on the remote at all) is copied
+// into extDir untouched.
+func TestMergeExtSnapshot_LocalOnlyFileIsRestored(t *testing.T) {
+	snapshotDir := t.TempDir()
+	extDir := t.TempDir()
+
+	writeFile(t, filepath.Join(snapshotDir, "docs", "new.md"), "local-only content")
+
+	conflicts, err := mergeExtSnapshot(snapshotDir, extDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(conflicts) != 0 {
+		t.Errorf("expected no conflicts, got %v", conflicts)
+	}
+	got := readFile(t, filepath.Join(extDir, "docs", "new.md"))
+	if got != "local-only content" {
+		t.Errorf("expected local-only file to be restored, got %q", got)
+	}
+}
+
+// TestMergeExtSnapshot_IdenticalFileIsLeftAlone pins that a file unchanged on
+// both sides is a no-op — not rewritten, not reported as a conflict.
+func TestMergeExtSnapshot_IdenticalFileIsLeftAlone(t *testing.T) {
+	snapshotDir := t.TempDir()
+	extDir := t.TempDir()
+
+	writeFile(t, filepath.Join(snapshotDir, "docs", "same.md"), "same content")
+	writeFile(t, filepath.Join(extDir, "docs", "same.md"), "same content")
+
+	conflicts, err := mergeExtSnapshot(snapshotDir, extDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(conflicts) != 0 {
+		t.Errorf("expected no conflicts, got %v", conflicts)
+	}
+	got := readFile(t, filepath.Join(extDir, "docs", "same.md"))
+	if got != "same content" {
+		t.Errorf("expected identical file untouched, got %q", got)
+	}
+}
+
+// TestMergeExtSnapshot_DivergedFileIsConflict pins the fix for a bug where
+// reconnecting to Gitea after an offline session blindly overwrote _ext/
+// with the local snapshot, silently discarding any _ext/ changes made on the
+// remote side (by another developer or the mirror bot) while offline. The
+// remote version must survive in place, and the local version must be saved
+// alongside — not silently dropped — with the conflict reported to the caller.
+func TestMergeExtSnapshot_DivergedFileIsConflict(t *testing.T) {
+	snapshotDir := t.TempDir()
+	extDir := t.TempDir()
+
+	writeFile(t, filepath.Join(snapshotDir, "docs", "decisions.md"), "local offline edit")
+	writeFile(t, filepath.Join(extDir, "docs", "decisions.md"), "remote edit made while offline")
+
+	conflicts, err := mergeExtSnapshot(snapshotDir, extDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(conflicts) != 1 || conflicts[0] != "docs/decisions.md" {
+		t.Fatalf("expected exactly one conflict for docs/decisions.md, got %v", conflicts)
+	}
+
+	// Remote version must survive in place — this is the crux of the bug fix.
+	got := readFile(t, filepath.Join(extDir, "docs", "decisions.md"))
+	if got != "remote edit made while offline" {
+		t.Errorf("expected remote version to be kept in place, got %q", got)
+	}
+
+	// Local version must be preserved alongside, not silently discarded.
+	localBackup := readFile(t, filepath.Join(extDir, "docs", "decisions.md.local-conflict"))
+	if localBackup != "local offline edit" {
+		t.Errorf("expected local version saved as .local-conflict, got %q", localBackup)
+	}
+}
+
+// TestMergeExtSnapshot_MixedTree exercises all three cases together across a
+// small tree to guard against the walk logic mishandling one when others are
+// present.
+func TestMergeExtSnapshot_MixedTree(t *testing.T) {
+	snapshotDir := t.TempDir()
+	extDir := t.TempDir()
+
+	writeFile(t, filepath.Join(snapshotDir, "context.md"), "local-only")
+	writeFile(t, filepath.Join(snapshotDir, "invariants.md"), "unchanged")
+	writeFile(t, filepath.Join(extDir, "invariants.md"), "unchanged")
+	writeFile(t, filepath.Join(snapshotDir, "issues.md"), "local version")
+	writeFile(t, filepath.Join(extDir, "issues.md"), "remote version")
+
+	conflicts, err := mergeExtSnapshot(snapshotDir, extDir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	sort.Strings(conflicts)
+	if len(conflicts) != 1 || conflicts[0] != "issues.md" {
+		t.Fatalf("expected exactly one conflict (issues.md), got %v", conflicts)
+	}
+	if got := readFile(t, filepath.Join(extDir, "context.md")); got != "local-only" {
+		t.Errorf("expected local-only file restored, got %q", got)
+	}
+	if got := readFile(t, filepath.Join(extDir, "invariants.md")); got != "unchanged" {
+		t.Errorf("expected unchanged file untouched, got %q", got)
+	}
+	if got := readFile(t, filepath.Join(extDir, "issues.md")); got != "remote version" {
+		t.Errorf("expected remote version kept for conflicting file, got %q", got)
+	}
+	if got := readFile(t, filepath.Join(extDir, "issues.md.local-conflict")); got != "local version" {
+		t.Errorf("expected local version saved alongside, got %q", got)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
 }

--- a/plugins/corezoid/mcp-server/git-sync_test.go
+++ b/plugins/corezoid/mcp-server/git-sync_test.go
@@ -304,7 +304,11 @@ func TestGitPushContext_RevertsNonExtChangesBeforePull(t *testing.T) {
 		t.Errorf("expected non-_ext/ working-tree edit to be reverted to HEAD before pull, got %q", got)
 	}
 
-	pushed, err := runGit(ctx, bareDir, "show", "HEAD:_ext/docs/context.md")
+	// Reference the branch explicitly rather than HEAD — the bare repo's HEAD
+	// symref follows whatever init.defaultBranch the git installation defaults
+	// to (e.g. "master" on some runners), which was never pushed here; only
+	// "main" was.
+	pushed, err := runGit(ctx, bareDir, "show", "main:_ext/docs/context.md")
 	if err != nil {
 		t.Fatalf("could not read pushed content from origin: %v (%s)", err, pushed)
 	}

--- a/plugins/corezoid/mcp-server/main.go
+++ b/plugins/corezoid/mcp-server/main.go
@@ -224,9 +224,23 @@ func loadConfig() {
 	stageID, _ = strconv.Atoi(os.Getenv("COREZOID_STAGE_ID"))
 	debug = debugFromEnv() // executor API trace; same switch as logger.IsDebug
 	insecureTLS = os.Getenv("COREZOID_INSECURE_TLS") != ""
-	// Loaded from .env — valid as long as WORKSPACE_ID/COREZOID_STAGE_ID in the
-	// same .env haven't changed since it was written (see cachedProjectID doc).
-	cachedProjectID, _ = strconv.Atoi(os.Getenv("COREZOID_PROJECT_ID"))
+	// Loaded from .env, but only trusted if COREZOID_PROJECT_ID_STAGE_ID (written
+	// alongside it by resolveAndCacheProjectID) matches the stage we just loaded.
+	// Without this check, manually editing WORKSPACE_ID/COREZOID_STAGE_ID in .env
+	// (bypassing the login tool, which clears the cache on a real switch) would
+	// silently reuse a project ID resolved for a different stage — pointing
+	// git-pull-context/git-push-context at the wrong project's mirror repo.
+	if pid, _ := strconv.Atoi(os.Getenv("COREZOID_PROJECT_ID")); pid != 0 && projectIDStageMatches(stageID) {
+		cachedProjectID = pid
+	} else {
+		cachedProjectID = 0
+		os.Unsetenv("COREZOID_PROJECT_ID")
+		os.Unsetenv("COREZOID_PROJECT_ID_STAGE_ID")
+		if envPath := findDotEnvPath(); envPath != "" {
+			removeEnvKey(envPath, "COREZOID_PROJECT_ID")           //nolint:errcheck
+			removeEnvKey(envPath, "COREZOID_PROJECT_ID_STAGE_ID") //nolint:errcheck
+		}
+	}
 	apiLogin = os.Getenv("API_LOGIN")
 	apiSecret = os.Getenv("API_SECRET")
 	gitURL = os.Getenv("COREZOID_GIT_URL")
@@ -647,7 +661,8 @@ func fixStruct(dataBin string, inProcessID int) (string, []string) {
 // resolveAndCacheProjectID returns the project ID for the current stage and an
 // optional user-visible notice when COREZOID_PROJECT_ID is written to .env for
 // the first time. The notice is non-empty only on the first API resolution.
-// Priority: in-memory cache → COREZOID_PROJECT_ID env var → API (ShowFolder).
+// Priority: in-memory cache → COREZOID_PROJECT_ID env var (only if recorded for
+// the current stage, see projectIDStageMatches) → API (ShowFolder).
 // Thread-safe: reads under RLock, writes under Lock.
 func resolveAndCacheProjectID(v *Executor) (int, string) {
 	// Fast path: cache hit (read lock only).
@@ -658,9 +673,11 @@ func resolveAndCacheProjectID(v *Executor) (int, string) {
 		return id, ""
 	}
 
-	// Try env var (no API call needed).
+	// Try env var (no API call needed) — only trust it if COREZOID_PROJECT_ID_STAGE_ID
+	// confirms it was resolved for this exact stage (see loadConfig for the
+	// equivalent startup-time check).
 	if s := os.Getenv("COREZOID_PROJECT_ID"); s != "" {
-		if parsed, err := strconv.Atoi(s); err == nil && parsed != 0 {
+		if parsed, err := strconv.Atoi(s); err == nil && parsed != 0 && projectIDStageMatches(v.StageID) {
 			withAuthLock(func() { cachedProjectID = parsed })
 			return parsed, ""
 		}
@@ -675,12 +692,35 @@ func resolveAndCacheProjectID(v *Executor) (int, string) {
 		return 0, ""
 	}
 	withAuthLock(func() { cachedProjectID = resolved })
+	wasEmpty := os.Getenv("COREZOID_PROJECT_ID") == ""
 	os.Setenv("COREZOID_PROJECT_ID", strconv.Itoa(resolved))
-	if written := appendToDotEnv("COREZOID_PROJECT_ID", strconv.Itoa(resolved)); written {
+	os.Setenv("COREZOID_PROJECT_ID_STAGE_ID", strconv.Itoa(v.StageID))
+	// Always (over)write both keys together — unlike the old append-only-if-absent
+	// behavior, a stale COREZOID_PROJECT_ID left over from a different stage must
+	// not survive in .env once we've resolved a fresh value for this one.
+	if envPath := findDotEnvPath(); envPath != "" {
+		withAuthLock(func() {
+			updateEnvFile(envPath, "COREZOID_PROJECT_ID", strconv.Itoa(resolved))          //nolint:errcheck
+			updateEnvFile(envPath, "COREZOID_PROJECT_ID_STAGE_ID", strconv.Itoa(v.StageID)) //nolint:errcheck
+		})
+	}
+	if wasEmpty {
 		notice := fmt.Sprintf("(COREZOID_PROJECT_ID=%d saved to .env for future use)", resolved)
 		return resolved, notice
 	}
 	return resolved, ""
+}
+
+// projectIDStageMatches reports whether COREZOID_PROJECT_ID_STAGE_ID in the
+// environment matches stageID — i.e. whether a cached COREZOID_PROJECT_ID was
+// actually resolved for the stage we're currently on, not left over from a
+// stage/workspace switch that bypassed the login tool's cache invalidation.
+func projectIDStageMatches(stageID int) bool {
+	if stageID == 0 {
+		return false
+	}
+	saved, err := strconv.Atoi(os.Getenv("COREZOID_PROJECT_ID_STAGE_ID"))
+	return err == nil && saved == stageID
 }
 
 // appendToDotEnv appends key=value to the nearest .env file if the key is absent.

--- a/plugins/corezoid/mcp-server/main.go
+++ b/plugins/corezoid/mcp-server/main.go
@@ -58,17 +58,34 @@ func debugFromEnv() bool { return os.Getenv("COREZOID_DEBUG") != "" }
 var apigwURL string
 var stageID int
 var insecureTLS bool
-// cachedProjectID is written once (protected by authStateMu) and then read-only.
-// Reset to 0 on every loadConfig so a workspace switch gets a fresh value.
+
+// cachedProjectID holds the project ID resolved by resolveProjectID (see
+// mcp_handlers_git.go), persisted to COREZOID_PROJECT_ID in the project .env
+// so it survives server restarts without a repeat API round-trip. It is keyed
+// by stage — resolveProjectID resolves it from COREZOID_STAGE_ID — so it is
+// explicitly cleared (in-memory and in .env) whenever WORKSPACE_ID or
+// COREZOID_STAGE_ID changes (handleLogin) or on logout — never silently reset
+// on every loadConfig.
 var cachedProjectID int
 
 // apiLogin and apiSecret are the Corezoid API key credentials (API_LOGIN /
 // API_SECRET). They provide an alternative to OAuth2 PKCE for environments
 // where browser-based authentication is not available. When both are set,
 // requests are signed using the Corezoid double-salted SHA1 pattern instead of using a Simulator bearer token.
-// These are distinct from gitLoginID / gitSecret which are used for git-sync.
+// The same credentials are reused for git mirror Basic auth (login_id:secret).
 var apiLogin string
 var apiSecret string
+
+// gitURL is the Corezoid git mirror base URL including org path
+// (e.g. https://git-dev.dev.corezoid.com/corezoid-dev). Set via COREZOID_GIT_URL.
+// apiLogin/apiSecret are reused for git Basic auth — no separate git credential needed.
+var gitURL string
+
+// gitStagePath is the relative path inside .git-context/ to the current stage
+// directory (e.g. "projects/123_Foo/stages/456_Bar"). Resolved once after
+// git-pull-context and saved to .env as COREZOID_GIT_STAGE_PATH so the agent
+// can reference it directly when reading CLAUDE.md or _ext/docs/*.
+var gitStagePath string
 
 // authSnapshot returns a coherent snapshot of the auth-state globals taken
 // under the read lock. Callers that subsequently need to mutate state must
@@ -85,6 +102,24 @@ func apiKeySnapshot() (login, secret string) {
 	authStateMu.RLock()
 	defer authStateMu.RUnlock()
 	return apiLogin, apiSecret
+}
+
+// gitConfigSnapshot returns a coherent snapshot of the git mirror config.
+// gitLogin/gitSecret reuse apiLogin/apiSecret (same Corezoid API key for both).
+// accountURLv is included so callers can derive COREZOID_GIT_URL when not set.
+// The project ID itself is not part of this snapshot — resolveProjectID
+// resolves/caches it via the shared resolveAndCacheProjectID (see main.go).
+func gitConfigSnapshot() (gitURLv, loginv, secretv, companyIDv, accountURLv string) {
+	authStateMu.RLock()
+	defer authStateMu.RUnlock()
+	return gitURL, apiLogin, apiSecret, workspaceID, accountURL
+}
+
+// gitStagePathSnapshot returns the resolved stage path inside .git-context/.
+func gitStagePathSnapshot() string {
+	authStateMu.RLock()
+	defer authStateMu.RUnlock()
+	return gitStagePath
 }
 
 // withAuthLock runs fn while holding the auth-state write lock. Use for
@@ -189,10 +224,13 @@ func loadConfig() {
 	stageID, _ = strconv.Atoi(os.Getenv("COREZOID_STAGE_ID"))
 	debug = debugFromEnv() // executor API trace; same switch as logger.IsDebug
 	insecureTLS = os.Getenv("COREZOID_INSECURE_TLS") != ""
-	cachedProjectID = 0              // reset on workspace switch so it is re-resolved
-	os.Unsetenv("COREZOID_PROJECT_ID") // prevent stale process env from short-circuiting resolution
+	// Loaded from .env — valid as long as WORKSPACE_ID/COREZOID_STAGE_ID in the
+	// same .env haven't changed since it was written (see cachedProjectID doc).
+	cachedProjectID, _ = strconv.Atoi(os.Getenv("COREZOID_PROJECT_ID"))
 	apiLogin = os.Getenv("API_LOGIN")
 	apiSecret = os.Getenv("API_SECRET")
+	gitURL = os.Getenv("COREZOID_GIT_URL")
+	gitStagePath = os.Getenv("COREZOID_GIT_STAGE_PATH")
 }
 
 // runCLI executes a single MCP tool from the command line and exits.

--- a/plugins/corezoid/mcp-server/main_config_test.go
+++ b/plugins/corezoid/mcp-server/main_config_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 )
@@ -189,6 +190,70 @@ func TestLoadConfig_ReadsEnvVars(t *testing.T) {
 	}
 	if apigwURL != "https://gw.example" {
 		t.Errorf("apigwURL = %q", apigwURL)
+	}
+}
+
+// TestLoadConfig_TrustsMatchingProjectIDStage pins that a COREZOID_PROJECT_ID
+// resolved for the stage we're currently loading is kept across a restart —
+// the whole point of persisting it to .env in the first place.
+func TestLoadConfig_TrustsMatchingProjectIDStage(t *testing.T) {
+	snapshotConfigGlobals(t)
+	origPID := cachedProjectID
+	t.Cleanup(func() { cachedProjectID = origPID })
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := t.TempDir()
+	chdirWithCleanup(t, dir)
+
+	t.Setenv("COREZOID_STAGE_ID", "4242")
+	t.Setenv("COREZOID_PROJECT_ID", "555")
+	t.Setenv("COREZOID_PROJECT_ID_STAGE_ID", "4242")
+
+	loadConfig()
+
+	if cachedProjectID != 555 {
+		t.Errorf("expected cachedProjectID=555 when stage matches, got %d", cachedProjectID)
+	}
+}
+
+// TestLoadConfig_ClearsStaleProjectIDOnStageMismatch pins the fix for a bug
+// where manually editing WORKSPACE_ID/COREZOID_STAGE_ID in .env (bypassing the
+// login tool, which clears the cache on a real switch) silently reused a
+// COREZOID_PROJECT_ID resolved for a different stage — pointing
+// git-pull-context/git-push-context at the wrong project's mirror repo.
+func TestLoadConfig_ClearsStaleProjectIDOnStageMismatch(t *testing.T) {
+	snapshotConfigGlobals(t)
+	origPID := cachedProjectID
+	t.Cleanup(func() { cachedProjectID = origPID })
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := t.TempDir()
+	chdirWithCleanup(t, dir)
+
+	envPath := filepath.Join(dir, ".env")
+	if err := os.WriteFile(envPath, []byte("COREZOID_PROJECT_ID=555\nCOREZOID_PROJECT_ID_STAGE_ID=1111\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate a manual .env edit that switched the stage without going
+	// through login — COREZOID_PROJECT_ID_STAGE_ID (1111) no longer matches.
+	t.Setenv("COREZOID_STAGE_ID", "9999")
+	t.Setenv("COREZOID_PROJECT_ID", "555")
+	t.Setenv("COREZOID_PROJECT_ID_STAGE_ID", "1111")
+
+	loadConfig()
+
+	if cachedProjectID != 0 {
+		t.Errorf("expected cachedProjectID=0 on stage mismatch, got %d", cachedProjectID)
+	}
+	if got := os.Getenv("COREZOID_PROJECT_ID"); got != "" {
+		t.Errorf("expected COREZOID_PROJECT_ID env var cleared, got %q", got)
+	}
+	data, _ := os.ReadFile(envPath)
+	if strings.Contains(string(data), "COREZOID_PROJECT_ID=555") {
+		t.Errorf("expected stale COREZOID_PROJECT_ID removed from .env, got:\n%s", data)
 	}
 }
 

--- a/plugins/corezoid/mcp-server/mcp_handlers.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers.go
@@ -94,18 +94,30 @@ var toolHandlers = map[string]toolHandler{
 	"list-snapshots":  handleListSnapshots,
 	"delete-snapshot": handleDeleteSnapshot,
 	"get-snapshot":    handleGetSnapshot,
+
+	// git mirror
+	"git-pull-context":    handleGitPullContext,
+	"git-push-context":    handleGitPushContext,
+	"read-context-file":   handleReadContextFile,
+	"update-context-file": handleUpdateContextFile,
 }
 
 // noAuthTools don't need any credentials. lint runs entirely on local files;
 // login/logout manage credentials themselves.
 // send-feedback must not require auth so users can report problems that
 // occurred before or during the login flow.
+// git tools use their own credential check (COREZOID_GIT_URL + API_LOGIN/SECRET)
+// rather than Corezoid API auth.
 var noAuthTools = map[string]struct{}{
-	"layout-process": {},
-	"lint-process":   {},
-	"login":          {},
-	"logout":         {},
-	"send-feedback":  {},
+	"layout-process":      {},
+	"lint-process":        {},
+	"login":               {},
+	"logout":              {},
+	"send-feedback":       {},
+	"git-pull-context":    {},
+	"git-push-context":    {},
+	"read-context-file":   {},
+	"update-context-file": {},
 }
 
 // tokenOnlyTools need an OAuth token but not a fully configured workspace or

--- a/plugins/corezoid/mcp-server/mcp_handlers_auth.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_auth.go
@@ -9,6 +9,32 @@ import (
 	"time"
 )
 
+// resolveAndSaveAPIURL discovers COREZOID_API_URL via fetchCorezoidAPIURL and
+// persists it (global, env, .env). Falls back to ACCOUNT_URL only when
+// discovery genuinely returns an empty result with no error — a real fetch
+// error (network failure, transient 5xx, permission issue) leaves apiURL
+// unset instead of silently pointing it at ACCOUNT_URL, since that host does
+// not always also serve /api/2/json; a wrong silent fallback there produces
+// confusing downstream 404s instead of a clear "API URL not resolved" signal.
+// logSuffix is appended to the success log line to distinguish call sites.
+func resolveAndSaveAPIURL(accountURL, token, envPath, logSuffix string) {
+	corezoidURL, fetchErr := fetchCorezoidAPIURL(accountURL, token)
+	if fetchErr != nil {
+		logger.Warn("login: fetchCorezoidAPIURL failed: %v — COREZOID_API_URL left unresolved, retry on next login", fetchErr)
+		return
+	}
+	if corezoidURL == "" {
+		corezoidURL = strings.TrimRight(accountURL, "/")
+		logger.Info("login: COREZOID_API_URL discovery returned empty — using ACCOUNT_URL %q", corezoidURL)
+	}
+	withAuthLock(func() { apiURL = corezoidURL })
+	os.Setenv("COREZOID_API_URL", corezoidURL)
+	if err := updateEnvFile(envPath, "COREZOID_API_URL", corezoidURL); err != nil {
+		logger.Warn("login: could not save COREZOID_API_URL: %v", err)
+	}
+	logger.Info("login: COREZOID_API_URL=%q%s", corezoidURL, logSuffix)
+}
+
 // handleLogin runs the OAuth2 PKCE flow. ACCOUNT_URL, WORKSPACE_ID, and
 // COREZOID_STAGE_ID are persisted to the project .env; ACCESS_TOKEN is saved
 // to ~/.corezoid/credentials via saveCredentials(). The handler is
@@ -53,11 +79,23 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 		// Arguments override .env so users can switch environments explicitly.
 		if v := optStrArg(args, "account_url"); v != "" {
 			if v != accountURL {
-				// Account URL changed; the derived API URL is no longer valid for the new host.
+				// Account URL changed; the derived API URL and git mirror URL are
+				// no longer valid for the new host (gitURL is host-derived from
+				// ACCOUNT_URL exactly like apiURL — see deriveGitURL).
 				apiURL = ""
+				gitURL = ""
+				gitStagePath = ""
 				os.Setenv("COREZOID_API_URL", "")
+				os.Setenv("COREZOID_GIT_URL", "")
+				os.Setenv("COREZOID_GIT_STAGE_PATH", "")
 				if err := updateEnvFile(envPath, "COREZOID_API_URL", ""); err != nil {
 					logger.Warn("login: could not clear COREZOID_API_URL on host switch: %v", err)
+				}
+				if err := updateEnvFile(envPath, "COREZOID_GIT_URL", ""); err != nil {
+					logger.Warn("login: could not clear COREZOID_GIT_URL on host switch: %v", err)
+				}
+				if err := updateEnvFile(envPath, "COREZOID_GIT_STAGE_PATH", ""); err != nil {
+					logger.Warn("login: could not clear COREZOID_GIT_STAGE_PATH on host switch: %v", err)
 				}
 			}
 			accountURL = v
@@ -67,6 +105,14 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 			}
 		}
 		if v := optStrArg(args, "workspace_id"); v != "" {
+			if v != workspaceID {
+				// Workspace changed — any previously resolved project ID is invalid.
+				cachedProjectID = 0
+				os.Unsetenv("COREZOID_PROJECT_ID")
+				if err := removeEnvKey(envPath, "COREZOID_PROJECT_ID"); err != nil {
+					logger.Warn("login: could not clear COREZOID_PROJECT_ID on workspace switch: %v", err)
+				}
+			}
 			workspaceID = v
 			os.Setenv("WORKSPACE_ID", v)
 			if err := updateEnvFile(envPath, "WORKSPACE_ID", v); err != nil {
@@ -75,6 +121,23 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 		}
 		if v := optStrArg(args, "stage_id"); v != "" {
 			if id, err := strconv.Atoi(v); err == nil && id != 0 {
+				if id != stageID {
+					// cachedProjectID and the resolved git stage path are keyed by
+					// stage (resolveProjectID resolves from COREZOID_STAGE_ID), so
+					// they're invalid the moment the stage changes — not just on a
+					// workspace switch. Leaving them stale would silently mix the
+					// old stage's project/git-mirror context into the new stage.
+					cachedProjectID = 0
+					gitStagePath = ""
+					os.Unsetenv("COREZOID_PROJECT_ID")
+					os.Unsetenv("COREZOID_GIT_STAGE_PATH")
+					if err := removeEnvKey(envPath, "COREZOID_PROJECT_ID"); err != nil {
+						logger.Warn("login: could not clear COREZOID_PROJECT_ID on stage switch: %v", err)
+					}
+					if err := removeEnvKey(envPath, "COREZOID_GIT_STAGE_PATH"); err != nil {
+						logger.Warn("login: could not clear COREZOID_GIT_STAGE_PATH on stage switch: %v", err)
+					}
+				}
 				stageID = id
 				os.Setenv("COREZOID_STAGE_ID", v)
 				if err := updateEnvFile(envPath, "COREZOID_STAGE_ID", v); err != nil {
@@ -174,17 +237,7 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 		apiURLEmpty := apiURL == ""
 		authStateMu.RUnlock()
 		if apiURLEmpty {
-			corezoidURL, fetchErr := fetchCorezoidAPIURL(snapAccountURL, res.AccessToken)
-			if fetchErr != nil {
-				logger.Warn("login: fetchCorezoidAPIURL failed: %v", fetchErr)
-			} else {
-				withAuthLock(func() { apiURL = corezoidURL })
-				os.Setenv("COREZOID_API_URL", corezoidURL)
-				if err := updateEnvFile(envPath, "COREZOID_API_URL", corezoidURL); err != nil {
-					logger.Warn("login: could not save COREZOID_API_URL: %v", err)
-				}
-				logger.Info("login: derived COREZOID_API_URL=%q from clients API", corezoidURL)
-			}
+			resolveAndSaveAPIURL(snapAccountURL, res.AccessToken, envPath, "")
 		}
 	} else if snapToken != "" {
 		// If we already have a token but no derived API URL (e.g. token came from
@@ -193,17 +246,7 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 		apiURLEmpty := apiURL == ""
 		authStateMu.RUnlock()
 		if apiURLEmpty {
-			corezoidURL, fetchErr := fetchCorezoidAPIURL(snapAccountURL, snapToken)
-			if fetchErr != nil {
-				logger.Warn("login: fetchCorezoidAPIURL failed: %v", fetchErr)
-			} else {
-				withAuthLock(func() { apiURL = corezoidURL })
-				os.Setenv("COREZOID_API_URL", corezoidURL)
-				if err := updateEnvFile(envPath, "COREZOID_API_URL", corezoidURL); err != nil {
-					logger.Warn("login: could not save COREZOID_API_URL: %v", err)
-				}
-				logger.Info("login: derived COREZOID_API_URL=%q from clients API (pre-existing token)", corezoidURL)
-			}
+			resolveAndSaveAPIURL(snapAccountURL, snapToken, envPath, " (pre-existing token)")
 		}
 	} else {
 		// API key flow: COREZOID_API_URL cannot be derived via /face/api/1/clients
@@ -272,6 +315,14 @@ func handleLogin(ctx context.Context, args map[string]interface{}) (string, bool
 					id := selected
 					if raw, ok := wsIDByLabel[selected]; ok {
 						id = raw
+					}
+					// We're inside the snapWorkspaceID == "" branch, i.e. this always
+					// sets a workspace where none was configured before — clear any
+					// stale leftover COREZOID_PROJECT_ID defensively.
+					withAuthLock(func() { cachedProjectID = 0 })
+					os.Unsetenv("COREZOID_PROJECT_ID")
+					if err := removeEnvKey(envPath, "COREZOID_PROJECT_ID"); err != nil {
+						logger.Warn("login: could not clear COREZOID_PROJECT_ID on workspace switch: %v", err)
 					}
 					snapWorkspaceID = id
 					withAuthLock(func() { workspaceID = id })
@@ -526,8 +577,24 @@ func handleLogout(_ context.Context, _ map[string]interface{}) (string, bool) {
 	if err := removeEnvKey(envPath, "API_SECRET"); err != nil {
 		logger.Warn("logout: could not remove API_SECRET from .env: %v", err)
 	}
+	if err := removeEnvKey(envPath, "COREZOID_PROJECT_ID"); err != nil {
+		logger.Warn("logout: could not remove COREZOID_PROJECT_ID from .env: %v", err)
+	}
+	// gitURL/gitStagePath are host- and stage-derived exactly like apiURL and
+	// cachedProjectID — leaving them behind would make the next login into a
+	// different environment silently try to reach the old environment's git
+	// mirror (resolveGitURL short-circuits on any non-empty gitURL).
+	if err := removeEnvKey(envPath, "COREZOID_GIT_URL"); err != nil {
+		logger.Warn("logout: could not remove COREZOID_GIT_URL from .env: %v", err)
+	}
+	if err := removeEnvKey(envPath, "COREZOID_GIT_STAGE_PATH"); err != nil {
+		logger.Warn("logout: could not remove COREZOID_GIT_STAGE_PATH from .env: %v", err)
+	}
 	os.Unsetenv("API_LOGIN")
 	os.Unsetenv("API_SECRET")
+	os.Unsetenv("COREZOID_PROJECT_ID")
+	os.Unsetenv("COREZOID_GIT_URL")
+	os.Unsetenv("COREZOID_GIT_STAGE_PATH")
 	withAuthLock(func() {
 		apiToken = ""
 		accountURL = ""
@@ -536,6 +603,9 @@ func handleLogout(_ context.Context, _ map[string]interface{}) (string, bool) {
 		apiURL = ""
 		apiLogin = ""
 		apiSecret = ""
+		cachedProjectID = 0
+		gitURL = ""
+		gitStagePath = ""
 	})
 
 	browserHost := strings.TrimRight(snapAccountURL, "/")

--- a/plugins/corezoid/mcp-server/mcp_handlers_git.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_git.go
@@ -1,0 +1,295 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// resolveAndSaveStagePath finds the stage directory inside .git-context/ that
+// matches the current COREZOID_STAGE_ID, saves the relative path to the global
+// gitStagePath and to COREZOID_GIT_STAGE_PATH in the project .env file.
+// Returns the path (empty string if not found or stage ID not set).
+func resolveAndSaveStagePath() string {
+	sid := func() int {
+		authStateMu.RLock()
+		defer authStateMu.RUnlock()
+		return stageID
+	}()
+
+	if sid == 0 {
+		logger.Warn("git-pull-context: COREZOID_STAGE_ID not set — cannot resolve stage path")
+		return ""
+	}
+
+	stagePath, err := findGitStagePath(gitContextDir(), sid)
+	if err != nil {
+		logger.Warn("git-pull-context: stage path search failed: %v", err)
+		return ""
+	}
+	if stagePath == "" {
+		logger.Warn("git-pull-context: stage %d not found in git context (not yet mirrored?)", sid)
+		return ""
+	}
+
+	withAuthLock(func() { gitStagePath = stagePath })
+	os.Setenv("COREZOID_GIT_STAGE_PATH", stagePath)
+	if err := updateEnvFile(envFilePath(), "COREZOID_GIT_STAGE_PATH", stagePath); err != nil {
+		logger.Warn("git-pull-context: could not save COREZOID_GIT_STAGE_PATH to .env: %v", err)
+	}
+	logger.Info("git-pull-context: stage path resolved → %s", stagePath)
+
+	copyStageCLAUDEMD(gitContextDir(), stagePath)
+	return stagePath
+}
+
+// copyStageCLAUDEMD copies CLAUDE.md from the stage directory inside
+// .git-context/ to the project root (COREZOID_WORK_DIR / cwd).
+// The mirror content is merged into the root file via injectMirrorBlock
+// (the mirror-generated file carries its own corezoid-mirror markers), so
+// any content a developer added to the root CLAUDE.md outside those markers
+// survives instead of being clobbered by a blind overwrite.
+func copyStageCLAUDEMD(contextDir, stagePath string) {
+	src := filepath.Join(contextDir, filepath.FromSlash(stagePath), "CLAUDE.md")
+	data, err := os.ReadFile(src)
+	if err != nil {
+		if os.IsNotExist(err) {
+			logger.Info("git-pull-context: no CLAUDE.md in stage yet (not mirrored or stage empty)")
+		} else {
+			logger.Warn("git-pull-context: could not read stage CLAUDE.md: %v", err)
+		}
+		return
+	}
+
+	dst := filepath.Join(gitContextDir(), "..", "CLAUDE.md") // = cwd/CLAUDE.md
+	dst = filepath.Clean(dst)
+
+	var existing string
+	if existingData, readErr := os.ReadFile(dst); readErr == nil {
+		existing = string(existingData)
+	}
+	merged := injectMirrorBlock(existing, string(data))
+
+	if err := os.WriteFile(dst, []byte(merged), 0644); err != nil {
+		logger.Warn("git-pull-context: could not write CLAUDE.md to project root: %v", err)
+		return
+	}
+	logger.Info("git-pull-context: CLAUDE.md copied to project root (%d bytes)", len(merged))
+}
+
+// resolveGitURL returns COREZOID_GIT_URL, deriving it from ACCOUNT_URL if not
+// already set. Saves the derived URL to the global and to .env so it persists
+// across server restarts. Returns ("", false) on any failure — caller silently skips.
+func resolveGitURL() (string, bool) {
+	gURL, _, _, _, acctURL := gitConfigSnapshot()
+	if gURL != "" {
+		return gURL, true
+	}
+
+	derived, err := deriveGitURL(acctURL)
+	if err != nil {
+		logger.Warn("git-pull-context: cannot derive COREZOID_GIT_URL from ACCOUNT_URL %q: %v", acctURL, err)
+		return "", false
+	}
+
+	withAuthLock(func() { gitURL = derived })
+	os.Setenv("COREZOID_GIT_URL", derived)
+	if err := updateEnvFile(envFilePath(), "COREZOID_GIT_URL", derived); err != nil {
+		logger.Warn("git-pull-context: could not save COREZOID_GIT_URL to .env: %v", err)
+	}
+	logger.Info("git-pull-context: derived COREZOID_GIT_URL=%s", derived)
+	return derived, true
+}
+
+// resolveProjectID returns the numeric project ID that owns the current
+// stage, needed to build the project-level git mirror clone URL
+// (c-<companyID>-p-<projectID>). Delegates to resolveAndCacheProjectID (see
+// main.go) — the same in-memory/.env cache used by push-process's
+// auto-snapshot and pull-folder's pre-warm, so the git-context and process
+// paths never resolve or persist COREZOID_PROJECT_ID independently.
+// Returns 0 if COREZOID_STAGE_ID is unset or resolution fails — callers treat
+// 0 as "cannot build the project-level mirror repo URL yet" and fall back to
+// local mode.
+func resolveProjectID(ctx context.Context) int {
+	pid, _ := resolveAndCacheProjectID(NewValidator(ctx, 0))
+	return pid
+}
+
+// syncGitContext derives COREZOID_GIT_URL (best-effort), pulls/clones/reconnects
+// .git-context/ via gitPullContext, and resolves+saves the current stage path.
+// It's the single sequence shared by ensureGitContext (pull-folder's best-effort
+// caller) and handleGitPullContext (the explicit MCP tool) — a fix to this
+// sequence only has to be made once instead of kept in lockstep across both.
+func syncGitContext(ctx context.Context) (msg, stagePath string, err error) {
+	// Best-effort URL derivation — gitPullContext handles all credential combinations:
+	//   GIT_URL + API_LOGIN + API_SECRET all present → try online, fallback to local on error
+	//   any of the three missing              → go straight to local mode
+	resolveGitURL()
+
+	msg, err = gitPullContext(ctx)
+	if err != nil {
+		return "", "", err
+	}
+
+	stagePath = resolveAndSaveStagePath()
+	return msg, stagePath, nil
+}
+
+// ensureGitContext tries to sync .git-context/ before pull-folder downloads
+// processes. It falls back to local mode if Gitea is unreachable.
+// Never returns an error — on total failure it logs a warning and returns false.
+func ensureGitContext(ctx context.Context) bool {
+	_, _, _, gCompany, _ := gitConfigSnapshot()
+
+	if gCompany == "" {
+		logger.Warn("git-pull-context: WORKSPACE_ID not set — skipping git context entirely")
+		return false
+	}
+
+	msg, _, err := syncGitContext(ctx)
+	if err != nil {
+		logger.Warn("git-pull-context: %v — continuing without git context", err)
+		return false
+	}
+	logger.Info("git-pull-context: %s", msg)
+	return true
+}
+
+// regenerateLocalCLAUDEMDIfNeeded regenerates CLAUDE.md from local .conv.json
+// files when running in offline / local mode. Called after pull-folder so the
+// process list is fresh. No-op in online mode (mirror CLAUDE.md is authoritative).
+func regenerateLocalCLAUDEMDIfNeeded(ctx context.Context) {
+	contextDir := gitContextDir()
+	if _, err := os.Stat(filepath.Join(contextDir, ".git")); err != nil {
+		return // no .git-context at all — git was completely skipped
+	}
+	if !isLocalOnlyContext(ctx, contextDir) {
+		return // online mode — copyStageCLAUDEMD already handled it
+	}
+	sp := gitStagePathSnapshot()
+	if sp == "" {
+		return
+	}
+	if err := generateLocalCLAUDEMD(ctx, sp); err != nil {
+		logger.Warn("git-pull-context: local CLAUDE.md generation failed: %v", err)
+	}
+}
+
+// handleGitPullContext is the MCP tool handler for "git-pull-context".
+// Surfaces errors to the caller; derives COREZOID_GIT_URL automatically.
+func handleGitPullContext(ctx context.Context, args map[string]interface{}) (string, bool) {
+	_, _, _, gCompany, _ := gitConfigSnapshot()
+
+	if gCompany == "" {
+		return "Error: WORKSPACE_ID not set. Run the 'login' tool first to select a workspace.", true
+	}
+
+	msg, stagePath, err := syncGitContext(ctx)
+	if err != nil {
+		return fmt.Sprintf("Error: %v", err), true
+	}
+	if stagePath != "" {
+		msg += fmt.Sprintf("\nStage path: %s", stagePath)
+	}
+	return msg, false
+}
+
+// handleGitPushContext is the MCP tool handler for "git-push-context".
+func handleGitPushContext(ctx context.Context, args map[string]interface{}) (string, bool) {
+	commitMsg, _ := args["commit_message"].(string)
+
+	msg, err := gitPushContext(ctx, commitMsg)
+	if err != nil {
+		return fmt.Sprintf("Error: %v", err), true
+	}
+
+	// In local mode: after committing _ext/docs/ changes, rebuild CLAUDE.md so
+	// Developer Notes (from _ext/docs/*.md) are visible without a full pull-folder.
+	regenerateLocalCLAUDEMDIfNeeded(ctx)
+
+	return msg, false
+}
+
+// handleReadContextFile reads a file from .git-context/ and returns its content.
+func handleReadContextFile(ctx context.Context, args map[string]interface{}) (string, bool) {
+	relPath, err := strArg(args, "path")
+	if err != nil {
+		return "Error: " + err.Error(), true
+	}
+
+	targetDir := gitContextDir()
+	fullPath := filepath.Join(targetDir, filepath.FromSlash(relPath))
+
+	// Prevent path traversal outside .git-context/.
+	if !strings.HasPrefix(fullPath, targetDir+string(os.PathSeparator)) && fullPath != targetDir {
+		return "Error: path escapes .git-context/ directory", true
+	}
+
+	data, err := os.ReadFile(fullPath)
+	if err != nil {
+		return fmt.Sprintf("Error reading %s: %v", relPath, err), true
+	}
+	return string(data), false
+}
+
+// handleUpdateContextFile writes or appends content to a file inside _ext/.
+func handleUpdateContextFile(ctx context.Context, args map[string]interface{}) (string, bool) {
+	relPath, err := strArg(args, "path")
+	if err != nil {
+		return "Error: " + err.Error(), true
+	}
+	content, err := strArg(args, "content")
+	if err != nil {
+		return "Error: " + err.Error(), true
+	}
+	mode, _ := args["mode"].(string)
+	if mode == "" {
+		mode = "replace"
+	}
+
+	// Validate that the path resolves to an _ext/ directory.
+	// Accepted forms:
+	//   _ext/docs/context.md                                         (workspace-root _ext/)
+	//   projects/123_Foo/stages/456_Bar/_ext/docs/context.md        (stage _ext/)
+	clean := filepath.ToSlash(filepath.Clean(relPath))
+	isExtPath := strings.HasPrefix(clean, "_ext/") || strings.Contains(clean, "/_ext/")
+	if !isExtPath {
+		return "Error: update-context-file can only write to _ext/ paths (e.g. _ext/docs/context.md or projects/.../stages/.../_ext/docs/context.md)", true
+	}
+
+	targetDir := gitContextDir()
+	fullPath := filepath.Join(targetDir, filepath.FromSlash(relPath))
+
+	// C1: containment guard — same as handleReadContextFile.
+	// filepath.Join already cleans ".." but we must still verify the result stays
+	// inside .git-context/ so a path like "../_ext/evil" cannot escape.
+	if !strings.HasPrefix(fullPath, targetDir+string(os.PathSeparator)) {
+		return "Error: path escapes .git-context/ directory", true
+	}
+
+	if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+		return fmt.Sprintf("Error creating directory for %s: %v", relPath, err), true
+	}
+
+	var flag int
+	switch mode {
+	case "append":
+		flag = os.O_CREATE | os.O_WRONLY | os.O_APPEND
+	default:
+		flag = os.O_CREATE | os.O_WRONLY | os.O_TRUNC
+	}
+
+	f, err := os.OpenFile(fullPath, flag, 0644)
+	if err != nil {
+		return fmt.Sprintf("Error opening %s: %v", relPath, err), true
+	}
+	defer f.Close()
+
+	if _, err := f.WriteString(content); err != nil {
+		return fmt.Sprintf("Error writing %s: %v", relPath, err), true
+	}
+
+	return fmt.Sprintf("Written to %s (mode=%s)", relPath, mode), false
+}

--- a/plugins/corezoid/mcp-server/mcp_handlers_process.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_process.go
@@ -116,11 +116,18 @@ func handlePullProcess(ctx context.Context, args map[string]interface{}) (string
 
 // handlePullFolder recursively downloads a folder (stage) and all its
 // processes/subfolders into the current working directory.
+// Before downloading processes, it attempts to sync the git mirror context
+// into .git-context/ (non-blocking — a git failure does not abort the pull).
 func handlePullFolder(ctx context.Context, args map[string]interface{}) (string, bool) {
 	folderID, err := intArg(args, "folder_id")
 	if err != nil {
 		return "Error: " + err.Error(), true
 	}
+
+	// Sync git mirror context before downloading processes.
+	// ensureGitContext handles elicitation of COREZOID_GIT_URL if missing,
+	// and silently skips on any error so the main pull always proceeds.
+	ensureGitContext(ctx)
 
 	v := NewValidator(ctx, 0)
 
@@ -131,6 +138,11 @@ func handlePullFolder(ctx context.Context, args map[string]interface{}) (string,
 	if err := downloadStageRecursively(v, folderID, "."); err != nil {
 		return fmt.Sprintf("Error fetching folder: %v", err), true
 	}
+
+	// In local/offline mode: regenerate CLAUDE.md from the freshly-downloaded
+	// .conv.json files (online mode copies it from the Gitea mirror instead).
+	regenerateLocalCLAUDEMDIfNeeded(ctx)
+
 	return fmt.Sprintf("Folder %d saved to current directory", folderID), false
 }
 
@@ -272,6 +284,9 @@ func handlePushProcess(ctx context.Context, args map[string]interface{}) (string
 	if _, err := v.ProcessJSON(filePath, jsonContent); err != nil {
 		return fmt.Sprintf("Error deploying process: %v", err), true
 	}
+
+	// In local mode: regenerate CLAUDE.md so the process index stays current.
+	regenerateLocalCLAUDEMDIfNeeded(ctx)
 
 	result := fmt.Sprintf("Process deployed successfully, ProcessID: %d", procID)
 	if rehydrateNote != "" {

--- a/plugins/corezoid/mcp-server/snapshot_helpers_test.go
+++ b/plugins/corezoid/mcp-server/snapshot_helpers_test.go
@@ -109,10 +109,13 @@ func TestResolveAndCacheProjectID_FromEnv(t *testing.T) {
 	defer func() { cachedProjectID = orig }()
 
 	os.Setenv("COREZOID_PROJECT_ID", "188280")
+	os.Setenv("COREZOID_PROJECT_ID_STAGE_ID", "4242")
 	defer os.Unsetenv("COREZOID_PROJECT_ID")
+	defer os.Unsetenv("COREZOID_PROJECT_ID_STAGE_ID")
 
-	// v with StageID=0 — API path must not be reached.
-	v := &Executor{}
+	// StageID matches COREZOID_PROJECT_ID_STAGE_ID, so the env fast path is
+	// trusted — API path must not be reached.
+	v := &Executor{StageID: 4242}
 	got, notice := resolveAndCacheProjectID(v)
 	if got != 188280 {
 		t.Errorf("expected 188280 from env, got %d", got)
@@ -137,5 +140,59 @@ func TestResolveAndCacheProjectID_FromCache(t *testing.T) {
 	}
 	if notice != "" {
 		t.Errorf("expected no notice from cache path, got %q", notice)
+	}
+}
+
+// TestResolveAndCacheProjectID_FromEnv_StageMismatch pins the fix for a bug
+// where a manually-edited .env (WORKSPACE_ID/COREZOID_STAGE_ID changed without
+// going through the login tool, which clears the cache on a real switch) would
+// silently reuse a COREZOID_PROJECT_ID resolved for a different stage — pointing
+// git-pull-context/git-push-context at the wrong project's mirror repo.
+func TestResolveAndCacheProjectID_FromEnv_StageMismatch(t *testing.T) {
+	orig := cachedProjectID
+	cachedProjectID = 0
+	defer func() { cachedProjectID = orig }()
+
+	// COREZOID_PROJECT_ID was resolved for stage 4242, but the executor (and,
+	// in the real bug, the freshly-loaded COREZOID_STAGE_ID) is now on a
+	// different stage.
+	os.Setenv("COREZOID_PROJECT_ID", "188280")
+	os.Setenv("COREZOID_PROJECT_ID_STAGE_ID", "4242")
+	defer os.Unsetenv("COREZOID_PROJECT_ID")
+	defer os.Unsetenv("COREZOID_PROJECT_ID_STAGE_ID")
+
+	// Empty APIUrl makes the fallback API call fail fast (no network I/O) —
+	// the assertion is that the stale env value is never returned/cached, not
+	// that resolution succeeds.
+	v := &Executor{StageID: 9999}
+	got, notice := resolveAndCacheProjectID(v)
+	if got != 0 {
+		t.Errorf("expected stale COREZOID_PROJECT_ID for a different stage to be rejected, got %d", got)
+	}
+	if notice != "" {
+		t.Errorf("expected no notice, got %q", notice)
+	}
+	if cachedProjectID != 0 {
+		t.Errorf("expected cachedProjectID to remain 0, got %d", cachedProjectID)
+	}
+}
+
+func TestProjectIDStageMatches(t *testing.T) {
+	defer os.Unsetenv("COREZOID_PROJECT_ID_STAGE_ID")
+
+	os.Unsetenv("COREZOID_PROJECT_ID_STAGE_ID")
+	if projectIDStageMatches(4242) {
+		t.Error("expected no match when COREZOID_PROJECT_ID_STAGE_ID is unset")
+	}
+
+	os.Setenv("COREZOID_PROJECT_ID_STAGE_ID", "4242")
+	if !projectIDStageMatches(4242) {
+		t.Error("expected match when stage IDs are equal")
+	}
+	if projectIDStageMatches(9999) {
+		t.Error("expected no match when stage IDs differ")
+	}
+	if projectIDStageMatches(0) {
+		t.Error("expected no match when stageID=0 (no real stage context)")
 	}
 }

--- a/plugins/corezoid/mcp-server/tools_registry.go
+++ b/plugins/corezoid/mcp-server/tools_registry.go
@@ -1283,4 +1283,63 @@ var toolRegistry = []mcpTool{
 			"required": []string{"process_path", "snapshot_id"},
 		},
 	},
+
+	// git mirror
+	{
+		Name:        "git-pull-context",
+		Description: "Clone or pull the Corezoid git mirror for the current workspace into .git-context/. Requires COREZOID_GIT_URL, API_LOGIN, and API_SECRET. Silently skipped if not configured.",
+		InputSchema: map[string]interface{}{
+			"type":       "object",
+			"properties": map[string]interface{}{},
+		},
+	},
+	{
+		Name:        "git-push-context",
+		Description: "Commit and push local _ext/ changes to the Corezoid git mirror. Requires API_LOGIN and API_SECRET. Returns a warning (not an error) if nothing changed.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"commit_message": map[string]interface{}{
+					"type":        "string",
+					"description": "Optional git commit message. Defaults to 'docs: update _ext/ after task session <timestamp>'.",
+				},
+			},
+		},
+	},
+	{
+		Name:        "read-context-file",
+		Description: "Read a file from .git-context/ of the current workspace (git mirror local copy). Returns content and a found flag.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"path": map[string]interface{}{
+					"type":        "string",
+					"description": "Relative path inside .git-context/, e.g. projects/123_Name/stages/456_Stage/_ext/docs/context.md",
+				},
+			},
+			"required": []string{"path"},
+		},
+	},
+	{
+		Name:        "update-context-file",
+		Description: "Write or append to a file inside _ext/ of the git mirror local copy (.git-context/). Path must start with _ext/. Use git-push-context to publish the changes.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"path": map[string]interface{}{
+					"type":        "string",
+					"description": "Relative path inside .git-context/, must start with _ext/ (e.g. _ext/docs/context.md or projects/123/stages/456/_ext/docs/context.md)",
+				},
+				"content": map[string]interface{}{
+					"type":        "string",
+					"description": "Text content to write",
+				},
+				"mode": map[string]interface{}{
+					"type":        "string",
+					"description": "Write mode: 'replace' (default) overwrites the file; 'append' adds to the end",
+				},
+			},
+			"required": []string{"path", "content"},
+		},
+	},
 }

--- a/plugins/corezoid/skills/corezoid-create/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-create/SKILL.md
@@ -207,3 +207,26 @@ Use the `Read` tool to load these files when specific node or validation details
 | `${CLAUDE_PLUGIN_ROOT}/samples/create-actors.json` | Business logic with multiple process calls |
 | `${CLAUDE_PLUGIN_ROOT}/samples/gpt-calculator.json` | GPT integration example |
 | `${CLAUDE_PLUGIN_ROOT}/samples/create-user.json` | User creation process |
+
+---
+
+## Final Step: Update Git Context
+
+> **Do NOT report the task as complete and do NOT stop until this step is evaluated.**
+> The main task being deployed does not mean the session is over — this step is next.
+
+Immediately after `push-process` or `create-process` succeeds, check whether
+**at least one** of the following is true:
+
+- `push-process` or `create-process` was actually called (not just previewed);
+- a new external host/API/service appeared that is not yet in `dependencies.md`;
+- an architectural decision was made (one approach chosen over another);
+- an issue was found or closed during this session.
+
+**If yes → activate `corezoid-git-context` skill right now.** Do not wait for the
+user to ask. Do not skip because the main task "looks done".
+
+**If none of the above → skip** and tell the user the session is complete.
+
+The skill handles everything autonomously: reads current `_ext/docs/`, proposes
+a unified diff, asks confirmation, writes files, and pushes — one invocation.

--- a/plugins/corezoid/skills/corezoid-edit/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-edit/SKILL.md
@@ -148,3 +148,26 @@ Use the `Read` tool to load these files when specific node or validation details
 | `${CLAUDE_PLUGIN_ROOT}/samples/create-user.json` | User creation process |
 | `${CLAUDE_PLUGIN_ROOT}/samples/gpt-calculator.json` | GPT integration example |
 | `${CLAUDE_PLUGIN_ROOT}/samples/api-post.json` | HTTP POST API call example |
+
+---
+
+## Final Step: Update Git Context
+
+> **Do NOT report the task as complete and do NOT stop until this step is evaluated.**
+> The main task being deployed does not mean the session is over — this step is next.
+
+Immediately after `push-process` or `create-process` succeeds, check whether
+**at least one** of the following is true:
+
+- `push-process` or `create-process` was actually called (not just previewed);
+- a new external host/API/service appeared that is not yet in `dependencies.md`;
+- an architectural decision was made (one approach chosen over another);
+- an issue was found or closed during this session.
+
+**If yes → activate `corezoid-git-context` skill right now.** Do not wait for the
+user to ask. Do not skip because the main task "looks done".
+
+**If none of the above → skip** and tell the user the session is complete.
+
+The skill handles everything autonomously: reads current `_ext/docs/`, proposes
+a unified diff, asks confirmation, writes files, and pushes — one invocation.

--- a/plugins/corezoid/skills/corezoid-git-context/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-git-context/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: corezoid-git-context
+description: >
+  Analyzes the current session and updates _ext/docs/*.md in the Corezoid git
+  mirror for the active stage. Use after corezoid-edit, corezoid-create, or
+  corezoid-review when the session was substantial (processes deployed, new
+  external dependencies discovered, architectural decisions made, issues found
+  or resolved). Activate when the user says "update context", "save context",
+  "update docs", "push context", "зафіксуй контекст", "збережи контекст",
+  "оновити документацію", "corezoid-git-context", or signals the session is
+  wrapping up after real changes were made to Corezoid. Do NOT activate for
+  purely informational sessions where nothing was deployed.
+---
+
+# Session Analysis — Update _ext/docs/*.md
+
+You manage the documentation layer for the Corezoid stage in the git mirror.
+Your only write surface is `_ext/docs/` inside the stage directory.
+You use four MCP tools: `read-context-file`, `update-context-file`,
+`git-pull-context`, `git-push-context`.
+
+---
+
+## Prerequisites — skip entirely if any condition is not met
+
+Before doing anything, verify all of the following. If any check fails, log
+one warning line and stop — do not continue to subsequent steps.
+
+1. **Stage path known** — read `.env` in the current working directory and
+   extract `COREZOID_GIT_STAGE_PATH`.
+   - If the key is absent → "Git context not configured for this stage (COREZOID_GIT_STAGE_PATH missing). Skipping context update."
+2. **Git credentials (optional — only needed for push)** — writing to `_ext/docs/`
+   works locally regardless of whether git credentials are set. The `git-push-context`
+   step at the end will silently skip if `API_LOGIN`, `API_SECRET`, or
+   `COREZOID_GIT_URL` are missing — local commits are preserved and will be
+   pushed when credentials become available.
+   - Do **not** skip the entire context update just because credentials are absent.
+3. **Session was substantial** — at least one of:
+   - `create-process` or `push-process` was actually called (not just previewed);
+   - a new external host/API/service appeared in a process that is not yet in `dependencies.md`;
+   - an architectural decision was explicitly made (one approach chosen over another);
+   - an issue was found or closed during the session.
+   - If none of the above → "Session was informational only. No context update needed."
+
+---
+
+## Step 1 — Sync git context
+
+Call `git-pull-context` with no arguments. This ensures `.git-context/` is
+up to date before reading or writing any files. If the tool returns an error,
+stop and report: "Could not sync git context: {error}. Skipping update."
+
+---
+
+## Step 2 — Read current state of all 5 files
+
+Using `STAGE_PATH` = value of `COREZOID_GIT_STAGE_PATH` from `.env`:
+
+Call `read-context-file` for each path below. A "not found" result is normal
+— treat missing files as empty (no current content).
+
+| File | Path |
+|------|------|
+| context.md | `{STAGE_PATH}/_ext/docs/context.md` |
+| invariants.md | `{STAGE_PATH}/_ext/docs/invariants.md` |
+| decisions.md | `{STAGE_PATH}/_ext/docs/decisions.md` |
+| dependencies.md | `{STAGE_PATH}/_ext/docs/dependencies.md` |
+| issues.md | `{STAGE_PATH}/_ext/docs/issues.md` |
+
+Read **all 5 at once** before analysing — you need the full picture to avoid
+duplication and to detect which existing entries need updating.
+
+---
+
+## Step 3 — Classify: which files to touch and how
+
+Analyse the session transcript and the Corezoid diff (what was
+created/changed/deployed) against the current file contents.
+
+Typically only 1–2 files need changes. Apply the following rules per file:
+
+### context.md
+**What it is:** living description of the stage's business purpose and role.
+**When to touch:** only if the stage's purpose or role genuinely changed.
+**How:** replace the relevant sentence/paragraph in place. Not a journal —
+do not append. If the file is missing and there is clear new context to
+record, create it.
+
+### invariants.md
+**What it is:** constraints that must never be violated.
+**When to touch:** new invariant discovered, or existing one proved wrong.
+**How:** replace in place. Never create an empty placeholder.
+
+### decisions.md
+**What it is:** ADR-style log of architectural decisions.
+**When to touch:** a real architectural decision was made (chose approach A
+over B, accepted a trade-off, chose a pattern).
+**How:** append a new entry in this format:
+```
+## {Short title} — {YYYY-MM-DD}
+**Decision:** {what was decided}
+**Rationale:** {why}
+**Alternatives rejected:** {what and why not}
+```
+If an older decision is now superseded, add `**Superseded by:** {new title}`
+to the old entry — do not silently rewrite it.
+
+### dependencies.md
+**What it is:** external APIs, services, queues this stage integrates with.
+**When to touch:** a new external host/service appeared in the session.
+**How:** check existing entries first — if the same service is already listed,
+do not add a duplicate. If genuinely new, append:
+```
+- **{ServiceName}** — {URL or endpoint pattern} — {what it's used for}
+```
+
+### issues.md
+**What it is:** known problems, limitations, TODOs.
+**When to touch:** new issue found, or existing issue resolved.
+**How:**
+- New issue → append:
+  ```
+  - [ ] {description} — found {YYYY-MM-DD}
+  ```
+- Resolved issue → find the matching open entry and mark it:
+  ```
+  - [x] {description} — found {date}, resolved {YYYY-MM-DD}
+  ```
+  Replace the existing line in-place using `mode: replace` on the full file
+  content, do not append a duplicate.
+
+---
+
+## Step 4 — Unified diff and confirmation
+
+**Before writing anything**, present the full planned changes to the user
+as a single markdown block:
+
+```
+## Proposed context updates
+
+### {filename}.md — {replace | append | new file}
+{show the new content or the changed section clearly}
+
+### {filename2}.md — ...
+...
+```
+
+Then ask: **"Apply these context updates and push to git? (yes/no)"**
+
+- If **yes** → proceed to Step 5.
+- If **no** → "Context update skipped. Your Corezoid changes are already
+  deployed and unaffected." Stop here.
+
+---
+
+## Step 5 — Write files and push
+
+For each file that needs updating:
+
+1. Call `update-context-file` with:
+   - `path`: `{STAGE_PATH}/_ext/docs/{filename}.md`
+   - `content`: the full new file content (for replace) or the text to append
+   - `mode`: `replace` for context/invariants/issues (full rewrite or targeted
+     replace); `append` for decisions/dependencies when adding a new entry
+
+   If the file does not exist yet, `mode: replace` with the full content
+   creates it — the directory structure is created automatically.
+
+2. After **all** files are written, call `git-push-context` once with a
+   meaningful commit message, e.g.:
+   `"docs: update _ext/docs/ after session — {brief summary of what changed}"`
+
+   One push for the whole session, not one push per file.
+
+---
+
+## Error handling
+
+| Situation | Action |
+|-----------|--------|
+| `read-context-file` returns "not found" | Treat as empty file, continue |
+| `update-context-file` returns error | Log warning, skip that file, continue with others |
+| `git-push-context` returns error | Log warning, report to user: "Changes written locally but push failed: {error}. Run git-push-context manually when git is available." |
+| No files needed updating | "Session analysed — no context updates needed." |
+
+---
+
+## What this skill never does
+
+- Never writes to `CLAUDE.md` — that file is owned by the git mirror bot.
+- Never touches files outside `_ext/docs/` (no `_ext/meta/`, no root files).
+- Never creates empty/placeholder files — only writes when there is real content.
+- Never pushes more than once per session invocation.
+- Never blocks or rolls back the main Corezoid task — context update is always optional.

--- a/plugins/corezoid/skills/corezoid-review/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-review/SKILL.md
@@ -354,3 +354,26 @@ Use the `Read` tool to load these files when specific node or validation details
 | `${CLAUDE_PLUGIN_ROOT}/docs/nodes/api-call-node.md` | HTTP API call configuration |
 | `${CLAUDE_PLUGIN_ROOT}/docs/process/error-handling.md` | Error handling patterns |
 | `${CLAUDE_PLUGIN_ROOT}/docs/process/process-json-validation.md` | Validation rules and common errors |
+
+---
+
+## Final Step: Update Git Context
+
+> **Do NOT report the task as complete and do NOT stop until this step is evaluated.**
+> The main task being deployed does not mean the session is over — this step is next.
+
+Immediately after `push-process` or `create-process` succeeds, check whether
+**at least one** of the following is true:
+
+- `push-process` or `create-process` was actually called (not just previewed);
+- a new external host/API/service appeared that is not yet in `dependencies.md`;
+- an architectural decision was made (one approach chosen over another);
+- an issue was found or closed during this session.
+
+**If yes → activate `corezoid-git-context` skill right now.** Do not wait for the
+user to ask. Do not skip because the main task "looks done".
+
+**If none of the above → skip** and tell the user the session is complete.
+
+The skill handles everything autonomously: reads current `_ext/docs/`, proposes
+a unified diff, asks confirmation, writes files, and pushes — one invocation.

--- a/plugins/corezoid/skills/corezoid/SKILL.md
+++ b/plugins/corezoid/skills/corezoid/SKILL.md
@@ -54,6 +54,10 @@ You have access to the Corezoid API via the `corezoid` MCP server.
 | `list-snapshots` | List all snapshots for a process |
 | `delete-snapshot` | Delete a snapshot by snapshot_id |
 | `get-snapshot` | Get snapshot node list for diff comparison against current process |
+| `git-pull-context` | Clone or pull the Corezoid git mirror into `.git-context/` |
+| `git-push-context` | Commit and push `_ext/` changes to the git mirror |
+| `read-context-file` | Read a file from `.git-context/` |
+| `update-context-file` | Write or append to a file inside `_ext/` |
 
 ## Platform Architecture
 
@@ -137,6 +141,7 @@ For domain-specific workflows use the specialized skills:
 - `/corezoid-api-connector` — build processes that call the Corezoid public API (`/api/2/json/`) using `api_secret_outer`
 - `/corezoid-retro` — end-of-session retrospective: extract learnings (failed→fixed push deltas, data-shape surprises, corrections) and route them to workspace CLAUDE.md, team feedback, settings, or personal memory with user confirmation
 - `/corezoid-describe` — update or create the description of a process, folder, or project without editing its logic
+- `/corezoid-git-context` — after a substantial session: analyse changes and update `_ext/docs/*.md` in the git mirror
 
 ## Reference Documents
 


### PR DESCRIPTION
## Summary
- Adds `git-pull-context` / `git-push-context` / `read-context-file` / `update-context-file` MCP tools that sync `.git-context/` with the Corezoid Gitea mirror (project-level clone `c-<companyID>-p-<projectID>`), with an automatic local-only fallback repo when Gitea is unreachable and a reconnect-and-merge path when connectivity returns.
- `pull-folder` / `push-process` now sync git context and regenerate `CLAUDE.md` as part of their normal flow — Developer Notes and a process index get merged into `CLAUDE.md` via marker-based injection (`<!-- BEGIN/END corezoid-mirror -->`), preserving any hand-authored content outside the markers in both online and local-only modes.
- New `corezoid-git-context` skill plus routing entries in `corezoid`, `corezoid-create`, `corezoid-edit`, and `corezoid-review` skills.
- Auth hardening found along the way: `cachedProjectID` / `gitURL` / `gitStagePath` are now invalidated on stage switch, host switch, and logout (previously only on workspace switch), and a failed `COREZOID_API_URL` discovery no longer silently falls back to the wrong host.
- Git mirror credentials are never persisted to `.git-context/.git/config` — Basic auth is injected per-invocation via `GIT_CONFIG_*` environment variables instead of a credentialed remote URL.
- `resolveProjectID` (git-context) delegates to the existing `resolveAndCacheProjectID` cache (`main.go`) instead of maintaining a second `COREZOID_PROJECT_ID` cache/persist path.

Branched from current `upstream/main`; version manifests and CHANGELOG.md are intentionally untouched (version bump is a separate release step).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [x] Version-sync check across the 4 plugin manifests
- [x] `scripts/check-skills-sync.py` (CLAUDE.md ↔ README.md ↔ filesystem)
- [x] `sh -n run.sh`, `CLAUDE_PLUGIN_ROOT` path check, no tracked `.env`/credentials
- [ ] Manual smoke test of `git-pull-context` / `git-push-context` against a real Corezoid Gitea mirror (needs a live workspace with git mirror enabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)