### PR TITLE
feat(corezoid-review): add cross-process cycle detection to step 12

### DIFF
--- a/plugins/corezoid/skills/corezoid-review/SKILL.md
+++ b/plugins/corezoid/skills/corezoid-review/SKILL.md
@@ -251,6 +251,33 @@ graph TD
 N direct dependencies, N total processes mapped.
 ```
 
+### Cross-Process Cycle Detection
+
+After building the graph, traverse it with DFS and flag any back-edges (closed chains).
+
+**A cycle is safe only when every route around it passes through at least one break point:**
+
+| Break point | Example |
+|-------------|---------|
+| ✅ User-initiated action | Waiting-for-Callback, form submit, manual trigger |
+| ✅ Iteration counter with static upper bound | `retry_count` incremented and guarded by `go_if_const ≤ 3` |
+| ✅ Absolute timeout / deadline semaphor | `time` semaphor that terminates the chain |
+
+**Checklist — apply to every cross-process call identified in Step 10:**
+1. Can the called process route a task back to the current process — directly or through a chain?
+2. If yes — which break point terminates the cycle?
+3. If no break point exists — flag 🔴 and recommend a bypass parameter or route restructure.
+
+Mark detected cycle edges in the Mermaid diagram with a `-->|⚠️ CYCLE|` label:
+
+```markdown
+\`\`\`mermaid
+graph TD
+    ProcessA --> |⚠️ CYCLE| ProcessB
+    ProcessB --> ProcessA
+\`\`\`
+```
+
 ---
 
 ## Step 13: Generate Report
@@ -339,6 +366,12 @@ graph TD
 ```
 
 N direct dependencies, N total processes mapped.
+
+## 13. Cross-Process Cycle Analysis
+
+- [ ] 🔴 **A → B → A** — closed cycle with no break point; unbounded tact risk
+- [ ] 🟡 **A → B → C → A** — cycle guarded by `retry_count ≤ 3`; verify bound holds and counter cannot be reset
+- [ ] ℹ️ **Process X → @dynamic-alias** — target unresolvable at design time; verify manually that no return path exists
 ```
 
 ---


### PR DESCRIPTION
## Summary

- `corezoid-review` Step 12 (Dependency Graph) gains a **Cross-Process Cycle Detection** subsection
- Break-point table lists the three accepted termination conditions: user-initiated action, iteration counter with static bound, absolute timeout/deadline semaphor
- Three-point checklist is applied to every cross-process call discovered in Step 10
- Detected cycle edges are marked with `-->|⚠️ CYCLE|` in the Mermaid diagram
- Report template gets a new **§13 Cross-Process Cycle Analysis** section with severity-coded checklist items

## Context

tool: lint-process / corezoid-review | version: 3.1.3 | install: c2d96fc7-994a-483e-872d-22279b6525e3

## Relation to PR #128

PR #128 (`feat/process-safety-policies`) adds server-side opt-in cycle-safety enforcement and extends Step 5 (intra-process cycle verification). It does **not** add cross-process cycle analysis to Step 12 (Dependency Graph). This PR fills that gap as a standalone, non-conflicting skill change — no Go code is touched and it merges cleanly regardless of whether #128 lands first.

## Checklist

- [x] JSON manifests valid (all 4 pass `python3 -m json.tool`)
- [x] `scripts/check-skills-sync.py` — 24 skills consistent
- [x] No version bump / CHANGELOG.md change included
- [x] No Go code or generated `public/` files changed
- [x] No credentials, hardcoded paths, or private data in diff

## Test plan

- Open a process that calls two or more other processes → run `corezoid-review`
- Verify Step 12 output includes the cycle detection subsection and the Mermaid diagram marks any detected cycle edges
- Verify the final report includes §13 Cross-Process Cycle Analysis with appropriate severity labels