### PR TITLE
fix(run-task): stop implicit process redeploy

### DIFF
--- a/plugins/corezoid/mcp-server/mcp_handlers_process.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_process.go
@@ -472,10 +472,10 @@ var runTaskPollEvery = 2 * time.Second
 // instead of waiting out a full poll interval.
 var runTaskFirstPollAfter = 300 * time.Millisecond
 
-// handleRunTask deploys the local process, fires a task at it, and polls until
-// the task reaches a final node or wait_sec elapses. Used to smoke-test a
-// process end-to-end — including processes whose path crosses async nodes
-// (api, api_rpc, db_call, delay), which take longer than one scheduler tick.
+// handleRunTask fires a task at the already-deployed process and polls until it
+// reaches a final node or wait_sec elapses. It deliberately reads runtime node
+// metadata from the server and never deploys the local file: all deployments
+// must pass through push-process and its safety gates first.
 func handleRunTask(ctx context.Context, args map[string]interface{}) (string, bool) {
 	filePath, err := resolveProcessPath(args, "process_path")
 	if err != nil {
@@ -504,21 +504,20 @@ func handleRunTask(ctx context.Context, args map[string]interface{}) (string, bo
 	if errMsg != "" {
 		return errMsg, true
 	}
+	if info, statErr := os.Stat(filePath); statErr != nil {
+		return fmt.Sprintf("Error reading process file: %v", statErr), true
+	} else if info.IsDir() {
+		return fmt.Sprintf("Error reading process file: %s is a directory", filePath), true
+	}
 
 	v := NewValidator(ctx, procID)
-
-	jsonContent, err := LoadBinFromFile(filePath)
-	if err != nil {
-		return fmt.Sprintf("Error reading process file: %v", err), true
-	}
-
-	if _, err := v.ProcessJSON(filePath, jsonContent); err != nil {
-		return fmt.Sprintf("Error deploying process: %v", err), true
-	}
 
 	taskData := make(map[string]interface{})
 	if err := json.Unmarshal([]byte(dataStr), &taskData); err != nil {
 		return fmt.Sprintf("Error parsing task data: %v", err), true
+	}
+	if err := loadRuntimeNodeMap(v); err != nil {
+		return fmt.Sprintf("Error reading deployed process: %v", err), true
 	}
 
 	ref := optStrArg(args, "ref")
@@ -611,6 +610,63 @@ func handleRunTask(ctx context.Context, args map[string]interface{}) (string, bo
 	summary := fmt.Sprintf("%s\nNodeID: %s\nNodeName: %s\nNodeType: %s\nProcessID: %d\nTaskRef: %s\nTaskID: %s\nData: %s",
 		msg, serverNodeID, nodeInfo.Name, nodeType, v.ProcessID, ref, taskID, string(rspTaskDataBin))
 	return summary, isErr
+}
+
+// loadRuntimeNodeMap indexes the server's currently deployed nodes without
+// modifying the process. run-task must never call ProcessJSON: doing so turns a
+// smoke test into an implicit deploy and bypasses push-process safety gates.
+func loadRuntimeNodeMap(v *Executor) error {
+	nodes, listErr := v.GetProcessNodes()
+	if len(nodes) == 0 {
+		exported, exportErr := v.ExportProcess()
+		if exportErr != nil {
+			if listErr != nil {
+				return fmt.Errorf("process node list failed (%v) and export failed: %w", listErr, exportErr)
+			}
+			return fmt.Errorf("process node list is empty and export failed: %w", exportErr)
+		}
+		doc := exported
+		if list, ok := exported.([]interface{}); ok && len(list) > 0 {
+			doc = list[0]
+		}
+		if process, ok := doc.(map[string]interface{}); ok {
+			for _, node := range schemeNodesFromDoc(process) {
+				nodes = append(nodes, node)
+			}
+		}
+	}
+	if len(nodes) == 0 {
+		if listErr != nil {
+			return fmt.Errorf("process node list failed (%v) and export returned no nodes", listErr)
+		}
+		return fmt.Errorf("process %d has no deployed nodes", v.ProcessID)
+	}
+	for _, raw := range nodes {
+		node, ok := raw.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		id, _ := node["id"].(string)
+		if id == "" {
+			continue
+		}
+		title, _ := node["title"].(string)
+		objType := nodeObjType(node)
+		icon := ""
+		if extra, _ := node["extra"].(string); extra != "" {
+			var decoded map[string]interface{}
+			if json.Unmarshal([]byte(extra), &decoded) == nil {
+				icon, _ = decoded["icon"].(string)
+			}
+		}
+		v.NodeIDMap[id] = NodeInfo{
+			Type: objType, ObjType: objType, ServerID: id, Name: title, Icon: icon,
+		}
+	}
+	if len(v.NodeIDMap) == 0 {
+		return fmt.Errorf("process %d returned no valid deployed nodes", v.ProcessID)
+	}
+	return nil
 }
 
 // lookupNode resolves a server node ID against the validator's NodeIDMap,

--- a/plugins/corezoid/mcp-server/mcp_handlers_test.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_test.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 // resetGlobals clears global auth state so tests don't interfere.
@@ -955,6 +956,136 @@ func TestHandleToolCall_RunTask_MissingData(t *testing.T) {
 		t.Error("expected isError=true when data missing")
 	}
 	_ = result
+}
+
+func TestHandleRunTask_UsesDeployedProcessWithoutRedeploy(t *testing.T) {
+	resetGlobals(t)
+	var operations []string
+	srv, _ := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
+		if len(ops) != 1 {
+			return map[string]interface{}{"request_proc": "error", "description": "unexpected operation count"}
+		}
+		obj, _ := ops[0]["obj"].(string)
+		typ, _ := ops[0]["type"].(string)
+		operations = append(operations, obj+":"+typ)
+		switch obj + ":" + typ {
+		case "conv:list":
+			return map[string]interface{}{
+				"request_proc": "ok",
+				"ops": []interface{}{map[string]interface{}{
+					"proc": "ok",
+					"list": []interface{}{map[string]interface{}{
+						"scheme": map[string]interface{}{"nodes": []interface{}{
+							map[string]interface{}{
+								"id": "server-final", "title": "Final", "obj_type": float64(2),
+								"extra": `{"icon":""}`,
+							},
+						}},
+					}},
+				}},
+			}
+		case "task:create":
+			return map[string]interface{}{
+				"request_proc": "ok",
+				"ops":          []interface{}{map[string]interface{}{"proc": "ok"}},
+			}
+		case "task:show":
+			return map[string]interface{}{
+				"request_proc": "ok",
+				"ops": []interface{}{map[string]interface{}{
+					"proc": "ok", "obj_id": "task-1", "node_id": "server-final",
+					"data": map[string]interface{}{"result": "ok"},
+				}},
+			}
+		default:
+			return map[string]interface{}{"request_proc": "error", "description": "unexpected mutating operation"}
+		}
+	})
+	setProjectAuth(t, srv.URL)
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	path := filepath.Join(dir, "123_runtime.conv.json")
+	localDraft := []byte(`this intentionally is not a deployable process`)
+	if err := os.WriteFile(path, localDraft, 0644); err != nil {
+		t.Fatal(err)
+	}
+	originalFirstPoll := runTaskFirstPollAfter
+	originalPollEvery := runTaskPollEvery
+	runTaskFirstPollAfter = time.Millisecond
+	runTaskPollEvery = time.Millisecond
+	t.Cleanup(func() {
+		runTaskFirstPollAfter = originalFirstPoll
+		runTaskPollEvery = originalPollEvery
+	})
+
+	result, isErr := handleRunTask(context.Background(), map[string]interface{}{
+		"process_path": filepath.Base(path), "data": `{}`, "ref": "read-only-run", "wait_sec": 1,
+	})
+	if isErr || !strings.Contains(result, "Task completed") || !strings.Contains(result, "NodeName: Final") {
+		t.Fatalf("read-only task run failed: %s", result)
+	}
+	if got := strings.Join(operations, ","); got != "conv:list,task:create,task:show" {
+		t.Fatalf("run-task issued unexpected operations: %s", got)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(after) != string(localDraft) {
+		t.Fatalf("run-task modified the local process file: %q", after)
+	}
+}
+
+func TestLoadRuntimeNodeMap_FallsBackToReadOnlyExport(t *testing.T) {
+	var srv *httptest.Server
+	var requests []string
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		if r.Method == http.MethodGet {
+			_ = json.NewEncoder(w).Encode([]interface{}{map[string]interface{}{
+				"obj_id": float64(123),
+				"scheme": map[string]interface{}{"nodes": []interface{}{
+					map[string]interface{}{
+						"id": "exported-error", "title": "Failed", "obj_type": float64(2),
+						"extra": `{"icon":"error"}`,
+					},
+				}},
+			}})
+			return
+		}
+		var body struct {
+			Ops []map[string]interface{} `json:"ops"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if r.URL.Path == "/api/2/download" {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"request_proc": "ok",
+				"ops": []interface{}{map[string]interface{}{
+					"proc": "ok", "download_url": srv.URL + "/runtime-process.json",
+				}},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"request_proc": "error"})
+	}))
+	t.Cleanup(srv.Close)
+
+	v := &Executor{
+		Ctx: context.Background(), APIUrl: srv.URL, Token: "test-token",
+		WorkspaceID: "workspace", ProcessID: 123, NodeIDMap: map[string]NodeInfo{},
+	}
+	if err := loadRuntimeNodeMap(v); err != nil {
+		t.Fatal(err)
+	}
+	node, ok := v.NodeIDMap["exported-error"]
+	if !ok || node.Type != 2 || node.Name != "Failed" || node.Icon != "error" {
+		t.Fatalf("unexpected exported runtime node: %+v", v.NodeIDMap)
+	}
+	if got := strings.Join(requests, ","); got != "POST /api/2/json,POST /api/2/download,GET /runtime-process.json" {
+		t.Fatalf("unexpected runtime metadata requests: %s", got)
+	}
 }
 
 // ---- get-dashboard ---------------------------------------------------------


### PR DESCRIPTION
## Summary

`run-task` now runs the **already-deployed** Corezoid process without implicitly deploying the local `.conv.json` first.

The tool previously called `ProcessJSON` before creating a task. That made a smoke-test command a hidden deployment path: it could modify the server process while bypassing the validation, snapshot, lint, Stub Mode confirmation, and other safety gates owned by `push-process`.

This PR removes that implicit mutation and loads runtime node metadata through read-only APIs so final-node names and icons are still reported correctly.

## Problem

The documented contract of `run-task` is to run an already-deployed process. Its actual sequence was:

1. resolve the local process file;
2. read and deploy it through `ProcessJSON`;
3. create a task;
4. poll the task until a final node or timeout.

That behavior had three consequences:

- running a test could unexpectedly change the deployed process;
- `run-task` formed a second deployment path that did not execute the checks and confirmations in `push-process`;
- a local draft could be deployed merely because the user wanted to test the currently deployed version.

This is a safety-boundary issue, not only a documentation mismatch. Any current or future gate implemented in `push-process` is ineffective if another tool can deploy the same file without going through that handler.

## What changed

- Removed `LoadBinFromFile` / `ProcessJSON` from `handleRunTask`.
- Kept the local path existence check because the filename remains the source of the process ID.
- Added `loadRuntimeNodeMap`, which:
  - first requests deployed nodes through `get_process` (`conv:list`, `include_nodes:true`);
  - falls back to the existing read-only `ExportProcess` path when the list endpoint fails or returns no nodes;
  - indexes server node ID, type, title, and icon for final-node reporting;
  - fails closed if neither read-only source returns usable deployed nodes.
- Left task creation, polling, timeout handling, and result formatting unchanged.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| Local file differs from server | local file was deployed, then tested | deployed server version is tested; local file is untouched |
| Local file is not valid process JSON | deployment failed | deployed process can still be tested because local JSON is not consumed |
| Node list is available | deploy + create/show task | list + create/show task |
| Node list is unavailable/empty | run failed during deploy/read path | read-only export fallback + create/show task |
| No deployed node metadata is readable | deployment side effects were possible before failure | tool fails without creating a task or mutating the process |

Users who intentionally want to deploy a local draft must now call `push-process` explicitly before `run-task`. This matches the existing tool descriptions and keeps deployment approval visible.

## Safety and compatibility

- No Corezoid process schema change.
- No new persistent state or credentials.
- No authorization behavior change; the implementation reuses existing `GetProcessNodes` and `ExportProcess` methods.
- No MCP protocol or tool-schema change.
- The fallback is read-only (`obj_scheme:download`); no create/modify/commit/delete-version operation is issued.
- Behavior is MCP-client neutral and is the same in Claude Code, Codex, Kiro, and other MCP clients.
- Existing final-node/error-node detection remains based on server node metadata.

## Tests added

### `TestHandleRunTask_UsesDeployedProcessWithoutRedeploy`

- uses an intentionally non-deployable local file;
- returns deployed node metadata from the mock server;
- verifies successful task completion and final-node name resolution;
- asserts the exact operation sequence is `conv:list,task:create,task:show`;
- rejects any unexpected operation as a mutating request;
- verifies the local file is unchanged.

### `TestLoadRuntimeNodeMap_FallsBackToReadOnlyExport`

- makes the list request fail;
- serves node metadata through the export download path;
- verifies node type, name, and error icon indexing;
- asserts the exact HTTP sequence is `POST /api/2/json`, `POST /api/2/download`, `GET /runtime-process.json`.

## Verification

Automated checks on this branch:

```bash
cd plugins/corezoid/mcp-server
go build ./...
go vet ./...
go test ./...
go test -race ./...
go test -run 'TestHandleRunTask_UsesDeployedProcessWithoutRedeploy|TestLoadRuntimeNodeMap_FallsBackToReadOnlyExport' -count=10 -v
git diff --check origin/main...HEAD
```

Results:

- full test suite: pass;
- race detector: pass (`83.381s`);
- targeted tests: 20/20 passes across 10 repeated runs;
- build, vet, gofmt, and diff check: pass.

## Live Corezoid verification

The compiled branch was exercised against an authorized sandbox process using a real task.

Observed request sequence:

```text
get_process (obj:conv, type:list, include_nodes:true)
export_process (obj:obj_scheme, type:download)   # read-only fallback
create_task (obj:task, type:create)
show_task (obj:task, type:show)
show_task (obj:task, type:show)
```

The task reached the expected final node. No `ProcessJSON`, node create/modify, commit, version deletion, or deployment request occurred. The exported process schema SHA-256 was identical before and after the run:

```text
3c83c8ed59c16d77c1b7e2b81eac9ae3a873a1b5531e0f904c4889212f01b453
```

## Reviewer checklist

- [ ] Confirm `handleRunTask` has no call to `ProcessJSON` or another mutating executor path.
- [ ] Confirm list and export fallback operations are read-only.
- [ ] Confirm node metadata still supports final and error node reporting.
- [ ] Confirm a missing/unreadable deployed process fails before task creation.
- [ ] Run the commands in **Verification**.

## Release note

No manifest/version bump is included. The repository's release process can version the plugin after merge.
