### PR TITLE
fix(push-process): improve self-reference api_copy error and detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,10 @@ jobs:
           python3 -m json.tool .agents/plugins/marketplace.json > /dev/null
           python3 -m json.tool plugins/corezoid/.claude-plugin/plugin.json > /dev/null
           python3 -m json.tool plugins/corezoid/.codex-plugin/plugin.json > /dev/null
+          python3 -m json.tool plugins/corezoid/.opencode-plugin/plugin.json > /dev/null
           python3 -m json.tool plugins/corezoid/.mcp.json > /dev/null
+          python3 -m json.tool plugins/corezoid/.mcp.opencode.json > /dev/null
+          python3 -m json.tool plugins/corezoid/opencode-plugin/package.json > /dev/null
 
       - name: No dead plugin paths in marketplace manifests
         run: |
@@ -62,6 +65,10 @@ jobs:
               claude_ver = json.load(f)["version"]
           with open("plugins/corezoid/.codex-plugin/plugin.json") as f:
               codex_ver = json.load(f)["version"]
+          with open("plugins/corezoid/.opencode-plugin/plugin.json") as f:
+              opencode_ver = json.load(f)["version"]
+          with open("plugins/corezoid/opencode-plugin/package.json") as f:
+              opencode_pkg_ver = json.load(f)["version"]
           with open(".claude-plugin/marketplace.json") as f:
               market_ver = json.load(f)["plugins"][0]["version"]
           with open(".agents/plugins/marketplace.json") as f:
@@ -70,6 +77,8 @@ jobs:
           versions = {
               "claude plugin.json": claude_ver,
               "codex plugin.json": codex_ver,
+              "opencode plugin.json": opencode_ver,
+              "opencode-plugin package.json": opencode_pkg_ver,
               ".claude-plugin/marketplace.json": market_ver,
               ".agents/plugins/marketplace.json": agents_ver,
           }
@@ -90,6 +99,8 @@ jobs:
           manifests = [
               ("plugins/corezoid/.claude-plugin/plugin.json", lambda d: d.get("license")),
               ("plugins/corezoid/.codex-plugin/plugin.json", lambda d: d.get("license")),
+              ("plugins/corezoid/.opencode-plugin/plugin.json", lambda d: d.get("license")),
+              ("plugins/corezoid/opencode-plugin/package.json", lambda d: d.get("license")),
               (".claude-plugin/marketplace.json",             lambda d: d["plugins"][0].get("license")),
               (".agents/plugins/marketplace.json",            lambda d: d["plugins"][0].get("license")),
           ]
@@ -192,6 +203,25 @@ jobs:
       - name: Lint run.sh (syntax check)
         run: sh -n plugins/corezoid/mcp-server/run.sh
 
+      - name: Lint install-opencode.sh (syntax check)
+        run: sh -n plugins/corezoid/scripts/install-opencode.sh
+
+      - name: install-opencode.sh --print-mcp emits valid JSON
+        run: |
+          bash plugins/corezoid/scripts/install-opencode.sh --print-mcp \
+            | python3 -m json.tool > /dev/null
+
+      - name: install-opencode.sh is idempotent
+        run: |
+          TMP=$(mktemp -d)
+          export XDG_CONFIG_HOME="$TMP/config"
+          export HOME="$TMP"
+          bash plugins/corezoid/scripts/install-opencode.sh "$TMP/opencode.json" > /dev/null
+          cp "$TMP/opencode.json" "$TMP/first.json"
+          bash plugins/corezoid/scripts/install-opencode.sh "$TMP/opencode.json" > /dev/null
+          diff "$TMP/first.json" "$TMP/opencode.json"
+          echo "Idempotency OK"
+
   docs:
     name: Docs link check
     runs-on: ubuntu-latest
@@ -203,6 +233,28 @@ jobs:
         with:
           use-quiet-mode: "yes"
           config-file: ".github/mlc_config.json"
+
+  opencode-plugin:
+    name: OpenCode plugin build & test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: plugins/corezoid/opencode-plugin
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install deps
+        run: bun install
+
+      - name: Type-check
+        run: bunx tsc --noEmit
+
+      - name: Test
+        run: bun test
 
   mcp-server:
     name: MCP server build & test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,3 +96,40 @@ jobs:
             public/llms.txt
             public/.well-known/skills/index.json
             POWER.md
+
+  publish-opencode-plugin:
+    name: Publish OpenCode plugin to npm
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: plugins/corezoid/opencode-plugin
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Verify package.json version matches tag
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          EXPECTED="${TAG#v}"
+          if [ "$PKG_VERSION" != "$EXPECTED" ]; then
+            echo "ERROR: package.json version ($PKG_VERSION) does not match tag ($EXPECTED)"
+            exit 1
+          fi
+          echo "Versions match: $PKG_VERSION"
+
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if [ -z "$NODE_AUTH_TOKEN" ]; then
+            echo "NPM_TOKEN secret is not set — skipping npm publish."
+            echo "Set the NPM_TOKEN repo secret to enable automatic publishing."
+            exit 0
+          fi
+          npm publish --access public

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,11 +4,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Purpose
 
