### PR TITLE
fix(deploy-stage): retry compare on transient server-side failures

### DIFF
--- a/plugins/corezoid/mcp-server/mcp_handlers_deploy.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_deploy.go
@@ -87,15 +87,27 @@ func handleDeployStage(ctx context.Context, args map[string]interface{}) (string
 		"project_id":  projectID,
 		"company_id":  companyID,
 	}}
-	cmpResp, err := v.req("compare", cmpOps)
+	// compareWithRetry retries on transient server-side failures (request-level
+	// errors, network timeouts) that occur when the box is under load. Op-level
+	// validation errors ("API op error:") are surfaced immediately — retrying
+	// them cannot help since the payload is idempotent.
+	cmpResp, err := compareWithRetry(v, cmpOps)
 	if err != nil {
 		// A failed compare (e.g. "One or more processes has errors") still returns
 		// a response whose op carries a nested `errors` tree naming the exact
 		// stage → process → node and the reason. Surface it — the bare description
 		// alone is undiagnosable through this tool.
-		msg := fmt.Sprintf("Error (compare): %v", err)
+		msg := fmt.Sprintf("Error (compare stage %d→%d): %v", sourceStage, targetStage, err)
 		if tree := compareErrorsFromResp(cmpResp); tree != "" {
 			msg += "\n" + tree
+		}
+		if isTransientCompareError(err) {
+			msg += fmt.Sprintf(
+				"\n\nℹ The server failed to compute the diff (project %d). "+
+					"This is typically caused by server load or a timeout on large projects — "+
+					"try again in a few minutes. If the error persists, use the Corezoid UI's "+
+					"Partial Merge to deploy individual processes.",
+				projectID)
 		}
 		return msg, true
 	}
@@ -207,6 +219,68 @@ var (
 	deployVerifyAttempts = 3
 	deployVerifyDelayVar = 2 * time.Second
 )
+
+// Retry tuning for the initial compare call. The /api/2/compare endpoint can
+// time out or return a request-level failure when the box is under load — unlike
+// op-level validation errors ("API op error:"), these are transient and worth
+// retrying. Package vars so tests can dial the values down.
+var (
+	compareRetryAttempts = 3
+	compareRetryDelay    = 3 * time.Second
+)
+
+// compareWithRetry calls v.req("compare", ops) and retries on transient
+// server-side failures. The compare payload is idempotent so retrying is safe.
+// Op-level validation errors (prefix "API op error:") are returned immediately
+// because they represent a schema problem the server already diagnosed — no
+// retry can change the outcome.
+func compareWithRetry(v *Executor, ops []map[string]any) (map[string]interface{}, error) {
+	var (
+		resp  map[string]interface{}
+		err   error
+		delay = compareRetryDelay
+	)
+	for attempt := 1; attempt <= compareRetryAttempts; attempt++ {
+		if attempt > 1 {
+			// A previous attempt returned a transient error; wait before retrying.
+			wait := delay + jitter(delay)
+			logger.Warn("compare failed (attempt %d/%d): %v — retrying in %s",
+				attempt-1, compareRetryAttempts, err, wait)
+			timer := time.NewTimer(wait)
+			select {
+			case <-v.Ctx.Done():
+				timer.Stop()
+				return resp, v.Ctx.Err()
+			case <-timer.C:
+			}
+			delay *= 2
+			if delay > 30*time.Second {
+				delay = 30 * time.Second
+			}
+		}
+		r, e := v.req("compare", ops)
+		if r != nil {
+			resp = r // preserve for error-tree extraction on final failure
+		}
+		if e == nil {
+			return r, nil
+		}
+		err = e
+		if !isTransientCompareError(e) {
+			return resp, err
+		}
+	}
+	return resp, err
+}
+
+// isTransientCompareError reports whether a compare error is worth retrying.
+// "API op error:" means the compare ran and found a schema/validation problem —
+// that's a business-logic failure no retry can fix. Everything else (network
+// faults, request_proc failures, JSON parse errors) is a server-side transient
+// failure that may resolve under load.
+func isTransientCompareError(err error) bool {
+	return err != nil && !strings.HasPrefix(err.Error(), "API op error:")
+}
 
 // deployVerifyByCompare answers "did the merge actually land?" when the
 // progress WebSocket could not: it re-runs the same compare and calls the

--- a/plugins/corezoid/mcp-server/mcp_handlers_deploy_test.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_deploy_test.go
@@ -119,6 +119,15 @@ func shortVerifyRetries(t *testing.T) {
 	t.Cleanup(func() { deployVerifyAttempts, deployVerifyDelayVar = origA, origD })
 }
 
