### PR TITLE
fix(pull-folder): include path in error wrapping for json format/unmarshal

### DIFF
--- a/plugins/corezoid/mcp-server/pull-project.go
+++ b/plugins/corezoid/mcp-server/pull-project.go
@@ -433,7 +433,7 @@ func renameFiles2Folders(filePath string) error {
 			}
 			err = formatJSON(newPath)
 			if err != nil {
-				return fmt.Errorf("Failed to format json in directory: %v", err)
+				return fmt.Errorf("Failed to format json in directory %s: %v", newPath, err)
 			}
 			err = renameFiles2Folders(newPath)
 			if err != nil {
@@ -462,10 +462,11 @@ func formatJSONWithFallback(e *Executor, filePath string) error {
 
 	for _, f := range files {
 		if f.IsDir() {
-			//fmt.Println("Downloaded folder", filepath.Join(filePath, f.Name()))
-			err := formatJSONWithFallback(e, filepath.Join(filePath, f.Name()))
+			subDir := filepath.Join(filePath, f.Name())
+			//fmt.Println("Downloaded folder", subDir)
+			err := formatJSONWithFallback(e, subDir)
 			if err != nil {
-				return fmt.Errorf("Failed to format json in directory: %v", err)
+				return fmt.Errorf("Failed to format json in directory %s: %v", subDir, err)
 			}
 		}
 		if filepath.Ext(f.Name()) != ".json" {
@@ -479,7 +480,7 @@ func formatJSONWithFallback(e *Executor, filePath string) error {
 		var dataRsp any
 		err = json.Unmarshal(dataJson, &dataRsp)
 		if err != nil {
-			return fmt.Errorf("failed to unmarshal file: %v", err)
+			return fmt.Errorf("failed to unmarshal file %s: %v", filePath1, err)
 		}
 		// везде где есть uuid в scheme.nodes объект удалить
 		if procMap, ok := dataRsp.(map[string]interface{}); ok {


### PR DESCRIPTION
## Summary
- `renameFiles2Folders`: error from `formatJSON(newPath)` now includes `newPath` in the message
- `formatJSONWithFallback`: recursive call error now includes the subdirectory path
- `formatJSONWithFallback`: `json.Unmarshal` error now includes `filePath1` (the exact file)

Previously all three `fmt.Errorf` calls used only `%v` with no path argument, so the error chain `failed to rename files: Failed to format json in directory: Failed to format json in directory: Failed to format json in directory: failed to unmarshal file: invalid character '}' looking for beginning of object key string` gave zero indication of which file or directory triggered the failure. The path was lost at each wrapping level.

## Context
tool: pull-folder / login | version: 3.1.3 | install: 5205199f-7e45-4e69-9f55-45ab3982f971

Reproduced on multiple workspaces (Middleware, Bold Food) and multiple `folder_id` values including 0, across client versions 2.1.224–3.1.3. Static analysis of the `convctl` binary confirmed the missing `%s` path argument in exactly these two error-format strings.

## Checklist
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes (`ok convctl 41.909s`)
- [x] Manifest JSON files all valid
- [x] No version bump / CHANGELOG.md change included
- [x] No credentials or private URLs added

## Test plan
- Run `pull-folder` or `login` on a workspace that triggers the unmarshal error
- Confirm the error message now shows the full path to the offending file, e.g.: `failed to rename files: Failed to format json in directory /path/to/dir: Failed to format json in directory /path/to/dir/sub: failed to unmarshal file /path/to/dir/sub/file.json: invalid character '}'…`