-This is a Claude Code / Codex / Kiro plugin (`@corezoid/corezoid-ai-plugin`) that gives the AI the knowledge and tools to create, edit, and review [Corezoid](https://corezoid.com) BPM processes directly from the IDE. The repo ships:
+This is a Claude Code / Codex / Kiro / OpenCode plugin (`@corezoid/corezoid-ai-plugin`) that gives the AI the knowledge and tools to create, edit, and review [Corezoid](https://corezoid.com) BPM processes directly from the IDE. The repo ships:
 
 - Static skills (`plugins/corezoid/skills/*/SKILL.md` + reference docs, JSON samples).
-- Plugin manifests for Claude Code, Codex, and the agents marketplace.
+- Plugin manifests for Claude Code, Codex, Kiro, OpenCode, and the agents marketplace.
 - A Go-based MCP server (`convctl`) in `plugins/corezoid/mcp-server/` that exposes Corezoid operations as MCP tools. It has real tests (`go test -race`), golden tests for layout and lint, integration tests, and a release pipeline that builds signed multi-platform binaries.
+- An OpenCode adapter (`plugins/corezoid/opencode-plugin/`) — a TypeScript module that registers each skill as an OpenCode tool with `${CLAUDE_PLUGIN_ROOT}` substituted at install time. Bundled into `~/.config/opencode/plugins/corezoid.ts` by `scripts/install-opencode.sh`.
 
 ## Plugin Development Commands
 
@@ -52,8 +53,8 @@ go test -run TestLayoutGolden -update ./...
 
 CI (`.github/workflows/ci.yml`) also runs:
 
-- JSON validation for all four plugin manifests + `.mcp.json`.
-- Version sync across `plugins/corezoid/.claude-plugin/plugin.json`, `plugins/corezoid/.codex-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.agents/plugins/marketplace.json`.
+- JSON validation for all plugin manifests + `.mcp.json` + `.mcp.opencode.json`.
+- Version sync across `plugins/corezoid/.claude-plugin/plugin.json`, `plugins/corezoid/.codex-plugin/plugin.json`, `plugins/corezoid/.opencode-plugin/plugin.json`, `plugins/corezoid/opencode-plugin/package.json`, `.claude-plugin/marketplace.json`, `.agents/plugins/marketplace.json`.
 - License consistency (must be MIT everywhere).
 - Markdown link check.
 - Skills-list sync (`scripts/check-skills-sync.py`): the skill directories under `plugins/corezoid/skills/` must match the lists in `CLAUDE.md` and `README.md`.
@@ -71,6 +72,14 @@ python3 scripts/generate-discovery.py
 .claude-plugin/plugin.json        — Plugin manifest (name, version, description)
 plugins/corezoid/
   mcp-server/                     — Go MCP server source (starts automatically via .mcp.json)
+  opencode-plugin/                — TypeScript adapter for OpenCode (opencode.ai). Registers
+                                    each SKILL.md under skills/ as an OpenCode tool with
+                                    ${CLAUDE_PLUGIN_ROOT} resolved at install time.
+                                    index.ts + skills-loader.ts + index.test.ts (bun test).
+  scripts/
+    install-kiro.sh               — Kiro workspace / Power installer
+    install-opencode.sh           — OpenCode installer: patches opencode.json (MCP entry)
+                                    and bundles the TS adapter to ~/.config/opencode/plugins/
   skills/
     corezoid/                       — Main skill: platform overview, MCP tools, routing
       SKILL.md

--- a/POWER.md
+++ b/POWER.md
@@ -1,8 +1,8 @@
 ---
 name: corezoid
 displayName: Corezoid
-version: 2.9.0
-description: Corezoid BPM platform assistant. Exposes the Corezoid REST API as MCP tools (`convctl`) plus 20 skills covering process creation, editing, review, validation, dashboards, state diagrams, variables, and access. Ships JSON schemas and per-node-type documentation for all 24 Corezoid node types.
+оversion: 2.10.0
+description: Corezoid BPM platform assistant. Exposes the Corezoid REST API as MCP tools (`convctl`) plus 21 skills covering process creation, editing, review, validation, dashboards, state diagrams, variables, and access. Ships JSON schemas and per-node-type documentation for all 24 Corezoid node types.
 author:
   name: Corezoid
   url: https://corezoid.com

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Corezoid — Claude Code & Codex Plugin
+# Corezoid — Claude Code, Codex, Kiro & OpenCode Plugin
 
-A plugin for [Claude Code](https://claude.ai/code) and [Codex](https://openai.com/codex) that connects the [Corezoid](https://corezoid.com) platform to Claude via MCP. Claude gets direct access to Corezoid processes and deep platform knowledge to create, edit, review, and deploy workflows through natural conversation.
+A plugin for [Claude Code](https://claude.ai/code), [Codex](https://openai.com/codex), [AWS Kiro](https://kiro.dev) and [OpenCode](https://opencode.ai) that connects the [Corezoid](https://corezoid.com) platform to the coding agent via MCP. The agent gets direct access to Corezoid processes and deep platform knowledge to create, edit, review, and deploy workflows through natural conversation.
 
 > *Not just an MCP wrapper over the Corezoid API — an AI-Native management layer for the platform.*
 
@@ -41,7 +41,7 @@ workflows through natural conversation.
 
 ## Requirements
 
-- [Claude Code](https://claude.ai/code), [Codex](https://openai.com/codex), or [AWS Kiro](https://kiro.dev) installed
+- [Claude Code](https://claude.ai/code), [Codex](https://openai.com/codex), [AWS Kiro](https://kiro.dev), or [OpenCode](https://opencode.ai) installed
 - A Corezoid account
 
 ## Installation
@@ -97,6 +97,29 @@ sh plugins/corezoid/scripts/install-kiro.sh .
 
 Open the workspace in Kiro — the `corezoid` MCP server, skills, and steering are picked up automatically. This also registers the plugin as a Kiro Power (`~/.kiro/powers/installed/power-corezoid/`), so it stays available in every Kiro workspace, not just this one — restart Kiro (or reload the window) to pick it up.
 
+### OpenCode
+
+**From npm (recommended):**
+
+```bash
+opencode plugin @corezoid/opencode-plugin
+opencode mcp add   # choose local, command: sh <path-to>/mcp-server/run.sh
+```
+
+`opencode plugin` installs the TypeScript adapter that registers every Corezoid skill as an OpenCode tool with the `corezoid_` prefix. `opencode mcp add` walks you through the MCP server entry — the same `convctl` Go server used by Claude Code / Codex. Both are added to `~/.config/opencode/opencode.json`.
+
+**From a local clone:**
+
+```bash
+git clone https://github.com/corezoid/corezoid-ai-plugin
+cd corezoid-ai-plugin
+sh plugins/corezoid/scripts/install-opencode.sh
+```
+
+Does both steps at once — merges an `mcp.corezoid` block into `./opencode.json` and bundles the TypeScript adapter to `~/.config/opencode/plugins/corezoid.ts` with paths pre-resolved to your checkout. Use this when the npm package isn't available or you want to test unreleased changes.
+
+See [`plugins/corezoid/docs/opencode-setup.md`](plugins/corezoid/docs/opencode-setup.md) for user-scope install, uninstall, and troubleshooting.
+
 ### Updating
 
 ```bash
@@ -112,7 +135,12 @@ name to target one) and re-run `codex plugin add` to install the refreshed versi
 git pull && sh plugins/corezoid/scripts/install-kiro.sh .   # AWS Kiro
 ```
 
-Restart Claude Code / Codex after updating to apply the new version.
+```bash
+opencode plugin @corezoid/opencode-plugin --force   # OpenCode (from npm)
+git pull && sh plugins/corezoid/scripts/install-opencode.sh   # OpenCode (from a local clone)
+```
+
+Restart Claude Code / Codex / OpenCode after updating to apply the new version.
 
 ## Authentication
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -6,12 +6,14 @@ Use this before tagging a public release.
 
 - [ ] `plugins/corezoid/.claude-plugin/plugin.json` version is updated.
 - [ ] `plugins/corezoid/.codex-plugin/plugin.json` version matches Claude manifest.
-- [ ] `.claude-plugin/marketplace.json` `plugins[0].version` matches both manifests.
+- [ ] `plugins/corezoid/.opencode-plugin/plugin.json` version matches Claude manifest.
+- [ ] `plugins/corezoid/opencode-plugin/package.json` version matches Claude manifest.
+- [ ] `.claude-plugin/marketplace.json` `plugins[0].version` matches all manifests.
 - [ ] `.agents/plugins/marketplace.json` `plugins[0].version` matches all manifests.
 - [ ] `.agents/plugins/marketplace.json` `plugins[0].license` is `"MIT"`.
 - [ ] No TODO or placeholder values remain in any manifest.
 - [ ] Manifest asset and skill paths resolve under `plugins/corezoid/`.
-- [ ] All four manifests have `"license": "MIT"` (not ISC).
+- [ ] All manifests have `"license": "MIT"` (not ISC).
 - [ ] All plugin `source` paths listed in marketplace manifests exist on disk.
 
 ## MCP Server
@@ -34,14 +36,19 @@ python3 -m json.tool .claude-plugin/marketplace.json >/dev/null
 python3 -m json.tool .agents/plugins/marketplace.json >/dev/null
 python3 -m json.tool plugins/corezoid/.claude-plugin/plugin.json >/dev/null
 python3 -m json.tool plugins/corezoid/.codex-plugin/plugin.json >/dev/null
+python3 -m json.tool plugins/corezoid/.opencode-plugin/plugin.json >/dev/null
+python3 -m json.tool plugins/corezoid/opencode-plugin/package.json >/dev/null
 python3 -m json.tool plugins/corezoid/.mcp.json >/dev/null
+python3 -m json.tool plugins/corezoid/.mcp.opencode.json >/dev/null
 ```
 
 ## Testing
 
 - [ ] Claude Code can install the plugin from the local clone.
 - [ ] Codex can install the plugin from the local clone.
+- [ ] OpenCode: `sh plugins/corezoid/scripts/install-opencode.sh` merges MCP + bundles TS plugin, restart OpenCode, `corezoid_*` tools visible.
 - [ ] MCP server starts and `login` tool responds.
+- [ ] `NPM_TOKEN` secret is set in GitHub if the OpenCode npm package should auto-publish on tag push.
 
 ## Git
 

--- a/plugins/corezoid/.mcp.opencode.json
+++ b/plugins/corezoid/.mcp.opencode.json
@@ -1,0 +1,14 @@
+{
+  "mcp": {
+    "corezoid": {
+      "type": "local",
+      "command": [
+        "sh",
+        "-c",
+        "PLUGIN_ROOT=\"${OPENCODE_PLUGIN_ROOT:-$PWD}\"; [ -f \"$PLUGIN_ROOT/mcp-server/run.sh\" ] || PLUGIN_ROOT=\"$PLUGIN_ROOT/plugins/corezoid\"; [ -f \"$PLUGIN_ROOT/mcp-server/run.sh\" ] || { echo \"ERROR: cannot find mcp-server/run.sh under $PLUGIN_ROOT\" >&2; exit 1; }; export COREZOID_WORK_DIR=\"$PWD\"; exec sh \"$PLUGIN_ROOT/mcp-server/run.sh\""
+      ],
+      "enabled": true,
+      "environment": {}
+    }
+  }
+}

--- a/plugins/corezoid/.opencode-plugin/plugin.json
+++ b/plugins/corezoid/.opencode-plugin/plugin.json
@@ -9,12 +9,10 @@
   "homepage": "https://github.com/corezoid/corezoid-ai-plugin",
   "repository": "https://github.com/corezoid/corezoid-ai-plugin",
   "license": "MIT",
-  "keywords": ["corezoid", "process", "bpm", "workflow", "automation", "mcp"],
-  "skills": "./skills/",
-  "mcpServers": "./.mcp.kiro.json",
-  "kiro": {
-    "steering": "./steering/corezoid.md",
-    "skills": "./skills/",
-    "mcpServers": "./.mcp.kiro.json"
+  "keywords": ["corezoid", "process", "bpm", "workflow", "automation", "mcp", "opencode"],
+  "opencode": {
+    "plugin": "./opencode-plugin",
+    "mcpConfig": "./.mcp.opencode.json",
+    "installer": "./scripts/install-opencode.sh"
   }
 }

--- a/plugins/corezoid/docs/opencode-setup.md
+++ b/plugins/corezoid/docs/opencode-setup.md
@@ -1,0 +1,78 @@
+# OpenCode setup
+
+`corezoid-ai-plugin` works in [OpenCode](https://opencode.ai) via a small
+TypeScript adapter that registers every Corezoid skill as an OpenCode tool,
+plus the same Go MCP server used by Claude Code / Codex / Kiro.
+
+## Install from a local clone
+
+```bash
+git clone https://github.com/corezoid/corezoid-ai-plugin
+cd corezoid-ai-plugin
+sh plugins/corezoid/scripts/install-opencode.sh
+```
+
+This does two things:
+
+1. Merges an `mcp.corezoid` entry into `./opencode.json` (creating the file
+   if needed), with the MCP command resolved to this checkout's absolute
+   plugin path. Existing MCP entries and other keys are preserved.
+2. Bundles `plugins/corezoid/opencode-plugin/` into a single file at
+   `~/.config/opencode/plugins/corezoid.ts`. OpenCode auto-loads it at
+   startup and registers every `SKILL.md` under `plugins/corezoid/skills/`
+   as a tool named `corezoid_<skill_name>` (about 20 tools).
+
+Restart OpenCode (or open a new session) and both the MCP server and the
+skill tools become available.
+
+### User-scope install
+
+Patch `~/.config/opencode/opencode.json` instead of the project one:
+
+```bash
+sh plugins/corezoid/scripts/install-opencode.sh --user-install
+```
+
+### Inspect what will be merged
+
+```bash
+sh plugins/corezoid/scripts/install-opencode.sh --print-mcp
+```
+
+Emits the resolved MCP JSON block to stdout without writing anywhere.
+
+## Update
+
+Pull the latest source and re-run the installer:
+
+```bash
+cd corezoid-ai-plugin && git pull
+sh plugins/corezoid/scripts/install-opencode.sh
+```
+
+The bundled plugin at `~/.config/opencode/plugins/corezoid.ts` is
+regenerated. `opencode.json` is merged idempotently — sibling MCP entries
+you added by hand stay intact.
+
+## Uninstall
+
+Remove the bundle and the MCP block:
+
+```bash
+rm ~/.config/opencode/plugins/corezoid.ts
+# then delete "corezoid" from the "mcp" section of opencode.json
+```
+
+## How it fits together
+
+```
+opencode.json          ← MCP entry launches mcp-server/run.sh (Go binary)
+~/.config/opencode/plugins/corezoid.ts
+                       ← bundled skills-loader.ts + index.ts,
+                         with ${CLAUDE_PLUGIN_ROOT} substituted to the
+                         absolute plugin path at install time
+```
+
+`opencode plugin install @corezoid/opencode-plugin` (via npm, once
+published) is an equivalent alternative to the local-clone install for the
+plugin side; MCP still has to be added to `opencode.json` either way.

--- a/plugins/corezoid/mcp-server/executor_tasks.go
+++ b/plugins/corezoid/mcp-server/executor_tasks.go
@@ -120,7 +120,21 @@ func (v *Executor) BeforeValidation(jsonContent string, taskData map[string]inte
 						type1, _ := logicMap["type"].(string)
 						if type1 == "api_copy" || type1 == "api_rpc" {
 							if convID, ok := logicMap["conv_id"].(float64); ok && int(convID) == v.ProcessID {
-								return fmt.Errorf("node with type %s and conv_id %d must not have the same process", type1, int(convID))
+								nodeID, _ := nodeMap["id"].(string)
+								nodeTitle, _ := nodeMap["title"].(string)
+								if nodeTitle == "" {
+									nodeTitle = "(untitled)"
+								}
+								kindName := "Copy Task"
+								if type1 == "api_rpc" {
+									kindName = "Call a Process"
+								}
+								return fmt.Errorf(
+									"self-reference blocked: node %q (id=%s) uses %s (type=%s, conv_id=%d) to send tasks into this same process.\n"+
+										"This check cannot be bypassed with force=true — it is a pre-deployment validation, not a lint finding.\n"+
+										"Fix: replace the self-copy node with a time-semaphore delay node (≥30s) followed by a bare `go` back to the loop entry point. "+
+										"The task cycles in-place without spawning a new one. Run lint-process for a full analysis of this process.",
+									nodeTitle, nodeID, kindName, type1, int(convID))
 							}
 						}
 						if type1 != "go" && type1 != "go_if_const" {

--- a/plugins/corezoid/mcp-server/lint.go
+++ b/plugins/corezoid/mcp-server/lint.go
@@ -25,6 +25,7 @@ type LintResult struct {
 	ShortTimers            []ShortTimer
 	BrokenLinks            []BrokenLink
 	UnderspecifiedAPINodes []UnderspecifiedAPINode
+	SelfReferenceCopies    []SelfReferenceCopy
 	TotalNodes             int
 	ReachableCount         int
 	SchemaValid            bool
@@ -209,6 +210,11 @@ func lintProcess(filePath string) (*LintResult, error) {
 
 	title, _ := proc["title"].(string)
 
+	var processID int
+	if id, ok := proc["obj_id"].(float64); ok {
+		processID = int(id)
+	}
+
 	result := &LintResult{ProcessTitle: title, TotalNodes: len(nodes)}
 
 	typed := parseProcessNodes(nodes)
@@ -224,6 +230,7 @@ func lintProcess(filePath string) (*LintResult, error) {
 	result.ShortTimers = findShortTimers(typed)
 	result.BrokenLinks = findBrokenLinks(typed)
 	result.UnderspecifiedAPINodes = findUnderspecifiedAPINodes(typed)
+	result.SelfReferenceCopies = findSelfReferenceCopies(typed, processID)
 
 	schemaErr := ValidateJSONSchema(filePath, debug)
 	if schemaErr != nil {
@@ -724,6 +731,62 @@ func findBrokenLinks(nodes []processNode) []BrokenLink {
 	return result
 }
 
+// SelfReferenceCopy is an api_copy or api_rpc logic whose conv_id equals the
+// process's own obj_id — a self-referencing "infinite-loop" pattern. The native
+// Corezoid UI deploys such processes, but push-process's pre-deployment validation
+// rejects them and force=true does NOT bypass that check.
+// Recommended replacement: a time-semaphore delay node (≥30s) with a bare go back
+// to the loop entry point — the existing task cycles in-place without spawning a new one.
+type SelfReferenceCopy struct {
+	NodeID    string
+	NodeTitle string
+	NodeType  string // "api_copy" or "api_rpc"
+	Issue     string
+}
+
+// findSelfReferenceCopies detects api_copy or api_rpc logics whose conv_id
+// equals the process's own processID — the self-referencing loop pattern that
+// the Corezoid UI allows but push-process rejects (force=true cannot override it).
+// If processID is 0 (unknown / new process), no findings are emitted.
+func findSelfReferenceCopies(nodes []processNode, processID int) []SelfReferenceCopy {
+	if processID == 0 {
+		return nil
+	}
+	var result []SelfReferenceCopy
+	for _, n := range nodes {
+		for _, lg := range n.logics {
+			lgType, _ := lg["type"].(string)
+			if lgType != "api_copy" && lgType != "api_rpc" {
+				continue
+			}
+			convID, ok := lg["conv_id"].(float64)
+			if !ok || int(convID) != processID {
+				continue
+			}
+			title := n.title
+			if title == "" {
+				title = "(untitled)"
+			}
+			kindName := "Copy Task"
+			if lgType == "api_rpc" {
+				kindName = "Call a Process"
+			}
+			result = append(result, SelfReferenceCopy{
+				NodeID:    n.id,
+				NodeTitle: title,
+				NodeType:  lgType,
+				Issue: fmt.Sprintf(
+					"node %q (id=%s) uses %s (type=%s, conv_id=%d) to send tasks into this same process — "+
+						"push-process blocks this regardless of force=true. "+
+						"Fix: replace with a time-semaphore delay node (≥30s) → bare `go` back to the loop entry; "+
+						"the task cycles in-place without spawning a new one.",
+					title, n.id, kindName, lgType, processID),
+			})
+		}
+	}
+	return result
+}
+
 // findUnrepliedTerminals detects final nodes reachable from Start without
 // crossing any api_rpc_reply, in processes that reply somewhere else. A process
 // that replies on its error paths but ends its success path in a bare final is
@@ -1218,6 +1281,15 @@ func FormatLintResult(result *LintResult) string {
 		}
 	}
 
+	if len(result.SelfReferenceCopies) > 0 {
+		hasIssues = true
+		sb.WriteString(fmt.Sprintf("\n=== SELF-REFERENCING COPY/CALL NODES (%d) — push-process blocks these; force=true does NOT bypass ===\n", len(result.SelfReferenceCopies)))
+		for _, sr := range result.SelfReferenceCopies {
+			sb.WriteString(fmt.Sprintf("  [%s] %s  (type: %s)\n", sr.NodeID, sr.NodeTitle, sr.NodeType))
+			sb.WriteString(fmt.Sprintf("  Issue: %s\n", sr.Issue))
+		}
+	}
+
 	if !hasIssues {
 		sb.WriteString("\nNo issues found.")
 	} else {
@@ -1225,7 +1297,7 @@ func FormatLintResult(result *LintResult) string {
 		if !result.SchemaValid {
 			schemaIssues = 1
 		}
-		total := len(result.NoopConditions) + len(result.UnusedSetParams) + len(result.OrphanedNodes) + len(result.RpcReplyMismatches) + len(result.PassthroughEscalations) + len(result.LiteralReplyValues) + len(result.SharedErrorClusters) + len(result.OldFormatNodes) + len(result.UnrepliedTerminals) + len(result.MissingDefaultGo) + len(result.ShortTimers) + len(result.BrokenLinks) + len(result.UnderspecifiedAPINodes) + schemaIssues
+		total := len(result.NoopConditions) + len(result.UnusedSetParams) + len(result.OrphanedNodes) + len(result.RpcReplyMismatches) + len(result.PassthroughEscalations) + len(result.LiteralReplyValues) + len(result.SharedErrorClusters) + len(result.OldFormatNodes) + len(result.UnrepliedTerminals) + len(result.MissingDefaultGo) + len(result.ShortTimers) + len(result.BrokenLinks) + len(result.UnderspecifiedAPINodes) + len(result.SelfReferenceCopies) + schemaIssues
 		sb.WriteString(fmt.Sprintf("\nTotal issues: %d\n", total))
 	}
 

--- a/plugins/corezoid/mcp-server/lint_self_ref_test.go
+++ b/plugins/corezoid/mcp-server/lint_self_ref_test.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestLintProcess_SelfReferenceCopy verifies that lint detects api_copy nodes
+// whose conv_id equals the process's own obj_id.
+func TestLintProcess_SelfReferenceCopy(t *testing.T) {
+	result, err := lintProcess("samples/api_copy_to_itself.json")
+	if err != nil {
+		t.Fatalf("unexpected lint error: %v", err)
+	}
+	if len(result.SelfReferenceCopies) != 1 {
+		t.Errorf("expected 1 SelfReferenceCopy finding, got %d", len(result.SelfReferenceCopies))
+	}
+	if len(result.SelfReferenceCopies) > 0 {
+		sr := result.SelfReferenceCopies[0]
+		if sr.NodeType != "api_copy" {
+			t.Errorf("expected NodeType=api_copy, got %q", sr.NodeType)
+		}
+		if sr.NodeTitle != "Copy to Self" {
+			t.Errorf("expected NodeTitle=%q, got %q", "Copy to Self", sr.NodeTitle)
+		}
+		if !strings.Contains(sr.Issue, "force=true") {
+			t.Errorf("issue message should mention force=true: %s", sr.Issue)
+		}
+	}
+}
+
+// TestFindSelfReferenceCopies_ProcessIDZero verifies that processID=0 produces
+// no findings (cannot check when process ID is unknown).
+func TestFindSelfReferenceCopies_ProcessIDZero(t *testing.T) {
+	nodes := []processNode{
+		{
+			id:    "aabbccddaabbccddaabb0001",
+			title: "Self Copy",
+			logics: []map[string]interface{}{
+				{"type": "api_copy", "conv_id": float64(999)},
+			},
+		},
+	}
+	result := findSelfReferenceCopies(nodes, 0)
+	if len(result) != 0 {
+		t.Errorf("expected 0 findings for processID=0, got %d", len(result))
+	}
+}
+
+// TestFindSelfReferenceCopies_NoMatch verifies no finding when conv_id != processID.
+func TestFindSelfReferenceCopies_NoMatch(t *testing.T) {
+	nodes := []processNode{
+		{
+			id:    "aabbccddaabbccddaabb0001",
+			title: "Copy to Other",
+			logics: []map[string]interface{}{
+				{"type": "api_copy", "conv_id": float64(456)},
+			},
+		},
+	}
+	result := findSelfReferenceCopies(nodes, 999)
+	if len(result) != 0 {
+		t.Errorf("expected 0 findings, got %d", len(result))
+	}
+}
+
+// TestFindSelfReferenceCopies_ApiRpc verifies api_rpc self-reference is also detected.
+func TestFindSelfReferenceCopies_ApiRpc(t *testing.T) {
+	nodes := []processNode{
+		{
+			id:    "aabbccddaabbccddaabb0001",
+			title: "RPC to Self",
+			logics: []map[string]interface{}{
+				{"type": "api_rpc", "conv_id": float64(777)},
+			},
+		},
+	}
+	result := findSelfReferenceCopies(nodes, 777)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 finding, got %d", len(result))
+	}
+	if result[0].NodeType != "api_rpc" {
+		t.Errorf("expected NodeType=api_rpc, got %q", result[0].NodeType)
+	}
+	if !strings.Contains(result[0].Issue, "Call a Process") {
+		t.Errorf("issue should mention 'Call a Process': %s", result[0].Issue)
+	}
+}

--- a/plugins/corezoid/mcp-server/mcp_handlers_process.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_process.go
@@ -111,7 +111,28 @@ func handlePullProcess(ctx context.Context, args map[string]interface{}) (string
 	if err := os.WriteFile(filePath, data, 0644); err != nil {
 		return fmt.Sprintf("Error writing file: %v", err), true
 	}
-	return fmt.Sprintf("Process %d saved to %s", processID, filePath), false
+
+	result := fmt.Sprintf("Process %d saved to %s", processID, filePath)
+
+	// Warn if the downloaded process contains self-referencing api_copy/api_rpc
+	// nodes — the Corezoid UI supports this pattern but push-process cannot deploy
+	// it and force=true does NOT bypass the pre-deployment check.
+	if m, ok := procInfo.(map[string]interface{}); ok {
+		if rawNodes, getErr := getNodes(m); getErr == nil {
+			typed := parseProcessNodes(rawNodes)
+			if selfRefs := findSelfReferenceCopies(typed, processID); len(selfRefs) > 0 {
+				var parts []string
+				for _, sr := range selfRefs {
+					parts = append(parts, fmt.Sprintf("%q (id=%s, type=%s)", sr.NodeTitle, sr.NodeID, sr.NodeType))
+				}
+				result += fmt.Sprintf(
+					"\n\nWarning: %d self-referencing node(s) detected — this process cannot be re-deployed with push-process without fixing them first (force=true does not bypass this check):\n  • %s\nFix: replace each self-copy node with a time-semaphore delay node (≥30s) followed by a bare `go` back to the loop entry. The task cycles in-place without spawning a new one.",
+					len(selfRefs), strings.Join(parts, "\n  • "))
+			}
+		}
+	}
+
+	return result, false
 }
 
 // handlePullFolder recursively downloads a folder (stage) and all its
@@ -228,7 +249,7 @@ func handlePushProcess(ctx context.Context, args map[string]interface{}) (string
 		hard := len(lintRes.BrokenLinks) + len(lintRes.OldFormatNodes) +
 			len(lintRes.MissingDefaultGo) + len(lintRes.ShortTimers) +
 			len(lintRes.RpcReplyMismatches) + len(lintRes.LiteralReplyValues) +
-			len(lintRes.UnrepliedTerminals)
+			len(lintRes.UnrepliedTerminals) + len(lintRes.SelfReferenceCopies)
 		advisory := len(lintRes.NoopConditions) + len(lintRes.UnusedSetParams) +
 			len(lintRes.OrphanedNodes) + len(lintRes.PassthroughEscalations) +
 			len(lintRes.SharedErrorClusters)

--- a/plugins/corezoid/mcp-server/tools_registry.go
+++ b/plugins/corezoid/mcp-server/tools_registry.go
@@ -151,7 +151,7 @@ var toolRegistry = []mcpTool{
 	},
 	{
 		Name:        "push-process",
-		Description: "Validate and deploy a process file to Corezoid. Runs lint-process first and blocks the deploy on issues that would break it (broken node links, old-format nodes, RPC paths without reply, nodes missing a default go, sub-30s timers, literal reply values); advisory findings are shown but do not block. Pass force=true to deploy despite blocking lint issues. Note: the server regenerates node IDs on every push and the local file is rewritten in place with the server's canonical scheme — reference nodes by title when iterating, and re-read the file after a push instead of reusing old node IDs.",
+		Description: "Validate and deploy a process file to Corezoid. Runs lint-process first and blocks the deploy on issues that would break it (broken node links, old-format nodes, RPC paths without reply, nodes missing a default go, sub-30s timers, literal reply values); advisory findings are shown but do not block. Pass force=true to deploy despite blocking lint issues. Note: force=true only bypasses lint-detected structural issues — pre-deployment validation errors such as self-referencing api_copy/api_rpc nodes are always blocked and cannot be overridden. Note: the server regenerates node IDs on every push and the local file is rewritten in place with the server's canonical scheme — reference nodes by title when iterating, and re-read the file after a push instead of reusing old node IDs.",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
@@ -161,7 +161,7 @@ var toolRegistry = []mcpTool{
 				},
 				"force": map[string]interface{}{
 					"type":        "boolean",
-					"description": "Deploy even if the pre-push lint finds blocking issues. Advisory findings never block. Default false.",
+					"description": "Deploy even if the pre-push lint finds blocking issues (broken links, old-format nodes, etc.). Advisory findings never block. Does NOT bypass pre-deployment validation errors such as self-referencing api_copy/api_rpc nodes — those must be fixed in the process design. Default false.",
 				},
 			},
 			"required": []string{"process_path"},
@@ -191,7 +191,7 @@ var toolRegistry = []mcpTool{
 	},
 	{
 		Name:        "lint-process",
-		Description: "Validate process structure. Reports orphaned nodes, noop conditions, unused set_params, passthrough escalations, shared error clusters (an error node fed by several different failing nodes — each needs its own Reply/Error cluster), old-format nodes (obj_type:0 err_node_id targets, or action logic mixed with go_if_const — the UI would force-convert the process), finals reachable without api_rpc_reply in a process that replies elsewhere (an RPC caller would hang), nodes whose logics do not end with a default go and time semaphors under the 30s server minimum (both reject the deploy), and literal non-string values in api_rpc_reply res_data (a scheme shape that hangs the server commit on push).",
+		Description: "Validate process structure. Reports orphaned nodes, noop conditions, unused set_params, passthrough escalations, shared error clusters (an error node fed by several different failing nodes — each needs its own Reply/Error cluster), old-format nodes (obj_type:0 err_node_id targets, or action logic mixed with go_if_const — the UI would force-convert the process), finals reachable without api_rpc_reply in a process that replies elsewhere (an RPC caller would hang), nodes whose logics do not end with a default go and time semaphors under the 30s server minimum (both reject the deploy), literal non-string values in api_rpc_reply res_data (a scheme shape that hangs the server commit on push), and self-referencing api_copy/api_rpc nodes (valid in the Corezoid UI but always blocked by push-process — force=true does not bypass this).",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{

--- a/plugins/corezoid/opencode-plugin/index.test.ts
+++ b/plugins/corezoid/opencode-plugin/index.test.ts
@@ -1,0 +1,151 @@
+// Tests for the OpenCode skills loader. Runs under `bun test`.
+//
+// Deliberately avoids importing index.ts so we don't need @opencode-ai/plugin
+// or zod installed to exercise the skill-discovery logic.
+
+import { describe, expect, test } from "bun:test"
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs"
+import { join } from "node:path"
+import { tmpdir } from "node:os"
+import {
+  parseFrontmatter,
+  substituteRoot,
+  skillToolName,
+  discoverSkills,
+  resolvePluginRoot,
+} from "./skills-loader.ts"
+
+describe("parseFrontmatter", () => {
+  test("parses simple inline fields", () => {
+    const raw = "---\nname: foo\ndescription: bar baz\n---\n\n# body\n"
+    const got = parseFrontmatter(raw)
+    expect(got?.frontmatter.name).toBe("foo")
+    expect(got?.frontmatter.description).toBe("bar baz")
+    expect(got?.body).toBe("# body\n")
+  })
+
+  test("parses folded multi-line description with '>'", () => {
+    const raw = [
+      "---",
+      "name: corezoid-create",
+      "description: >",
+      "  first line",
+      "  second line",
+      "---",
+      "",
+      "body",
+    ].join("\n")
+    const got = parseFrontmatter(raw)
+    expect(got?.frontmatter.name).toBe("corezoid-create")
+    expect(got?.frontmatter.description).toBe("first line second line")
+  })
+
+  test("returns null when frontmatter is missing", () => {
+    expect(parseFrontmatter("# just a heading")).toBeNull()
+  })
+
+  test("returns null when required fields are absent", () => {
+    const raw = "---\ndescription: no name\n---\nbody"
+    expect(parseFrontmatter(raw)).toBeNull()
+  })
+})
+
+describe("substituteRoot", () => {
+  test("replaces braced token", () => {
+    expect(substituteRoot("see ${CLAUDE_PLUGIN_ROOT}/docs/x.md", "/p")).toBe(
+      "see /p/docs/x.md",
+    )
+  })
+
+  test("replaces unbraced token", () => {
+    expect(substituteRoot("see $CLAUDE_PLUGIN_ROOT/docs/x.md", "/p")).toBe(
+      "see /p/docs/x.md",
+    )
+  })
+
+  test("replaces all occurrences", () => {
+    const body = "${CLAUDE_PLUGIN_ROOT}/a ${CLAUDE_PLUGIN_ROOT}/b $CLAUDE_PLUGIN_ROOT/c"
+    expect(substituteRoot(body, "/p")).toBe("/p/a /p/b /p/c")
+  })
+})
+
+describe("skillToolName", () => {
+  test("prefixes with corezoid_ and converts hyphens to underscores", () => {
+    expect(skillToolName("corezoid-create")).toBe("corezoid_corezoid_create")
+    expect(skillToolName("state-diagram-edit")).toBe("corezoid_state_diagram_edit")
+  })
+})
+
+describe("discoverSkills — synthetic fixture", () => {
+  const root = join(tmpdir(), `corezoid-opencode-test-${Date.now()}`)
+
+  function seed(name: string, contents: string) {
+    const dir = join(root, "skills", name)
+    mkdirSync(dir, { recursive: true })
+    writeFileSync(join(dir, "SKILL.md"), contents)
+  }
+
+  function cleanup() {
+    if (existsSync(root)) rmSync(root, { recursive: true, force: true })
+  }
+
+  test("registers each SKILL.md as a tool", async () => {
+    cleanup()
+    seed("alpha", "---\nname: alpha\ndescription: alpha skill\n---\nA body ${CLAUDE_PLUGIN_ROOT}/x\n")
+    seed("beta-gamma", "---\nname: beta-gamma\ndescription: bg skill\n---\nB body\n")
+    // Skill dir with no SKILL.md is skipped.
+    mkdirSync(join(root, "skills", "empty"), { recursive: true })
+
+    const skills = await discoverSkills(root)
+    expect(skills).toHaveLength(2)
+
+    const alpha = skills.find((s) => s.toolName === "corezoid_alpha")
+    const beta = skills.find((s) => s.toolName === "corezoid_beta_gamma")
+    expect(alpha).toBeDefined()
+    expect(beta).toBeDefined()
+    expect(alpha!.description).toBe("alpha skill")
+    expect(alpha!.body).toContain(`${root}/x`)
+    expect(alpha!.body).not.toContain("${CLAUDE_PLUGIN_ROOT}")
+
+    cleanup()
+  })
+
+  test("returns empty list when skills dir is missing", async () => {
+    cleanup()
+    mkdirSync(root, { recursive: true })
+    const skills = await discoverSkills(root)
+    expect(skills).toHaveLength(0)
+    cleanup()
+  })
+})
+
+describe("discoverSkills — against real corezoid plugin", () => {
+  test("finds all real SKILL.md files with valid frontmatter", async () => {
+    const pluginRoot = resolvePluginRoot(import.meta.url)
+    const skills = await discoverSkills(pluginRoot)
+
+    // Sanity: at least the well-known core skills must load.
+    expect(skills.length).toBeGreaterThanOrEqual(10)
+
+    const names = skills.map((s) => s.toolName)
+    expect(names).toContain("corezoid_corezoid")
+    expect(names).toContain("corezoid_corezoid_create")
+    expect(names).toContain("corezoid_corezoid_edit")
+
+    // Names all follow corezoid_<snake> pattern.
+    for (const n of names) {
+      expect(n).toMatch(/^corezoid_[a-z0-9_]+$/)
+    }
+
+    // Descriptions all meet Anthropic Agent Skills Spec minimum (≥20 chars).
+    for (const s of skills) {
+      expect(s.description.length).toBeGreaterThanOrEqual(20)
+    }
+
+    // No skill body still contains the raw token — substitution happened.
+    for (const s of skills) {
+      expect(s.body).not.toContain("${CLAUDE_PLUGIN_ROOT}")
+      expect(s.body).not.toContain("$CLAUDE_PLUGIN_ROOT")
+    }
+  })
+})

--- a/plugins/corezoid/opencode-plugin/index.ts
+++ b/plugins/corezoid/opencode-plugin/index.ts
@@ -1,0 +1,35 @@
+// OpenCode host adapter for the Corezoid plugin.
+//
+// Registers every SKILL.md under ../skills/ as an OpenCode tool named
+// `corezoid_<skill_name>`, with `${CLAUDE_PLUGIN_ROOT}` resolved in-memory
+// to this plugin's on-disk location. The model receives the same skill
+// contents that Claude Code / Codex would inject natively — OpenCode has
+// no native concept of Anthropic Agent Skills.
+//
+// The MCP server (Go binary launched by ../mcp-server/run.sh) is configured
+// separately via opencode.json — see plugins/corezoid/.mcp.opencode.json
+// and scripts/install-opencode.sh.
+
+import { type Plugin, tool } from "@opencode-ai/plugin"
+import { discoverSkills, resolvePluginRoot } from "./skills-loader.ts"
+
+export const CorezoidOpenCodePlugin: Plugin = async () => {
+  const pluginRoot = resolvePluginRoot(import.meta.url)
+  const skills = await discoverSkills(pluginRoot)
+
+  const tools: Record<string, ReturnType<typeof tool>> = {}
+  for (const skill of skills) {
+    const body = skill.body
+    tools[skill.toolName] = tool({
+      description: skill.description,
+      args: {},
+      async execute() {
+        return body
+      },
+    })
+  }
+
+  return { tool: tools }
+}
+
+export default CorezoidOpenCodePlugin

--- a/plugins/corezoid/opencode-plugin/package.json
+++ b/plugins/corezoid/opencode-plugin/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@corezoid/opencode-plugin",
+  "version": "2.10.0",
+  "description": "OpenCode host adapter for the Corezoid AI plugin. Registers Corezoid skills as OpenCode tools.",
+  "type": "module",
+  "main": "index.ts",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "files": [
+    "index.ts",
+    "README.md"
+  ],
+  "author": {
+    "name": "Corezoid",
+    "url": "https://corezoid.com"
+  },
+  "homepage": "https://github.com/corezoid/corezoid-ai-plugin",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/corezoid/corezoid-ai-plugin.git",
+    "directory": "plugins/corezoid/opencode-plugin"
+  },
+  "license": "MIT",
+  "keywords": [
+    "opencode",
+    "opencode-plugin",
+    "corezoid",
+    "bpm",
+    "workflow",
+    "mcp"
+  ],
+  "peerDependencies": {
+    "@opencode-ai/plugin": "*"
+  },
+  "devDependencies": {
+    "@opencode-ai/plugin": "*",
+    "@types/node": "^20"
+  },
+  "scripts": {
+    "test": "bun test"
+  }
+}

--- a/plugins/corezoid/opencode-plugin/skills-loader.ts
+++ b/plugins/corezoid/opencode-plugin/skills-loader.ts
@@ -1,0 +1,108 @@
+// Pure skill-discovery + frontmatter logic. Split out from index.ts so tests
+// can import it without pulling in the @opencode-ai/plugin peer dependency.
+
+import { readFile, readdir } from "node:fs/promises"
+import { existsSync, realpathSync } from "node:fs"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const TOKEN_BRACED = "${CLAUDE_PLUGIN_ROOT}"
+const TOKEN_UNBRACED = "$CLAUDE_PLUGIN_ROOT"
+
+export interface SkillFrontmatter {
+  name: string
+  description: string
+}
+
+export interface Skill {
+  toolName: string
+  description: string
+  body: string
+}
+
+export function resolvePluginRoot(moduleUrl: string): string {
+  // In npm-installed layout the file lives at <pkg>/index.ts (or .js after build);
+  // in-repo it lives at plugins/corezoid/opencode-plugin/index.ts.
+  // Either way, one dir up is the corezoid plugin root (siblings: skills/, mcp-server/, docs/...).
+  const here = dirname(fileURLToPath(moduleUrl))
+  const candidate = resolve(here, "..")
+  return realpathSync(candidate)
+}
+
+export function parseFrontmatter(
+  raw: string,
+): { frontmatter: SkillFrontmatter; body: string } | null {
+  if (!raw.startsWith("---")) return null
+  const end = raw.indexOf("\n---", 3)
+  if (end < 0) return null
+
+  const yaml = raw.slice(3, end).trim()
+  const body = raw.slice(end + 4).replace(/^\r?\n/, "")
+
+  const fm: Partial<SkillFrontmatter> = {}
+  let key: keyof SkillFrontmatter | null = null
+  let accum: string[] = []
+
+  const flush = () => {
+    if (key) {
+      fm[key] = accum.join(" ").replace(/\s+/g, " ").trim()
+    }
+    key = null
+    accum = []
+  }
+
+  for (const line of yaml.split("\n")) {
+    const m = line.match(/^([A-Za-z_-]+):\s*(.*)$/)
+    if (m) {
+      flush()
+      const [, k, rest] = m
+      if (k === "name" || k === "description") {
+        key = k
+        if (rest && rest.trim() !== ">" && rest.trim() !== "|") {
+          accum.push(rest.trim())
+        }
+      }
+    } else if (key) {
+      accum.push(line.trim())
+    }
+  }
+  flush()
+
+  if (!fm.name || !fm.description) return null
+  return { frontmatter: fm as SkillFrontmatter, body }
+}
+
+export function substituteRoot(body: string, pluginRoot: string): string {
+  return body.split(TOKEN_BRACED).join(pluginRoot).split(TOKEN_UNBRACED).join(pluginRoot)
+}
+
+export function skillToolName(skillDirName: string): string {
+  return `corezoid_${skillDirName.replace(/-/g, "_")}`
+}
+
+export async function discoverSkills(pluginRoot: string): Promise<Skill[]> {
+  const skillsDir = join(pluginRoot, "skills")
+  if (!existsSync(skillsDir)) return []
+
+  const entries = await readdir(skillsDir, { withFileTypes: true })
+  const skills: Skill[] = []
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    const skillPath = join(skillsDir, entry.name, "SKILL.md")
+    if (!existsSync(skillPath)) continue
+
+    const raw = await readFile(skillPath, "utf8")
+    const parsed = parseFrontmatter(raw)
+    if (!parsed) continue
+
+    skills.push({
+      toolName: skillToolName(entry.name),
+      description: parsed.frontmatter.description,
+      body: substituteRoot(parsed.body, pluginRoot),
+    })
+  }
+
+  skills.sort((a, b) => a.toolName.localeCompare(b.toolName))
+  return skills
+}

--- a/plugins/corezoid/opencode-plugin/tsconfig.json
+++ b/plugins/corezoid/opencode-plugin/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "types": ["node"],
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["index.ts", "index.test.ts"]
+}

--- a/plugins/corezoid/scripts/install-kiro.sh
+++ b/plugins/corezoid/scripts/install-kiro.sh
@@ -312,6 +312,8 @@ FOOTER
 
   sync_version "$PLUGIN_ROOT/.kiro-plugin/plugin.json"
   sync_version "$PLUGIN_ROOT/.codex-plugin/plugin.json"
+  sync_version "$PLUGIN_ROOT/.opencode-plugin/plugin.json"
+  sync_version "$PLUGIN_ROOT/opencode-plugin/package.json"
   sync_version "$REPO_ROOT/.claude-plugin/marketplace.json"
   sync_version "$REPO_ROOT/.agents/plugins/marketplace.json"
 

--- a/plugins/corezoid/scripts/install-opencode.sh
+++ b/plugins/corezoid/scripts/install-opencode.sh
@@ -1,0 +1,210 @@
+#!/bin/sh
+# install-opencode.sh — set up the Corezoid plugin for OpenCode (opencode.ai).
+#
+# What this script does, and does NOT do:
+#   - It configures the Corezoid MCP server in the target opencode.json.
+#     `.mcp.opencode.json` is a template with `${OPENCODE_PLUGIN_ROOT:-$PWD}`
+#     resolved to this checkout's absolute plugin path, then merged into the
+#     target opencode.json via a Python JSON merge (idempotent — safe to
+#     re-run).
+#   - It installs the sibling TypeScript plugin (../opencode-plugin/) via
+#     `opencode plugin install file://<absolute-path>`. That plugin reads
+#     ../skills/*/SKILL.md at load time and registers each as a tool named
+#     `corezoid_<snake_skill_name>`. Skills are NOT copied anywhere — the
+#     TS plugin loads them straight from the plugin dir with
+#     `${CLAUDE_PLUGIN_ROOT}` substituted in memory.
+#
+# Usage:
+#   plugins/corezoid/scripts/install-opencode.sh
+#     workspace-install mode. Patches ./opencode.json in $PWD, installs the
+#     TS plugin. Also runs `opencode plugin install ...` if the `opencode`
+#     CLI is on PATH.
+#
+#   plugins/corezoid/scripts/install-opencode.sh --user-install
+#     Patches ~/.config/opencode/opencode.json (creating it and its parent
+#     dirs if needed). Same TS-plugin install step.
+#
+#   plugins/corezoid/scripts/install-opencode.sh --print-mcp
+#     Emits the resolved MCP JSON block to stdout. Nothing is written. Used
+#     by CI to validate the template and by the docs to show what gets
+#     merged into opencode.json.
+#
+# Idempotent — safe to run repeatedly; the JSON merge overwrites the
+# `mcp.corezoid` entry but preserves all sibling entries and top-level keys.
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMPLATE="$PLUGIN_ROOT/.mcp.opencode.json"
+
+if [ ! -f "$TEMPLATE" ]; then
+  echo "ERROR: MCP template not found: $TEMPLATE" >&2
+  exit 1
+fi
+
+# ─── Resolve template ───────────────────────────────────────────────────────
+# Substitute ${OPENCODE_PLUGIN_ROOT:-$PWD} with the absolute PLUGIN_ROOT.
+# `#` delimiter avoids escaping `/` in paths; two-step `sed -i.bak` isn't
+# needed here since we're piping to a variable, not editing in place.
+
+resolve_template() {
+  sed "s#\${OPENCODE_PLUGIN_ROOT:-\$PWD}#$PLUGIN_ROOT#g" "$TEMPLATE"
+}
+
+# ─── Mode: --print-mcp ──────────────────────────────────────────────────────
+
+run_print_mcp() {
+  resolve_template
+}
+
+# ─── JSON merge helper ──────────────────────────────────────────────────────
+# python3 is required (same dependency as install-kiro.sh's power-install
+# mode). Merges the resolved template's `mcp.corezoid` entry into the target
+# opencode.json, creating the file if it doesn't exist. Preserves all other
+# keys and MCP entries. Uses 2-space indent to match OpenCode's own writes.
+
+merge_into_opencode_json() {
+  target="$1"
+  mkdir -p "$(dirname "$target")"
+
+  resolved=$(resolve_template)
+
+  python3 - "$target" "$resolved" << 'PYEOF'
+import json
+import os
+import sys
+
+target_path = sys.argv[1]
+resolved_json = sys.argv[2]
+
+resolved = json.loads(resolved_json)
+new_entry = resolved.get("mcp", {}).get("corezoid")
+if not new_entry:
+    print("ERROR: resolved template lacks mcp.corezoid entry", file=sys.stderr)
+    sys.exit(1)
+
+if os.path.exists(target_path):
+    with open(target_path) as f:
+        try:
+            data = json.load(f)
+        except json.JSONDecodeError as e:
+            print(f"ERROR: {target_path} is not valid JSON: {e}", file=sys.stderr)
+            sys.exit(1)
+else:
+    data = {}
+
+data.setdefault("mcp", {})["corezoid"] = new_entry
+
+with open(target_path, "w") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+
+print(f"✓ Merged mcp.corezoid into {target_path}")
+PYEOF
+}
+
+# ─── Install the sibling TS plugin ──────────────────────────────────────────
+# OpenCode loads local plugins from ~/.config/opencode/plugins/*.ts (docs:
+# https://opencode.ai/docs/plugins → "Use a plugin > From local files"). The
+# `opencode plugin install` CLI is only for npm modules, not local paths, so
+# for a from-source install we bundle skills-loader.ts + index.ts into a
+# single file at that location. Bundling (not symlinking) is required because
+# OpenCode scans that dir for top-level .ts entry points, not subdirectories.
+
+install_ts_plugin() {
+  ts_plugin_src="$PLUGIN_ROOT/opencode-plugin"
+  if [ ! -d "$ts_plugin_src" ]; then
+    echo "⚠ TS plugin dir not found: $ts_plugin_src" >&2
+    return 0
+  fi
+
+  cfg_plugins_dir="${XDG_CONFIG_HOME:-$HOME/.config}/opencode/plugins"
+  mkdir -p "$cfg_plugins_dir"
+  dest="$cfg_plugins_dir/corezoid.ts"
+
+  python3 - "$ts_plugin_src/index.ts" "$ts_plugin_src/skills-loader.ts" "$dest" "$PLUGIN_ROOT" << 'PYEOF'
+import re
+import sys
+
+index_path, loader_path, dest, plugin_root = sys.argv[1:]
+
+with open(loader_path) as f:
+    loader = f.read()
+with open(index_path) as f:
+    index = f.read()
+
+# Strip the `import { ... } from "./skills-loader.ts"` line from index — the
+# names are declared inline below via the loader body.
+index = re.sub(
+    r'^import\s*\{[^}]+\}\s+from\s+"\./skills-loader\.ts"\s*\n',
+    "",
+    index,
+    flags=re.MULTILINE,
+)
+
+# Replace `resolvePluginRoot(import.meta.url)` with the hardcoded absolute
+# path — the bundle lives in ~/.config/opencode/plugins/corezoid.ts, so
+# import.meta.url points to that location, not the source plugin dir.
+index = index.replace(
+    "resolvePluginRoot(import.meta.url)",
+    f'"{plugin_root}"',
+)
+
+header = (
+    "// AUTOGENERATED by plugins/corezoid/scripts/install-opencode.sh —\n"
+    "// bundle of opencode-plugin/index.ts + skills-loader.ts.\n"
+    f"// Plugin root hardcoded to: {plugin_root}\n"
+    "// Edits here are lost on the next install. Change the source files.\n\n"
+)
+bundle = header + "// ─── skills-loader.ts ───\n" + loader + "\n\n// ─── index.ts ───\n" + index
+
+with open(dest, "w") as f:
+    f.write(bundle)
+
+print(f"✓ Bundled OpenCode plugin: {dest}")
+PYEOF
+}
+
+# ─── Mode: workspace-install (default) ──────────────────────────────────────
+
+run_workspace_install() {
+  target="${1:-$PWD/opencode.json}"
+  merge_into_opencode_json "$target"
+  install_ts_plugin
+
+  echo ""
+  echo "✓ Corezoid OpenCode adapter installed"
+  echo "  opencode.json:  $target"
+  echo "  Plugin root:    $PLUGIN_ROOT"
+  echo "  MCP command resolved with OPENCODE_PLUGIN_ROOT=$PLUGIN_ROOT"
+  echo ""
+  echo "  Start OpenCode in this workspace to load the Corezoid MCP server"
+  echo "  and skills (registered as tools with the corezoid_ prefix)."
+}
+
+# ─── Mode: --user-install ───────────────────────────────────────────────────
+
+run_user_install() {
+  case "$(uname -s 2>/dev/null || echo Unknown)" in
+    Darwin) CFG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/opencode" ;;
+    Linux)  CFG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/opencode" ;;
+    *)      CFG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/opencode" ;;
+  esac
+  target="$CFG_DIR/opencode.json"
+  merge_into_opencode_json "$target"
+  install_ts_plugin
+
+  echo ""
+  echo "✓ Corezoid OpenCode adapter installed (user scope)"
+  echo "  opencode.json:  $target"
+  echo "  Plugin root:    $PLUGIN_ROOT"
+}
+
+# ─── Dispatch ───────────────────────────────────────────────────────────────
+
+case "${1:-}" in
+  --print-mcp)     run_print_mcp ;;
+  --user-install)  shift; run_user_install "$@" ;;
+  *)               run_workspace_install "$@" ;;
+esac


### PR DESCRIPTION
## Summary
- `BeforeValidation` now emits an actionable error: names the blocking node, states `force=true` cannot override it, and recommends the time-semaphore loop pattern
- `lint-process` detects self-referencing `api_copy`/`api_rpc` nodes as a **hard** finding (reads `obj_id` from the process JSON)
- `pull-process` appends a warning at download time when the process already has self-reference nodes — surfaces the push-blocker before the first deploy attempt
- `force` parameter description now explicitly states it only bypasses lint-detected structural issues, not pre-deployment validation errors

## Context
tool: push-process | version: 2.3.5 | install: 278022ea-2291-4146-ba5f-44f47fc26b41

## Checklist
- [x] `go build` passes
- [x] `go vet` passes
- [x] `go test ./...` passes
- [x] No version bump / CHANGELOG.md change included

## Test plan
- `TestBeforeValidation_ApiCopyToItself` — still passes; improved message names node and explains `force=true` limitation
- `TestLintProcess_SelfReferenceCopy` — new: verifies lint detects self-reference from sample fixture
- `TestFindSelfReferenceCopies_*` — unit tests covering zero-processID, no-match, api_rpc variants