### PR TITLE
docs(nodes): fix __queue_task_data__ contract and moment.js require pattern

### DIFF
--- a/plugins/corezoid/docs/nodes/code-node-libraries.md
+++ b/plugins/corezoid/docs/nodes/code-node-libraries.md
@@ -56,6 +56,24 @@ function. These libraries provide functionality for cryptography, date manipulat
 | Moment Timezone     | `require("libs/moment-timezone.js")`     | Adds timezone support to Moment.js                                                |
 | Moment with Locales | `require("libs/moment-with-locales.js")` | Adds internationalization support to Moment.js                                    |
 
+> **Important — Moment.js libraries use global side-effect injection, not CommonJS exports.**
+> These libraries do **not** return a value from `require()`. Instead, calling `require()` attaches
+> the `moment` function to the global scope as a side effect. Do **not** assign the result of
+> `require()` to a variable — doing so creates a local variable that shadows the global `moment`
+> with `undefined`, causing a `TypeError` on any subsequent call.
+>
+> **Correct pattern:**
+> ```javascript
+> require("libs/moment.js");          // side-effect: sets global moment
+> var date = moment(data.timestamp);  // use global directly
+> ```
+>
+> **Incorrect pattern (breaks with TypeError):**
+> ```javascript
+> var moment = require("libs/moment.js");  // ← moment is undefined here
+> var date = moment(data.timestamp);       // TypeError: moment is not a function
+> ```
+
 ### Other Libraries
 
 | Library | Import Statement             | Description                                |
@@ -133,7 +151,7 @@ function. These libraries provide functionality for cryptography, date manipulat
 
 ```javascript
 
-  var moment = require("libs/moment.js");
+  require("libs/moment.js");  // side-effect: sets global moment — do not assign
 
   // Parse and format a date
   var date = moment(data.timestamp);
@@ -154,7 +172,7 @@ function. These libraries provide functionality for cryptography, date manipulat
 
 ```javascript
 
-  var moment = require("libs/moment-timezone.js");
+  require("libs/moment-timezone.js");  // side-effect: sets global moment — do not assign
 
   // Convert timestamp to specific timezone
   var date = moment(data.timestamp).tz("Europe/Kiev");
@@ -334,9 +352,9 @@ Set an appropriate timeout value based on the complexity of your code:
 ```javascript
 
   try {
-    // Require necessary libraries
-    var moment = require("libs/moment.js");
-    require("libs/sha256.js");  // sets global CryptoJS — do not assign
+    // Require necessary libraries — neither returns a value; both inject globals
+    require("libs/moment.js");   // sets global moment — do not assign
+    require("libs/sha256.js");   // sets global CryptoJS — do not assign
 
     // Process dates
     var now = moment();

--- a/plugins/corezoid/docs/nodes/get-from-queue-node.md
+++ b/plugins/corezoid/docs/nodes/get-from-queue-node.md
@@ -129,6 +129,45 @@ Example of poor naming:
 Meaningful titles and descriptions make processes more maintainable, easier to troubleshoot, and
 more accessible to other team members.
 
+## Accessing Retrieved Task Data
+
+When a task is successfully dequeued, the Corezoid platform does **not** merge the task's fields
+flat into the current task's root `data` object. The dequeued data is placed under the system
+field `__queue_task_data__`:
+
+```
+__queue_task_data__
+├── <field_1>
+├── <field_2>
+└── ...
+```
+
+### Referencing fields in subsequent nodes
+
+Use the `{{__queue_task_data__.<field_name>}}` template syntax in Set Parameters nodes, Condition
+nodes, Code nodes, and API Call nodes that follow the Get from Queue node:
+
+```
+{{__queue_task_data__.session_id}}
+{{__queue_task_data__.amount}}
+{{__queue_task_data__.user_email}}
+```
+
+### Copying fields into the root data object
+
+If you need the retrieved fields at the root level, add a **Set Parameters** node immediately after
+the Get from Queue node and copy each field explicitly:
+
+| Parameter name | Value                                 |
+| -------------- | ------------------------------------- |
+| `session_id`   | `{{__queue_task_data__.session_id}}`  |
+| `amount`       | `{{__queue_task_data__.amount}}`      |
+
+### Empty queue
+
+When the queue is empty, `__queue_task_data__` is absent. Guard against this in subsequent nodes
+with a **Condition** node that checks whether the field exists before attempting to use it.
+
 ## Configuration Example
 
 This example demonstrates a Get from Queue Node configuration extracted from a real process. It
@@ -177,5 +216,6 @@ shows how to retrieve tasks from a specific Queue node in another process.
   access denied). Note that an empty queue is typically not considered an error by this node itself
   but might be handled by subsequent logic.
 - The `go` logic block defines the path taken after the retrieval attempt. The retrieved task's data
-  will be available in the `data` object for the subsequent nodes. If the queue was empty, the task
-  proceeds without new data.
+  is **not** merged flat into the root `data` object. Instead, it is placed under the system field
+  `__queue_task_data__` (see [Accessing Retrieved Task Data](#accessing-retrieved-task-data) below).
+  If the queue was empty, the task proceeds and `__queue_task_data__` is absent.


### PR DESCRIPTION
## Summary

- **get-from-queue-node.md**: corrects the false claim that dequeued task data merges flat into the root `data` object. Data actually arrives under the system field `__queue_task_data__` (e.g. `{{__queue_task_data__.session_id}}`). Adds a dedicated **Accessing Retrieved Task Data** section with template-syntax usage examples, a copy-to-root pattern using Set Parameters, and an empty-queue guard note.
- **code-node-libraries.md**: `moment.js`, `moment-timezone.js`, and `moment-with-locales.js` use the same global side-effect injection as CryptoJS — `require()` returns `undefined`, so `var moment = require(...)` shadows the injected global with `undefined`, causing a `TypeError` on any subsequent call. Adds an **Important** warning box matching the existing CryptoJS note, and fixes all three affected code examples.

## Context

tool: corezoid-edit | version: 2.3.5 | install: 104e5afc-1da9-4961-91fc-b01fbc7f11e5

Discovered by a user working with the Get from Queue node — data arrived at `__queue_task_data__.*` rather than flat in the root as the docs claimed. Same class of contract mismatch found in the moment.js examples (CryptoJS was already fixed in #93 but moment.js was missed).

## Checklist

- [x] No code changes — documentation only
- [x] No version bump / CHANGELOG.md change included
- [x] No credentials or private URLs
- [x] make build / vet / test not applicable (docs-only PR)

## Test plan

- Open `get-from-queue-node.md` and confirm the new **Accessing Retrieved Task Data** section describes `__queue_task_data__` with correct syntax examples
- Open `code-node-libraries.md` and confirm the moment.js **Important** warning box is present and all three `require("libs/moment*.js")` calls no longer use `var moment =` assignment
- Verify the CryptoJS examples remain unchanged