### PR TITLE
feat(push-process): require developer approval before every push

### DIFF
--- a/plugins/corezoid/skills/corezoid-alias-manager/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-alias-manager/SKILL.md
@@ -128,7 +128,13 @@ grep -rl '"conv_id": 1834583' . --include="*.conv.json"
 ```
 
 For each file found, replace `"conv_id": 1834583` with `"conv_id": "@payment-checkout"`.
-Then for each modified file, run **`lint-process`** and on success **`push-process`**.
+For each modified file, run **`lint-process`** to validate it.
+
+**⛔ Do NOT call `push-process` without explicit developer approval.** After all files pass lint, ask for one approval covering the whole group:
+
+> "Lint passed ✅ for [N] file(s). Ready to deploy them all? (yes/no)"
+
+After receiving explicit approval ("yes", "go", "деплой", "deploy", or equivalent), call **`push-process`** for each file.
 
 > After pushing, tell the user: "Changes deployed. Please **refresh the page** in Corezoid to see the updated process."
 

--- a/plugins/corezoid/skills/corezoid-api-connector/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-api-connector/SKILL.md
@@ -120,11 +120,15 @@ Add a 30-second timeout semaphor to the API Call node.
 
 ---
 
-## Step 5: Validate and Deploy
+## Step 5: Validate, Get Approval, and Deploy
 
-```
-lint-process → fix errors → push-process → run-task (smoke test)
-```
+1. Run `lint-process` — fix all errors before proceeding.
+2. **⛔ Do NOT call `push-process` without explicit developer approval.** After lint passes, ask:
+
+   > "Lint passed ✅. Ready to deploy **[Process Name]** (`<PROCESS_PATH>`)? (yes/no)"
+
+3. After receiving explicit approval ("yes", "go", "деплой", "deploy", or equivalent), run `push-process`.
+4. Run `run-task` as a smoke test.
 
 ---
 

--- a/plugins/corezoid/skills/corezoid-create/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-create/SKILL.md
@@ -182,9 +182,17 @@ Fix all reported errors and re-run until the output is clean. Do not proceed wit
 
 ---
 
-## Step 7: Deploy and Test
+## Step 7: Get Developer Approval, Then Deploy and Test
 
-Call MCP tool **`push-process`** with `process_path: "<PROCESS_PATH>"`.
+**⛔ Do NOT call `push-process` without explicit developer approval.**
+
+After lint passes (Step 6), present a summary to the developer and ask for a go-ahead:
+
+> "Lint passed ✅. Ready to deploy **[Process Name]** (`<PROCESS_PATH>`)? (yes/no)"
+
+**Group push:** If you are deploying a set of related processes together in the same session, list all of them in a single prompt and wait for **one approval** covering the whole group — do not ask separately for each process.
+
+After receiving explicit approval ("yes", "go", "деплой", "deploy", or equivalent), call MCP tool **`push-process`** with `process_path: "<PROCESS_PATH>"`.
 
 After a successful deploy, run a test task to verify the process behaves as expected:
 

--- a/plugins/corezoid/skills/corezoid-describe/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-describe/SKILL.md
@@ -89,8 +89,12 @@ Write 1–2 sentences describing the project's overall purpose and the main syst
 
 **For a process:**
 1. Update the `description` field at the root of the `.conv.json` file
-2. Call MCP tool **`push-process`** with `process_path`
-3. Confirm: *"Description updated and deployed."*
+2. **⛔ Do NOT call `push-process` without explicit developer approval.** Ask for a go-ahead:
+
+   > "Ready to push the updated description for **[Process Name]**? (yes/no)"
+
+3. After receiving explicit approval, call MCP tool **`push-process`** with `process_path`
+4. Confirm: *"Description updated and deployed."*
 
 **For a folder:**
 Use the `folder_id` resolved in Step 2a. If it was not resolved (source 4 — not found), skip this step.

--- a/plugins/corezoid/skills/corezoid-edit/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-edit/SKILL.md
@@ -101,11 +101,19 @@ If the parent folder was structurally affected (process added, removed, or renam
 
 ---
 
-## Step 4: Deploy the Changes
+## Step 4: Get Developer Approval, Then Deploy the Changes
 
-**MANDATORY: Always run this step whenever any changes were made to the process file — even if there are open questions or the work is not fully complete. Without deploying, all changes are lost.**
+**MANDATORY: Always execute this step whenever any changes were made to the process file — even if there are open questions or the work is not fully complete. Without deploying, all changes are lost.**
 
-Deploy the modified process by calling MCP tool **`push-process`** with `process_path: "<PROCESS_PATH>"`.
+**⛔ Do NOT call `push-process` without explicit developer approval.**
+
+Run `lint-process` first (if not already done). Then present a summary of the changes and ask for a go-ahead:
+
+> "Lint passed ✅. Ready to deploy changes to **[Process Name]** (`<PROCESS_PATH>`)? (yes/no)"
+
+**Group push:** If the session involves multiple related processes that need to be pushed together, list all of them in a single prompt and use **one approval for the entire group** — do not ask separately for each process.
+
+After receiving explicit approval ("yes", "go", "деплой", "deploy", or equivalent), deploy the modified process by calling MCP tool **`push-process`** with `process_path: "<PROCESS_PATH>"`.
 
 If deployment fails, fix the reported errors and re-run `push-process` until it succeeds. Do not skip this step or postpone it — changes exist only in memory until pushed.
 

--- a/plugins/corezoid/skills/corezoid-process-optimizer/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-process-optimizer/SKILL.md
@@ -289,8 +289,12 @@ Always apply in this sequence:
 
 1. Write updated JSON to `PROCESS_PATH`.
 2. Call **`lint-process`** — fix any errors before proceeding.
-3. Call **`push-process`**.
-4. Notify the user: "Deployed. Please **refresh the page** in Corezoid to see the updated process."
+3. **⛔ Do NOT call `push-process` without explicit developer approval.** After lint passes, ask:
+
+   > "Lint passed ✅. Ready to deploy optimized **[Process Name]** (`PROCESS_PATH`)? (yes/no)"
+
+4. After receiving explicit approval ("yes", "go", "деплой", "deploy", or equivalent), call **`push-process`**.
+5. Notify the user: "Deployed. Please **refresh the page** in Corezoid to see the updated process."
 
 ---
 

--- a/plugins/corezoid/skills/corezoid-state-diagram-create/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-state-diagram-create/SKILL.md
@@ -176,9 +176,15 @@ Fix every reported error and re-run until the output is clean. Do not proceed wi
 
 ---
 
-## Step 6: Deploy
+## Step 6: Get Developer Approval, Then Deploy
 
-Call MCP tool **`push-process`** with `process_path: "<PROCESS_PATH>"`.
+**⛔ Do NOT call `push-process` without explicit developer approval.**
+
+After lint passes, ask for a go-ahead:
+
+> "Lint passed ✅. Ready to deploy state diagram **[Name]** (`<PROCESS_PATH>`)? (yes/no)"
+
+After receiving explicit approval ("yes", "go", "деплой", "deploy", or equivalent), call MCP tool **`push-process`** with `process_path: "<PROCESS_PATH>"`.
 
 If the push fails:
 - Re-read the file and confirm `"conv_type": "state"` is present at the root.

--- a/plugins/corezoid/skills/corezoid-state-diagram-edit/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-state-diagram-edit/SKILL.md
@@ -119,11 +119,17 @@ Only these logics may appear inside a state diagram. Adding anything else will f
 
 ---
 
-## Step 4: Deploy the Changes
+## Step 4: Get Developer Approval, Then Deploy the Changes
 
-**MANDATORY: Always push after any change — even if work is in-flight. Without push, the changes exist only on disk.**
+**MANDATORY: Always execute this step after any change — even if work is in-flight. Without push, the changes exist only on disk.**
 
-Call MCP tool **`push-process`** with `process_path: "<PROCESS_PATH>"`.
+**⛔ Do NOT call `push-process` without explicit developer approval.**
+
+After lint passes (run `lint-process` if not already done), ask for a go-ahead:
+
+> "Lint passed ✅. Ready to deploy changes to **[Name]** (`<PROCESS_PATH>`)? (yes/no)"
+
+After receiving explicit approval ("yes", "go", "деплой", "deploy", or equivalent), call MCP tool **`push-process`** with `process_path: "<PROCESS_PATH>"`.
 
 If push fails:
 - Re-read the file and confirm `"conv_type": "state"` is still at the root (a stray editor save or auto-format may have flipped it).

--- a/plugins/corezoid/skills/corezoid/SKILL.md
+++ b/plugins/corezoid/skills/corezoid/SKILL.md
@@ -181,6 +181,18 @@ Summary:
 
 ---
 
+## Push Approval Rule
+
+**Every `push-process` call requires explicit developer approval — no exceptions.**
+
+After lint passes, present the lint result and a brief summary of what will be deployed, then ask:
+
+> "Lint passed ✅. Ready to deploy **[Process Name]** (`path/to/file.conv.json`)? (yes/no)"
+
+Wait for the user to reply with an explicit "yes", "go", "деплой", "deploy", or equivalent before calling `push-process`. Do **not** push automatically.
+
+**Group push:** When multiple related processes are being deployed in the same session (e.g. a refactor that touches several files), list all of them in a single approval prompt. **One "yes" covers the entire group** — do not ask for separate confirmation per process.
+
 ## Tips
 
 - Always `lint-process` before `push-process` to catch errors early
@@ -188,6 +200,7 @@ Summary:
 - Node IDs are 24-char hex — generate with `crypto.randomBytes(12).toString('hex')`
 - Variables are workspace-scoped — check `_ENV_VARS_.json` before creating new ones
 - `push-process` is mandatory after any edit — changes exist only in memory until pushed
+- **Never call `push-process` without developer approval** — see the Push Approval Rule above
 
 ## Proactive improvement/bug reporting
 


### PR DESCRIPTION
## Summary

- All skills that call `push-process` now include an explicit **approval gate** before deploying: after lint passes the LLM presents a summary and asks the developer for a "yes" before calling `push-process`
- **Group push:** when multiple related processes are being deployed together in one session, a single approval covers the whole group — no separate confirmation per file
- A global **Push Approval Rule** section was added to `corezoid/SKILL.md` as the authoritative rule that all specialized skills reference

### Skills updated
`corezoid/SKILL.md` (global rule) · `corezoid-create` · `corezoid-edit` · `corezoid-state-diagram-create` · `corezoid-state-diagram-edit` · `corezoid-api-connector` · `corezoid-process-optimizer` · `corezoid-alias-manager` · `corezoid-describe`

## Context

tool: push-process / lint-process | version: 2.3.5 | install: 278022ea-2291-4146-ba5f-44f47fc26b41

## Checklist

- [x] `go build` / `go vet` pass
- [x] `go test -race` passes (all 62 s)
- [x] JSON manifests valid
- [x] No version bump / CHANGELOG.md change included

## Test plan

- Run `/corezoid-create` or `/corezoid-edit`, confirm that after lint passes the LLM asks for approval before calling `push-process`
- Decline ("no") → no push happens
- Accept ("yes") → `push-process` is called
- Deploy two related processes in one session → single approval prompt covers both