### PR TITLE
fix(modify-task): document shallow merge, add deep_merge option

### DIFF
--- a/plugins/corezoid/mcp-server/mcp_handlers_tasks.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_tasks.go
@@ -131,8 +131,35 @@ func handleGetNodeStat(ctx context.Context, args map[string]interface{}) (string
 	return string(data), false
 }
 
+// deepMerge recursively merges src into dst and returns the result. For keys
+// present in both maps where both values are themselves maps, the values are
+// merged recursively. For all other types the src value wins (overwrites dst).
+// Neither dst nor src is mutated.
+func deepMerge(dst, src map[string]interface{}) map[string]interface{} {
+	result := make(map[string]interface{}, len(dst))
+	for k, v := range dst {
+		result[k] = v
+	}
+	for k, v := range src {
+		if srcMap, ok := v.(map[string]interface{}); ok {
+			if dstMap, ok := result[k].(map[string]interface{}); ok {
+				result[k] = deepMerge(dstMap, srcMap)
+				continue
+			}
+		}
+		result[k] = v
+	}
+	return result
+}
+
 // handleModifyTask updates the data payload of an existing task. Either
 // task_id or ref must be supplied to identify the task.
+//
+// By default the Corezoid API performs a SHALLOW (top-level) merge: every
+// top-level key in data overwrites the entire existing value, so nested
+// objects are fully replaced. Pass deep_merge: true to fetch the current
+// task data first and perform a recursive merge that preserves sub-keys not
+// present in the caller's payload.
 func handleModifyTask(ctx context.Context, args map[string]interface{}) (string, bool) {
 	processID, err := intArg(args, "process_id")
 	if err != nil {
@@ -153,6 +180,39 @@ func handleModifyTask(ctx context.Context, args map[string]interface{}) (string,
 		return fmt.Sprintf("Error parsing data JSON: %v", err), true
 	}
 
+	v := NewValidator(ctx, processID)
+
+	// deep_merge: fetch current task data and recursively merge into it.
+	deepMergeMode, _ := args["deep_merge"].(bool)
+	if deepMergeMode {
+		showOp := map[string]any{
+			"type":    "show",
+			"obj":     "task",
+			"conv_id": processID,
+		}
+		if taskID != "" {
+			showOp["obj_id"] = taskID
+		} else {
+			showOp["ref"] = ref
+		}
+		showResp, err := v.req("show_task", []map[string]any{showOp})
+		if err != nil {
+			return fmt.Sprintf("Error fetching current task for deep merge: %v", err), true
+		}
+		opsArr, _ := showResp["ops"].([]interface{})
+		if len(opsArr) == 0 {
+			return "Error: task not found", true
+		}
+		opMap, _ := opsArr[0].(map[string]interface{})
+		if opMap["proc"] != "ok" {
+			desc, _ := opMap["description"].(string)
+			return fmt.Sprintf("Error resolving task: %s", desc), true
+		}
+		if currentData, ok := opMap["data"].(map[string]interface{}); ok {
+			taskData = deepMerge(currentData, taskData)
+		}
+	}
+
 	op := map[string]any{
 		"type":    "modify",
 		"obj":     "task",
@@ -166,7 +226,6 @@ func handleModifyTask(ctx context.Context, args map[string]interface{}) (string,
 		op["ref"] = ref
 	}
 
-	v := NewValidator(ctx, processID)
 	resp, err := v.req("modify_task", []map[string]any{op})
 	if err != nil {
 		return fmt.Sprintf("Error: %v", err), true

--- a/plugins/corezoid/mcp-server/mcp_handlers_test.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_test.go
@@ -794,6 +794,67 @@ func TestHandleToolCall_ModifyTask_BadDataJSON(t *testing.T) {
 	_ = result
 }
 
+// ---- deepMerge unit tests ---------------------------------------------------
+
+func TestDeepMerge_ShallowScalar(t *testing.T) {
+	dst := map[string]interface{}{"a": 1, "b": 2}
+	src := map[string]interface{}{"b": 99, "c": 3}
+	got := deepMerge(dst, src)
+	if got["a"] != 1 || got["b"] != 99 || got["c"] != 3 {
+		t.Errorf("unexpected result: %v", got)
+	}
+}
+
+func TestDeepMerge_NestedObjectPreservesExistingKeys(t *testing.T) {
+	dst := map[string]interface{}{
+		"currencies": map[string]interface{}{
+			"count": 5, "ms": 100, "seconds": 1, "value": 42, "Requests ": 10,
+		},
+	}
+	src := map[string]interface{}{
+		"currencies": map[string]interface{}{
+			"usd": 1, "eur": 2, "gbp": 3, "jpy": 4,
+		},
+	}
+	got := deepMerge(dst, src)
+	cur, ok := got["currencies"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("currencies not a map: %T", got["currencies"])
+	}
+	// original keys must survive
+	for _, k := range []string{"count", "ms", "seconds", "value", "Requests "} {
+		if _, exists := cur[k]; !exists {
+			t.Errorf("key %q was lost after deep merge", k)
+		}
+	}
+	// new keys must be present
+	for _, k := range []string{"usd", "eur", "gbp", "jpy"} {
+		if _, exists := cur[k]; !exists {
+			t.Errorf("new key %q missing after deep merge", k)
+		}
+	}
+}
+
+func TestDeepMerge_NestedObjectScalarOverwrites(t *testing.T) {
+	// When src has a scalar at a key that dst has a map, src wins.
+	dst := map[string]interface{}{"x": map[string]interface{}{"a": 1}}
+	src := map[string]interface{}{"x": "flat"}
+	got := deepMerge(dst, src)
+	if got["x"] != "flat" {
+		t.Errorf("expected scalar overwrite, got %v", got["x"])
+	}
+}
+
+func TestDeepMerge_DoesNotMutateDst(t *testing.T) {
+	dst := map[string]interface{}{"a": map[string]interface{}{"k": 1}}
+	src := map[string]interface{}{"a": map[string]interface{}{"k": 2}}
+	_ = deepMerge(dst, src)
+	inner := dst["a"].(map[string]interface{})
+	if inner["k"] != 1 {
+		t.Error("deepMerge mutated dst")
+	}
+}
+
 func TestHandleToolCall_DeleteTask_MissingRefAndTaskID(t *testing.T) {
 	resetGlobals(t)
 	result, isErr := handleToolCall(context.Background(), "delete-task", map[string]interface{}{

--- a/plugins/corezoid/mcp-server/tools_registry.go
+++ b/plugins/corezoid/mcp-server/tools_registry.go
@@ -774,7 +774,7 @@ var toolRegistry = []mcpTool{
 	},
 	{
 		Name:        "list-task-history",
-		Description: "Return the execution history (node path) for a task. Shows each node transition with node_id, node_prev_id, create_time_ms.",
+		Description: "Return the execution history (node path) for a task. Shows each node transition with node_id, node_prev_id, create_time_ms. NOTE: the Corezoid API does not record data snapshots — the data field is always null in history entries. To inspect the current data payload before modifying a task, use modify-task with deep_merge: true (it fetches the live data internally).",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
@@ -852,7 +852,7 @@ var toolRegistry = []mcpTool{
 	},
 	{
 		Name:        "modify-task",
-		Description: "Modify an existing task's data. The task will continue from the node where it was paused with the updated data. At least one of task_id or ref must be provided.",
+		Description: "Modify an existing task's data. At least one of task_id or ref must be provided. WARNING: the Corezoid API performs a SHALLOW (top-level) merge — if a top-level key already holds a nested object (e.g. data.currencies), its entire value is replaced and any sub-keys absent from your payload are silently lost. Pass deep_merge: true to fetch the current task data first and perform a recursive merge that preserves existing sub-keys.",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
@@ -862,7 +862,7 @@ var toolRegistry = []mcpTool{
 				},
 				"data": map[string]interface{}{
 					"type":        "string",
-					"description": "JSON string with fields to merge into the task",
+					"description": "JSON string with fields to merge into the task. Each top-level key overwrites the full existing value at that key (shallow merge). Use deep_merge: true to recursively preserve existing sub-keys inside nested objects.",
 				},
 				"task_id": map[string]interface{}{
 					"type":        "string",
@@ -871,6 +871,10 @@ var toolRegistry = []mcpTool{
 				"ref": map[string]interface{}{
 					"type":        "string",
 					"description": "Task reference string",
+				},
+				"deep_merge": map[string]interface{}{
+					"type":        "boolean",
+					"description": "If true, fetch the current task data first and recursively merge your data into it before writing; existing sub-keys not present in your payload are preserved. Default: false (standard shallow merge).",
 				},
 			},
 			"required": []string{"process_id", "data"},


### PR DESCRIPTION
## Summary
- `modify-task` description now explicitly warns that the Corezoid API performs a **shallow (top-level) merge**: every top-level key passed in `data` *replaces* the entire existing value at that key — nested objects are fully overwritten and any sub-keys not present in the caller's payload are silently lost
- New optional `deep_merge: true` parameter fetches the current task data first, then recursively merges the caller's payload into it, preserving sub-keys in nested objects
- `list-task-history` description now documents that `data` is always `null` in history entries (Corezoid API limitation), directing users to `deep_merge` for safe edits

## Context
tool: modify-task | version: 2.3.5 | install: 104e5afc

Root cause: agent called `modify-task` with `data={"currencies": {4 new keys}}` without reading the current task state first, which silently wiped 5 existing sub-keys (`count`, `ms`, `seconds`, `value`, `Requests `) from `data.currencies`.

## Changes
- **`tools_registry.go`**: updated `modify-task` tool description and `data` parameter description to surface the shallow-replace hazard; added `deep_merge` (boolean, optional, default false) parameter
- **`mcp_handlers_tasks.go`**: added `deepMerge()` recursive merge helper; `handleModifyTask` now issues a `show_task` call before `modify` when `deep_merge: true` and merges the results
- **`mcp_handlers_test.go`**: four unit tests for `deepMerge` covering the exact reported scenario (nested `currencies` object preservation), scalar overwrite, and dst non-mutation

## Checklist
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (all 4 new `deepMerge` tests + existing task handler tests)
- [x] Plugin manifests validated (python3 -m json.tool)
- [x] No version bump / CHANGELOG.md change included
- [x] No credentials or private URLs introduced

## Test plan
- `TestDeepMerge_NestedObjectPreservesExistingKeys` — mirrors the exact incident: `currencies` had 5 keys before, 4 new keys added, all 9 survive
- `TestDeepMerge_ShallowScalar` — scalar-level keys are still overwritten (not accidentally deep-merged)
- `TestDeepMerge_NestedObjectScalarOverwrites` — when src has a scalar at a key that dst has a map, src wins
- `TestDeepMerge_DoesNotMutateDst` — confirms dst is never mutated (immutable merge semantics)