### PR TITLE
fix(mcp-server): count a Code-node read as a use of a set_param variable

### DIFF
--- a/plugins/corezoid/mcp-server/lint.go
+++ b/plugins/corezoid/mcp-server/lint.go
@@ -363,8 +363,7 @@ func findNoopNodes(nodes []processNode) ([]NoopCondition, []UnusedSetParam) {
 			}
 			var unreferenced []string
 			for varName := range extra {
-				pattern := "{{" + varName + "}}"
-				if !strings.Contains(refBlob, pattern) {
+				if !referencesVar(refBlob, varName) {
 					unreferenced = append(unreferenced, varName)
 				}
 			}
@@ -385,6 +384,55 @@ func findNoopNodes(nodes []processNode) ([]NoopCondition, []UnusedSetParam) {
 	}
 
 	return noopConditions, unusedSetParams
+}
+
+// referencesVar reports whether a variable set by set_param is read anywhere
+// downstream. Two syntaxes count, because Corezoid has two consumers:
+//
+//   - node configuration reads it as a template — {{name}} — which is what
+//     go_if_const, api_rpc extra, api urls and so on use;
+//   - a Code node (api_code) reads it as JavaScript — data.name, data["name"] —
+//     and NEVER as {{name}}.
+//
+// Checking only the template form is what made every set_param feeding a Code
+// node report as dead. That mattered beyond noise: the recommended middleware
+// shape maps outcomes in a Code node rather than a condition tree, so following
+// the guidance guaranteed the warning, and the cheapest way to silence it was to
+// rewrite a correct set_param as an api_code — lint pushing the author toward a
+// worse graph. A mention inside a JS comment now counts as a read, which is a
+// deliberate trade: under-reporting a genuinely dead node is far cheaper than
+// blocking a correct design.
+func referencesVar(blob, name string) bool {
+	if name == "" {
+		return false
+	}
+	if strings.Contains(blob, "{{"+name+"}}") {
+		return true
+	}
+	if strings.Contains(blob, `data["`+name+`"]`) || strings.Contains(blob, "data['"+name+"']") {
+		return true
+	}
+	// data.name — require a non-identifier character after the name so that
+	// `result` is not considered read by a reference to `data.result_code`.
+	needle := "data." + name
+	for i := 0; ; {
+		idx := strings.Index(blob[i:], needle)
+		if idx < 0 {
+			return false
+		}
+		end := i + idx + len(needle)
+		if end >= len(blob) || !isIdentChar(blob[end]) {
+			return true
+		}
+		i = end
+	}
+}
+
+func isIdentChar(c byte) bool {
+	return c == '_' || c == '$' ||
+		(c >= '0' && c <= '9') ||
+		(c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z')
 }
 
 // findSharedErrorClusters flags error-cluster nodes shared between the error

--- a/plugins/corezoid/mcp-server/setparam_codenode_test.go
+++ b/plugins/corezoid/mcp-server/setparam_codenode_test.go
@@ -1,0 +1,60 @@
+package main
+
+import "testing"
+
+// A set_param whose values are read by a Code node used to be reported dead,
+// because the check only looked for the {{template}} form. This is the exact
+// shape the middleware guidance recommends (namespace with set_param, then map
+// the outcome in one Code node), so following the docs guaranteed the warning.
+func TestUnusedSetParam_CodeNodeReadCounts(t *testing.T) {
+	nodes := []processNode{
+		{id: "n1", title: "Namespace", objType: 0, logics: []map[string]interface{}{
+			{"type": "set_param",
+				"extra":       map[string]interface{}{"auth_result": "{{result}}", "auth_code": "{{code}}"},
+				"err_node_id": "e1"},
+			{"type": "go", "to_node_id": "n2"},
+		}},
+		{id: "n2", title: "Map outcome", objType: 0, logics: []map[string]interface{}{
+			{"type": "api_code", "lang": "js", "err_node_id": "e2",
+				"src": "if (data.auth_result === \"success\") { data.respCode = \"302\"; }\nvar c = data[\"auth_code\"];"},
+			{"type": "go", "to_node_id": "n3"},
+		}},
+	}
+	_, unused := findNoopNodes(nodes)
+	if len(unused) != 0 {
+		t.Fatalf("set_param read by a Code node must not be reported unused, got: %+v", unused)
+	}
+}
+
+// The check must still catch a genuinely dead set_param.
+func TestUnusedSetParam_StillCatchesDead(t *testing.T) {
+	nodes := []processNode{
+		{id: "n1", title: "Setter", objType: 0, logics: []map[string]interface{}{
+			{"type": "set_param", "extra": map[string]interface{}{"ghost": "1"}, "err_node_id": "e1"},
+			{"type": "go", "to_node_id": "n2"},
+		}},
+		{id: "n2", title: "Code", objType: 0, logics: []map[string]interface{}{
+			{"type": "api_code", "lang": "js", "src": "data.other = 2;", "err_node_id": "e2"},
+		}},
+	}
+	_, unused := findNoopNodes(nodes)
+	if len(unused) != 1 {
+		t.Fatalf("expected the dead set_param to be reported, got: %+v", unused)
+	}
+}
+
+// A prefix must not count: data.result_code does not read `result`.
+func TestReferencesVar_NoPrefixFalseNegative(t *testing.T) {
+	if referencesVar("data.result_code = 1;", "result") {
+		t.Error("data.result_code must not count as a read of `result`")
+	}
+	if !referencesVar("data.result = 1;", "result") {
+		t.Error("data.result must count as a read of `result`")
+	}
+	if !referencesVar("x = {{result}}", "result") {
+		t.Error("template form must still count")
+	}
+	if !referencesVar("var v = data['result'];", "result") {
+		t.Error("single-quoted bracket form must count")
+	}
+}


### PR DESCRIPTION
## Problem

The unused-`set_param` check only looked for the template form, `{{name}}`:

```go
pattern := "{{" + varName + "}}"
if !strings.Contains(refBlob, pattern) { /* reported dead */ }
```

A Code node never reads a variable that way. It reads `data.name` or `data["name"]`. So **every** `set_param` whose consumer was an `api_code` node was reported as dead.

## Why this was worse than noise

The middleware shape we recommend namespaces inputs with `set_param` and then maps the outcome in one Code node rather than a condition tree. Following our own guidance therefore *guaranteed* the warning — and the cheapest way to silence it was to fold a correct `set_param` into an `api_code`. Lint was pushing the author toward a worse graph.

## Fix

`referencesVar` accepts all three read syntaxes: `{{name}}`, `data.name`, `data["name"]` / `data['name']`.

`data.name` requires a non-identifier character after the name, so `data.result_code` is **not** treated as a read of `result` — that prefix case is pinned by a test.

## Deliberate trade-off

A mention inside a JS comment counts as a read. Distinguishing code from comments means parsing JS, and the failure modes are not symmetric: under-reporting one genuinely dead node costs a stale line in a graph, while over-reporting blocks a correct design and pushes the author to restructure it. Erring toward silence is the cheaper mistake here.

## Tests

`setparam_codenode_test.go` — the recommended middleware shape reports clean; a genuinely dead `set_param` is still caught; the `data.result_code` / `result` prefix case; all three read syntaxes individually.

`go vet ./...` and `go test -race ./...` green.

## Note for whoever merges

Touches the same region of `lint.go` as #162 — textual conflict only, not semantic. Both blocks are inserted before `findSharedErrorClusters`; keep both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)