+// shortCompareRetries dials the initial-compare retry loop down to
+// milliseconds so transient-retry tests don't slow the suite.
+func shortCompareRetries(t *testing.T) {
+	t.Helper()
+	origA, origD := compareRetryAttempts, compareRetryDelay
+	compareRetryAttempts, compareRetryDelay = 2, time.Millisecond
+	t.Cleanup(func() { compareRetryAttempts, compareRetryDelay = origA, origD })
+}
+
 // stubDeployMonitor replaces the WS wait with a canned log for the duration of a test.
 func stubDeployMonitor(t *testing.T, log string, err error) {
 	t.Helper()
@@ -529,5 +538,82 @@ func TestSetImmutable_OK(t *testing.T) {
 	})
 	if isErr || !strings.Contains(res, "now immutable") {
 		t.Fatalf("expected success, got isErr=%v: %s", isErr, res)
+	}
+}
+
+// ---- compareWithRetry ---------------------------------------------------------
+
+// TestDeployStage_CompareTransientRetrySuccess: the initial compare returns a
+// request-level failure (transient) on the first attempt but succeeds on retry.
+// The deploy should complete normally — retrying a transient compare is safe.
+func TestDeployStage_CompareTransientRetrySuccess(t *testing.T) {
+	shortCompareRetries(t)
+	diff := []map[string]interface{}{diffItem("proc-a", "changed")}
+	calls := 0
+	res, isErr := callDeployWithFn(t, func(ops []map[string]interface{}) interface{} {
+		if len(ops) > 0 {
+			if typ, _ := ops[0]["type"].(string); typ == "compare" {
+				calls++
+				if calls == 1 {
+					// First attempt: request-level failure (transient — request_proc not ok).
+					return map[string]interface{}{"request_proc": "fail", "ops": []interface{}{}}
+				}
+				// Second attempt: normal success.
+				list := make([]interface{}, len(diff))
+				for i, d := range diff {
+					list[i] = d
+				}
+				return map[string]interface{}{
+					"request_proc": "ok",
+					"ops":          []interface{}{map[string]interface{}{"proc": "ok", "list": list}},
+				}
+			}
+		}
+		// show-stage and other ops succeed normally via the standard mock.
+		return map[string]interface{}{
+			"request_proc": "ok",
+			"ops":          []interface{}{map[string]interface{}{"proc": "ok", "immutable": true, "undeployed": float64(0), "title": "prod", "short_name": "prod"}},
+		}
+	}, map[string]interface{}{"apply": false})
+	if isErr {
+		t.Fatalf("transient compare should succeed on retry, got error: %s", res)
+	}
+	if calls < 2 {
+		t.Errorf("expected at least 2 compare calls (initial + retry), got %d", calls)
+	}
+	if !strings.Contains(res, "DRY-RUN") {
+		t.Errorf("expected dry-run output after successful retry, got: %s", res)
+	}
+}
+
+// TestDeployStage_CompareTransientRetryExhausted: all compare attempts return
+// a transient error. The error message must include stage context and a hint to
+// retry or use Partial Merge — the bare API error alone is undiagnosable.
+func TestDeployStage_CompareTransientRetryExhausted(t *testing.T) {
+	shortCompareRetries(t)
+	calls := 0
+	res, isErr := callDeployWithFn(t, func(ops []map[string]interface{}) interface{} {
+		if len(ops) > 0 {
+			if typ, _ := ops[0]["type"].(string); typ == "compare" {
+				calls++
+				return map[string]interface{}{"request_proc": "fail", "ops": []interface{}{}}
+			}
+		}
+		return map[string]interface{}{
+			"request_proc": "ok",
+			"ops":          []interface{}{map[string]interface{}{"proc": "ok", "immutable": true, "undeployed": float64(0), "title": "prod", "short_name": "prod"}},
+		}
+	}, map[string]interface{}{"apply": false})
+	if !isErr {
+		t.Fatalf("exhausted transient retries must be an error, got: %s", res)
+	}
+	if calls < compareRetryAttempts {
+		t.Errorf("expected %d compare attempts, got %d", compareRetryAttempts, calls)
+	}
+	// Error must include stage context (source→target) and the load-hint.
+	for _, want := range []string{"compare stage", "200→300", "server load", "Partial Merge"} {
+		if !strings.Contains(res, want) {
+			t.Errorf("error must contain %q for diagnosability, got:\n%s", want, res)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- `deploy-stage` now retries the `/api/2/compare` call up to 3 times (3 s base delay, exponential back-off) when the server returns a request-level failure (`request_proc != ok`), a network timeout, or any other transient error
- Op-level schema/validation errors (`API op error:`) are **not** retried — those are business-logic failures the server already diagnosed; retrying would waste time
- When all retries are exhausted, the error message now includes the source→target stage IDs, the project ID, and a hint to try again later or use the Corezoid UI's **Partial Merge** to deploy individual processes

## Context
tool: deploy-stage | version: 3.1.3 | install: 2571983a-bb8e-42b2-8385-67e9406eb852

Background: `/api/2/compare` times out under server load. Previously the tool surfaced the error immediately with no retry. The same compare is already retried 3× in the post-merge verification path (`deployVerifyByCompare`) — this PR applies the same pattern to the initial dry-run compare call.

## Checklist
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes (all 69 s, no races)
- [x] Manifest JSON files validated — no version fields touched
- [x] No hardcoded endpoints, tokens, or credentials
- [x] No CHANGELOG.md or version bump included

## Test plan
- New test `TestDeployStage_CompareTransientRetrySuccess`: compare fails with `request_proc: fail` on attempt 1, succeeds on attempt 2 → dry-run output returned normally
- New test `TestDeployStage_CompareTransientRetryExhausted`: all compare attempts fail → error message contains stage context (`200→300`) and Partial Merge hint
- All existing `TestDeployStage_*` tests pass unchanged, including `TestDeployStage_CompareError` which exercises op-level errors that must **not** be retried