### PR TITLE
feat(mcp-server): allow Erlang (erl) in api_code lang enum

### DIFF
--- a/plugins/corezoid/mcp-server/json-schema/logics/api_code.json
+++ b/plugins/corezoid/mcp-server/json-schema/logics/api_code.json
@@ -13,8 +13,8 @@
     },
     "lang": {
       "type": "string",
-      "enum": ["js", "python"],
-      "description": "Programming language for the code",
+      "enum": ["js", "python", "erl"],
+      "description": "Programming language for the code. For 'erl' the src must be a full module: -module(node). -export([main/1]). main(Data) -> ... .",
       "default": "js"
     },
     "src": {
@@ -58,6 +58,12 @@
       "extra_type": {
         "timeout": "number"
       }
+    },
+    {
+      "type": "api_code",
+      "lang": "erl",
+      "src": "-module(node).\n-export([main/1]).\n\nmain(Data) ->\n    [{<<\"result\">>, <<\"ok\">>} | Data].",
+      "err_node_id": "error_node_id"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- `push-process` rejected any process containing an Erlang Code node — the `api_code` JSON schema whitelisted only `js`/`python`, so a process with even one `erl` node could not be deployed at all, even when the edit was in a different node.
- Added `"erl"` to the `lang` enum, documented the required full-module form (`-module(node). -export([main/1]).`) in the description, and added an `erl` example.
- The Corezoid API itself accepts `lang: "erl"` and compiles the module at deploy time, returning compile errors in the push response — so the client-side block only removed a capability without adding safety.

## Test plan
- [x] Pushed a new process with an Erlang Code node to a dev workspace — deployed, task executed the Erlang code successfully.
- [x] Pushed a copy of a real 88-node production-like process with modified Erlang nodes — deployed, repeated pushes (update-in-place) work, snapshots created, changes verified via pull round-trip.
- [x] Invalid Erlang source → push fails with the server's compile error in the response (no silent broken deploy).

@MalishkinMV

🤖 Generated with [Claude Code](https://claude.com/claude-code)