### PR TITLE
fix(safety): source-aware baseline + surface baseline write failures (v3.1.3)

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -6,7 +6,7 @@
   "plugins": [
     {
       "name": "corezoid",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "license": "MIT",
       "source": {
         "source": "local",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
       "name": "corezoid",
       "source": "./plugins/corezoid",
       "description": "Corezoid BPM platform skills, MCP server, docs, and samples for Claude Code.",
-      "version": "3.1.2",
+      "version": "3.1.3",
       "author": {
         "name": "Corezoid",
         "email": "support@corezoid.com"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.1.3]
+
+- Fix(mcp-server): `serverMovedSince` is source-aware again. v3.1.2 removed the version tiebreak globally so a `ListFolder`-derived baseline would stop producing false positives on `pull-folder`, but the same change silently disabled same-second lost-update detection on the `pull-process` path where both sides come from `GetProcessByID` and versions ARE comparable. Baselines now carry a `source` tag (`detail` vs `list`); the tiebreak applies only when both sides are `detail`. Fixes #152.
+- Fix(mcp-server): `push --merge` no longer claims "proceed cleanly" when the baseline sidecar could not be updated. The materialised merge is still preserved on disk, but the message now reports the baseline/ancestor write failure and warns that the next push will re-report the conflict. Fixes #151.
+- Docs: README telemetry blurb aligned with `SECURITY.md` — both references now list the same fields (tool name, duration, error type, API hostname).
+
 ## [3.1.2]
 
 - Revert(push-process): remove the developer approval gate introduced in 3.1.0. The extra confirmation on every push disrupted the normal dev iteration cycle in Corezoid workspaces without adding a meaningful safety guarantee — `push-process` is already an explicit tool invocation.

--- a/POWER.md
+++ b/POWER.md
@@ -1,7 +1,7 @@
 ---
 name: corezoid
 displayName: Corezoid
-version: 3.1.2
+version: 3.1.3
 description: Corezoid BPM platform assistant. Exposes the Corezoid REST API as MCP tools (`convctl`) plus 24 skills covering process creation, editing, lifecycle operations, review, validation, dashboards, state diagrams, variables, access, layout, docs, and custom-code git_call. Ships JSON schemas and per-node-type documentation for all 24 Corezoid node types.
 author:
   name: Corezoid

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ codex plugin add corezoid@corezoid
 
 No build step, no extra setup. The MCP server starts automatically on first use.
 
-> **Telemetry:** the plugin collects anonymous usage data (tool name, duration, error type, transport version) to improve reliability. No tokens, workspace IDs, or process content are ever sent. To opt out:
+> **Telemetry:** the plugin collects anonymous usage data (tool name, duration, error type, API hostname) to improve reliability. No tokens, workspace IDs, or process content are ever sent. To opt out:
 > ```bash
 > export COREZOID_ANALYTICS_DISABLED=1   # add to ~/.zshrc or ~/.bashrc to persist
 > ```

--- a/plugins/corezoid/.claude-plugin/plugin.json
+++ b/plugins/corezoid/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "corezoid",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Corezoid AI Documentation and Templates — skills and MCP server for working with Corezoid BPM processes.",
   "author": {
     "name": "Corezoid",

--- a/plugins/corezoid/.codex-plugin/plugin.json
+++ b/plugins/corezoid/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "corezoid",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Corezoid BPM platform assistant. Exposes Corezoid operations as an MCP server and provides skills for creating, editing, reviewing, and deploying business processes.",
   "author": {
     "name": "Corezoid",

--- a/plugins/corezoid/.kiro-plugin/plugin.json
+++ b/plugins/corezoid/.kiro-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "corezoid",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Corezoid AI Documentation and Templates — skills and MCP server for working with Corezoid BPM processes.",
   "author": {
     "name": "Corezoid",

--- a/plugins/corezoid/mcp-server/baseline.go
+++ b/plugins/corezoid/mcp-server/baseline.go
@@ -59,10 +59,17 @@ func readAncestorScheme(dir string, procID int) (string, bool) {
 
 // baselineEntry is one process's pulled-at version identity.
 type baselineEntry struct {
-	ChangeTime int64 `json:"change_time"`         // server process last-modified (advances on every server commit)
-	Version    int64 `json:"version"`             // last_confirmed_version (fallback: commits.version)
-	PulledAt   int64 `json:"pulled_at,omitempty"` // when this baseline was recorded (unix, for diagnostics)
+	ChangeTime int64  `json:"change_time"`         // server process last-modified (advances on every server commit)
+	Version    int64  `json:"version"`             // last_confirmed_version (fallback: commits.version)
+	PulledAt   int64  `json:"pulled_at,omitempty"` // when this baseline was recorded (unix, for diagnostics)
+	Source     string `json:"source,omitempty"`    // "detail" (GetProcessByID) or "list" (ListFolder). Empty = legacy sidecar written before the source tag existed; treated as unknown.
 }
+
+// baseline source tags — see serverMovedSince for why they matter.
+const (
+	baselineSourceDetail = "detail" // commits-derived version (GetProcessByID, last_confirmed_version)
+	baselineSourceList   = "list"   // ListFolder version (draft timestamp; not comparable to detail)
+)
 
 type corruptBaselineError struct {
 	path string
@@ -207,7 +214,7 @@ func lookupBaseline(dir string, procID int) (baselineEntry, bool, error) {
 // GetProcessByID (list conv) response. Prefers last_confirmed_version; falls
 // back to commits.version. PulledAt is stamped now.
 func baselineFromServer(proc map[string]any) baselineEntry {
-	e := baselineEntry{PulledAt: time.Now().Unix()}
+	e := baselineEntry{PulledAt: time.Now().Unix(), Source: baselineSourceDetail}
 	if ct, ok := proc["change_time"].(float64); ok {
 		e.ChangeTime = int64(ct)
 	}
@@ -291,13 +298,14 @@ func captureFolderChildren(v *Executor, folderID int, out map[int]baselineEntry,
 // entry. change_time is the primary lost-update signal — the same field
 // baselineFromServer prefers. Version comes from the list response too but its
 // semantics differ from GetProcessByID (draft timestamp vs commits.version),
-// so serverMovedSince deliberately ignores it for list-sourced baselines and
-// compares change_time only.
+// so we tag the entry with Source=list and serverMovedSince skips the version
+// tiebreak for list-sourced baselines to avoid mixed-semantics false positives.
 func baselineFromFolderChild(c FolderChild) baselineEntry {
 	return baselineEntry{
 		ChangeTime: c.ChangeTime,
 		Version:    c.Version,
 		PulledAt:   time.Now().Unix(),
+		Source:     baselineSourceList,
 	}
 }
 
@@ -308,6 +316,7 @@ func baselineFromWorkspaceRootItem(it WorkspaceRootItem) baselineEntry {
 		ChangeTime: it.ChangeTime,
 		Version:    it.Version,
 		PulledAt:   time.Now().Unix(),
+		Source:     baselineSourceList,
 	}
 }
 
@@ -357,13 +366,25 @@ func recordPulledBaselines(root string, snapshot map[int]baselineEntry) int {
 
 // serverMovedSince reports whether the server's current version has advanced
 // past the recorded baseline — i.e. someone committed a change since the pull.
-// change_time is authoritative: it advances on every server commit. We used to
-// tiebreak on version when timestamps collided within a second, but the
-// baseline is now built from ListFolder responses (whose "version" field is a
-// draft timestamp) while current comes from GetProcessByID (commits.version /
-// last_confirmed_version). Comparing mixed-source versions produces false
-// positives, so we compare change_time only — the sub-second tiebreak was
-// defensive rather than correctness-critical.
+// change_time is authoritative: it advances on every server commit.
+//
+// Sub-second commits are tiebroken by version, but ONLY when both sides come
+// from a commit-derived source (GetProcessByID). ListFolder's "version" field
+// is a draft timestamp, not a commit counter — comparing it against the
+// commits-derived version produces false positives, so a list-sourced baseline
+// (pull-folder) falls back to change_time-only and accepts the sub-second blind
+// spot. A detail-sourced baseline (pull-process, push refresh, merge advance)
+// keeps the tiebreak so same-second concurrent commits are still caught.
+//
+// A missing Source tag means the sidecar predates this field; treat it as
+// unknown-provenance and skip the tiebreak to stay on the safe (no-false-
+// positive) side.
 func serverMovedSince(base baselineEntry, current baselineEntry) bool {
-	return current.ChangeTime > base.ChangeTime
+	if current.ChangeTime != base.ChangeTime {
+		return current.ChangeTime > base.ChangeTime
+	}
+	if base.Source == baselineSourceDetail && current.Source == baselineSourceDetail {
+		return current.Version > base.Version
+	}
+	return false
 }

--- a/plugins/corezoid/mcp-server/baseline_test.go
+++ b/plugins/corezoid/mcp-server/baseline_test.go
@@ -271,21 +271,58 @@ func mustWrite(t *testing.T, path, content string) {
 }
 
 func TestBaseline_ServerMovedSince(t *testing.T) {
-	base := baselineEntry{ChangeTime: 100, Version: 10}
-	if serverMovedSince(base, baselineEntry{ChangeTime: 100, Version: 10}) {
+	// change_time is authoritative regardless of source.
+	base := baselineEntry{ChangeTime: 100, Version: 10, Source: baselineSourceDetail}
+	current := baselineEntry{ChangeTime: 100, Version: 10, Source: baselineSourceDetail}
+	if serverMovedSince(base, current) {
 		t.Fatal("identical baseline must not be flagged as moved")
 	}
-	if !serverMovedSince(base, baselineEntry{ChangeTime: 101, Version: 10}) {
+	if !serverMovedSince(base, baselineEntry{ChangeTime: 101, Version: 10, Source: baselineSourceDetail}) {
 		t.Fatal("advanced change_time must be flagged")
 	}
-	// Version tiebreak was removed: baselines built from ListFolder ("version"
-	// = draft timestamp) and current state fetched via GetProcessByID
-	// ("commits.version" = commit counter) don't share semantics, so comparing
-	// them produced false positives. change_time is authoritative.
-	if serverMovedSince(base, baselineEntry{ChangeTime: 100, Version: 11}) {
-		t.Fatal("same change_time must NOT be flagged even if version differs (mixed-source safeguard)")
-	}
-	if serverMovedSince(base, baselineEntry{ChangeTime: 99, Version: 10}) {
+	if serverMovedSince(base, baselineEntry{ChangeTime: 99, Version: 10, Source: baselineSourceDetail}) {
 		t.Fatal("older change_time must not be flagged as moved")
+	}
+}
+
+// TestBaseline_ServerMovedSince_SameSecondTiebreak locks in the pull-process
+// regression fix for issue #152: when both baseline and current came from
+// GetProcessByID (Source=detail), a same-second concurrent commit still
+// advances commits.version and must be caught as a conflict.
+func TestBaseline_ServerMovedSince_SameSecondTiebreak(t *testing.T) {
+	base := baselineEntry{ChangeTime: 100, Version: 10, Source: baselineSourceDetail}
+	current := baselineEntry{ChangeTime: 100, Version: 11, Source: baselineSourceDetail}
+	if !serverMovedSince(base, current) {
+		t.Fatal("same change_time + advanced version from detail-sourced baseline must be flagged (issue #152)")
+	}
+	// Detail-sourced version going backwards is a server anomaly, not a conflict signal.
+	older := baselineEntry{ChangeTime: 100, Version: 9, Source: baselineSourceDetail}
+	if serverMovedSince(base, older) {
+		t.Fatal("version going backwards on equal change_time must not be flagged as moved")
+	}
+}
+
+// TestBaseline_ServerMovedSince_ListSourceNoTiebreak asserts the pull-folder
+// path stays free of the mixed-semantics false positive: ListFolder's
+// "version" is a draft timestamp, not comparable to commits.version, so a
+// list-sourced baseline skips the tiebreak and accepts the sub-second blind
+// spot rather than block on non-changes.
+func TestBaseline_ServerMovedSince_ListSourceNoTiebreak(t *testing.T) {
+	base := baselineEntry{ChangeTime: 100, Version: 10, Source: baselineSourceList}
+	current := baselineEntry{ChangeTime: 100, Version: 999, Source: baselineSourceDetail}
+	if serverMovedSince(base, current) {
+		t.Fatal("list-sourced baseline must not tiebreak on version (mixed semantics)")
+	}
+}
+
+// TestBaseline_ServerMovedSince_LegacySourceMissing asserts that a sidecar
+// written before the Source field existed (Source="") does NOT tiebreak on
+// version. We can't tell whether the entry was list- or detail-sourced, so
+// the safe default is no tiebreak.
+func TestBaseline_ServerMovedSince_LegacySourceMissing(t *testing.T) {
+	base := baselineEntry{ChangeTime: 100, Version: 10} // no Source
+	current := baselineEntry{ChangeTime: 100, Version: 11, Source: baselineSourceDetail}
+	if serverMovedSince(base, current) {
+		t.Fatal("legacy baseline (no Source) must not tiebreak on version")
 	}
 }

--- a/plugins/corezoid/mcp-server/conflict.go
+++ b/plugins/corezoid/mcp-server/conflict.go
@@ -161,13 +161,33 @@ func applyMerge(dir, filePath string, procID int, localJSON string, current base
 	fmt.Fprintf(&sb, "Original local file saved to %s.\n\n", backupPath)
 	sb.WriteString(formatMergePlan(plan))
 	if mergeConflictCount(plan) == 0 {
-		if berr := writeBaseline(dir, procID, current); berr != nil {
-			logger.Warn("merge: baseline advance failed for %d: %v", procID, berr)
+		// Both writes must succeed to declare the merge fully reconciled: baseline
+		// advance is what makes the next push proceed cleanly, and the ancestor
+		// advance is what a later 3-way merge relies on. If either fails we still
+		// leave the materialised merge on disk (the user's work is preserved) but
+		// tell them the state is not clean and the next push will re-report the
+		// conflict — better than the earlier silent "proceed cleanly" claim (#151).
+		baselineErr := writeBaseline(dir, procID, current)
+		if baselineErr != nil {
+			logger.Warn("merge: baseline advance failed for %d: %v", procID, baselineErr)
 		}
-		if aerr := writeAncestorScheme(dir, procID, theirsConv); aerr != nil {
-			logger.Warn("merge: ancestor advance failed for %d: %v", procID, aerr)
+		ancestorErr := writeAncestorScheme(dir, procID, theirsConv)
+		if ancestorErr != nil {
+			logger.Warn("merge: ancestor advance failed for %d: %v", procID, ancestorErr)
 		}
-		fmt.Fprintf(&sb, "\nMerged into %s — no conflicts. Review it, then push again; it will proceed cleanly.\n", filePath)
+		switch {
+		case baselineErr != nil && ancestorErr != nil:
+			fmt.Fprintf(&sb, "\nMerged into %s — no conflicts, BUT baseline and ancestor could not be updated (%v; %v). Your merged file is safe, but the next push will re-report this conflict until the sidecar can be written. Fix the local filesystem/permissions and re-run.\n",
+				filePath, baselineErr, ancestorErr)
+		case baselineErr != nil:
+			fmt.Fprintf(&sb, "\nMerged into %s — no conflicts, BUT the baseline sidecar could not be updated (%v). The next push will re-report this conflict; force=true would still overwrite the server. Fix the sidecar (permissions/disk) and re-run, or accept that a repeat push needs force=true.\n",
+				filePath, baselineErr)
+		case ancestorErr != nil:
+			fmt.Fprintf(&sb, "\nMerged into %s — no conflicts, BUT the merge ancestor could not be refreshed (%v). Push will proceed cleanly, but a future 3-way merge will fall back to the delete-only impact report until the ancestor file is writable again.\n",
+				filePath, ancestorErr)
+		default:
+			fmt.Fprintf(&sb, "\nMerged into %s — no conflicts. Review it, then push again; it will proceed cleanly.\n", filePath)
+		}
 	} else {
 		fmt.Fprintf(&sb, "\nGrafted the non-conflicting changes into %s. The %d overlapping node/field value(s) above were kept as YOUR version.\nReview them, then push with force=true to deploy (a snapshot of the server version is attempted first; recoverable only if it succeeds — check the push result).\n",
 			filePath, mergeConflictCount(plan))

--- a/plugins/corezoid/mcp-server/conflict_test.go
+++ b/plugins/corezoid/mcp-server/conflict_test.go
@@ -254,3 +254,38 @@ func TestApplyMergeBacksUpExactLocalFile(t *testing.T) {
 		t.Fatalf("merged file mode = %v, want 0600", info.Mode().Perm())
 	}
 }
+
+// TestApplyMerge_BaselineWriteFailureDoesNotClaimClean locks in the issue #151
+// fix: when applyMerge lands a conflict-free merge but the baseline sidecar
+// can't be updated (here: pre-existing corrupt sidecar the non-recovery writer
+// refuses to overwrite), the message must NOT promise "proceed cleanly".
+// Otherwise the user would push and get the same conflict re-reported, or —
+// worse — assume the concurrency state is fresh when it isn't.
+func TestApplyMerge_BaselineWriteFailureDoesNotClaimClean(t *testing.T) {
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "1_x.conv.json")
+	local := `{"obj_id":1,"description":"mine","scheme":{"nodes":[]}}`
+	theirs := `{"obj_id":1,"description":"server","scheme":{"nodes":[]}}`
+	if err := os.WriteFile(fp, []byte(local), 0600); err != nil {
+		t.Fatal(err)
+	}
+	// Corrupt baseline sidecar → writeBaseline (non-recovery path) will fail.
+	if err := os.WriteFile(filepath.Join(dir, baselineFileName), []byte("{broken"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	plan := buildMergePlan(nil, nil, nil)
+	if err := addProcessFields(&plan, local, theirs, local); err != nil {
+		t.Fatal(err)
+	}
+
+	res := applyMerge(dir, fp, 1, local, baselineEntry{ChangeTime: 200, Version: 20, Source: baselineSourceDetail}, theirs, plan, nil, "", 0)
+	if res.action != conflictMerged {
+		t.Fatalf("merge action = %v, message=%s", res.action, res.message)
+	}
+	if strings.Contains(res.message, "proceed cleanly") {
+		t.Fatalf("message must NOT claim 'proceed cleanly' when baseline write failed (#151):\n%s", res.message)
+	}
+	if !strings.Contains(res.message, "baseline") || !strings.Contains(res.message, "could not be updated") {
+		t.Fatalf("message must surface the baseline write failure (#151):\n%s", res.message)
+	}
+}


### PR DESCRIPTION
## Summary

Two release-blocker fixes flagged after v3.1.2 shipped:

- **#152 — source-aware baseline conflict detection.** v3.1.2 removed the `serverMovedSince` version tiebreak globally to eliminate `pull-folder` false positives, but the same change silently disabled same-second lost-update detection on `pull-process`, where both sides come from `GetProcessByID` and versions ARE comparable. Baselines now carry a `Source` tag (`detail` vs `list`); the tiebreak applies only when both sides are `detail`.
- **#151 — surface baseline write failure in `applyMerge`.** The conflict-free branch logged a warning and then still promised "proceed cleanly" when the baseline sidecar could not be updated. Message now names the specific write failure (baseline, ancestor, or both) and warns that a repeat push needs `force=true` until the sidecar is writable again.

Plus a small README/telemetry doc alignment: the installation blurb listed `transport version` while the dedicated Telemetry section and `SECURITY.md` list `API hostname`. Both places now agree on the canonical short form.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -coverprofile=coverage.out ./...` — full suite green
- [x] New regression tests locked in:
  - [x] `TestBaseline_ServerMovedSince_SameSecondTiebreak` — detail-sourced baselines catch same-second version bump (#152)
  - [x] `TestBaseline_ServerMovedSince_ListSourceNoTiebreak` — list-sourced baselines skip the mixed-semantics tiebreak
  - [x] `TestBaseline_ServerMovedSince_LegacySourceMissing` — sidecars written before the Source tag existed default to safe (no tiebreak)
  - [x] `TestApplyMerge_BaselineWriteFailureDoesNotClaimClean` — message no longer claims "proceed cleanly" on baseline write failure (#151)
- [x] Version synced across all six release files (`.claude-plugin/marketplace.json`, three `plugins/corezoid/.*-plugin/plugin.json`, `.agents/plugins/marketplace.json`, `POWER.md`)
- [x] `CHANGELOG.md` entry added under `[3.1.3]`

Closes #151
Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)