### PR TITLE
fix(mcp-server): unblock create→push and mirror create placement onto pull's tree

### DIFF
--- a/plugins/corezoid/mcp-server/create_push_placement_test.go
+++ b/plugins/corezoid/mcp-server/create_push_placement_test.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// ---- processNeverDeployed --------------------------------------------------
+//
+// The pre-push snapshot gate blocks a push when CreateSnapshot fails, because
+// without git for .conv.json files the previous server version is unrecoverable.
+// A process that has never been deployed is the one case where that reasoning
+// does not hold: there is no previous version to lose, and CreateSnapshot
+// rejects it outright — so the gate must not read that rejection as a reason to
+// block. Getting this wrong makes create-process -> push-process impossible for
+// every brand-new process, which is why each branch below is pinned.
+
+func TestProcessNeverDeployed_NoCommitNoNodes(t *testing.T) {
+	_, e := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
+		return map[string]interface{}{
+			"request_proc": "ok",
+			"ops": []interface{}{map[string]interface{}{
+				"proc":    "ok",
+				"obj_id":  float64(555),
+				"commits": map[string]interface{}{"version": float64(0)},
+				"list":    []interface{}{},
+			}},
+		}
+	})
+	if !processNeverDeployed(e, 555) {
+		t.Error("a process with version 0 and no nodes has never been deployed")
+	}
+}
+
+func TestProcessNeverDeployed_HasCommittedVersion(t *testing.T) {
+	_, e := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
+		return map[string]interface{}{
+			"request_proc": "ok",
+			"ops": []interface{}{map[string]interface{}{
+				"proc":    "ok",
+				"obj_id":  float64(555),
+				"commits": map[string]interface{}{"version": float64(3)},
+				"list":    []interface{}{},
+			}},
+		}
+	})
+	if processNeverDeployed(e, 555) {
+		t.Error("version 3 is a deployed process — the snapshot gate must still block")
+	}
+}
+
+// A draft with nodes but no commit still holds work that a snapshot would
+// capture, so it must not take the exemption.
+func TestProcessNeverDeployed_HasNodesButNoCommit(t *testing.T) {
+	_, e := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
+		return map[string]interface{}{
+			"request_proc": "ok",
+			"ops": []interface{}{map[string]interface{}{
+				"proc":   "ok",
+				"obj_id": float64(555),
+				"list": []interface{}{
+					map[string]interface{}{"id": "aaaaaaaaaaaaaaaaaaaaaaa1"},
+				},
+			}},
+		}
+	})
+	if processNeverDeployed(e, 555) {
+		t.Error("a process carrying nodes has state a snapshot would capture")
+	}
+}
+
+// The whole point of the exemption is to unblock a push; a failed lookup must
+// therefore fall back to the conservative answer, not the permissive one.
+func TestProcessNeverDeployed_LookupFailureBlocks(t *testing.T) {
+	_, e := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
+		return map[string]interface{}{"request_proc": "fail"}
+	})
+	if processNeverDeployed(e, 555) {
+		t.Error("an unreachable API must not be read as never-deployed")
+	}
+}
+
+func TestProcessNeverDeployed_GuardsNilAndZero(t *testing.T) {
+	if processNeverDeployed(nil, 555) {
+		t.Error("nil executor must not be read as never-deployed")
+	}
+	_, e := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
+		t.Error("obj_id 0 must not reach the API")
+		return okResponse(ops)
+	})
+	if processNeverDeployed(e, 0) {
+		t.Error("obj_id 0 must not be read as never-deployed")
+	}
+}
+
+// ---- mirroredDirForFolder -------------------------------------------------
+//
+// create-process used to write into the CWD while a later pull-process wrote the
+// same object into the folder tree mirroring its parent_id, leaving two copies
+// and split baseline sidecars. mirroredDirForFolder is what makes create agree
+// with pull; every "" it returns is a fall back to the old CWD behaviour, so the
+// negative cases matter as much as the positive one.
+
+func TestMirroredDirForFolder_MirrorsPullPlacement(t *testing.T) {
+	root := tmpHomeAndCWD(t)
+	writeTestStageMarker(t, root, 900, 800, "stage")
+	if err := UpdateCurrent(func(f *Folder) { f.RootPath = root }); err != nil {
+		t.Fatalf("persist root: %v", err)
+	}
+
+	_, e := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
+		// One folder, 42_billing, whose parent is the stage itself.
+		return map[string]interface{}{
+			"request_proc": "ok",
+			"ops": []interface{}{map[string]interface{}{
+				"proc":          "ok",
+				"obj_id":        float64(42),
+				"title":         "billing",
+				"obj_type":      float64(0),
+				"parent_obj_id": float64(900),
+			}},
+		}
+	})
+	e.StageID = 900
+
+	got := mirroredDirForFolder(e, 42)
+	want := filepath.Join(root, "42_billing")
+	if got != want {
+		t.Errorf("mirrored dir = %q, want %q", got, want)
+	}
+}
+
+// A registered root is deliberately present here: without the StageID guard
+// findStageRootFromCWD(0) would happily return it and the folder would be
+// resolved against a workspace that is not wired for stages. The mock asserts
+// the API is never reached, so this test fails if the guard is dropped.
+func TestMirroredDirForFolder_NoStageFallsBack(t *testing.T) {
+	root := tmpHomeAndCWD(t)
+	if err := UpdateCurrent(func(f *Folder) { f.RootPath = root }); err != nil {
+		t.Fatalf("persist root: %v", err)
+	}
+	_, e := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
+		t.Error("no stage is known — the folder path must not be resolved")
+		return okResponse(ops)
+	})
+	e.StageID = 0
+
+	if got := mirroredDirForFolder(e, 42); got != "" {
+		t.Errorf("want fall back to caller's path, got %q", got)
+	}
+}
+
+func TestMirroredDirForFolder_APIErrorFallsBack(t *testing.T) {
+	root := tmpHomeAndCWD(t)
+	writeTestStageMarker(t, root, 900, 800, "stage")
+	if err := UpdateCurrent(func(f *Folder) { f.RootPath = root }); err != nil {
+		t.Fatalf("persist root: %v", err)
+	}
+	_, e := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
+		return map[string]interface{}{"request_proc": "fail"}
+	})
+	e.StageID = 900
+
+	if got := mirroredDirForFolder(e, 42); got != "" {
+		t.Errorf("an unresolvable folder must fall back, got %q", got)
+	}
+}
+
+// Fully wired workspace — stage marker, registered root, reachable API — so the
+// only thing standing between folderID 0 and a bogus resolve is the guard.
+func TestMirroredDirForFolder_GuardsNilAndZero(t *testing.T) {
+	if got := mirroredDirForFolder(nil, 42); got != "" {
+		t.Errorf("nil executor must fall back, got %q", got)
+	}
+	root := tmpHomeAndCWD(t)
+	writeTestStageMarker(t, root, 900, 800, "stage")
+	if err := UpdateCurrent(func(f *Folder) { f.RootPath = root }); err != nil {
+		t.Fatalf("persist root: %v", err)
+	}
+	_, e := mockAPIServer(t, func(ops []map[string]interface{}) interface{} {
+		t.Error("folder 0 must not reach the API")
+		return okResponse(ops)
+	})
+	e.StageID = 900
+
+	if got := mirroredDirForFolder(e, 0); got != "" {
+		t.Errorf("folder 0 must fall back, got %q", got)
+	}
+}

--- a/plugins/corezoid/mcp-server/mcp_handlers_process.go
+++ b/plugins/corezoid/mcp-server/mcp_handlers_process.go
@@ -545,10 +545,14 @@ func handlePushProcess(ctx context.Context, args map[string]interface{}) (string
 	//   • snapshot skipped because project/stage aren't resolved → warning
 	//     only; the workspace isn't wired for snapshots (misconfigured env),
 	//     blocking would be a false positive.
-	//   • snapshot was attempted and the API returned an error → BLOCK. Without
-	//     git for .conv.json files the previous server version is unrecoverable
-	//     once ProcessJSON overwrites it, and the same Corezoid API that just
-	//     failed here is the one ProcessJSON is about to call anyway.
+	//   • snapshot was attempted and the API returned an error → BLOCK, unless the
+	//     process has never been deployed. Without git for .conv.json files the
+	//     previous server version is unrecoverable once ProcessJSON overwrites it,
+	//     and the same Corezoid API that just failed here is the one ProcessJSON is
+	//     about to call anyway. A never-deployed process is the exception: it has no
+	//     committed version and no nodes, CreateSnapshot rejects it, and there is no
+	//     previous state that could be lost — blocking there would make the
+	//     create-process → push-process flow impossible for every new process.
 	var snapshotNote string
 	if existingObjID := extractObjIDFromJSON(jsonContent); existingObjID != 0 {
 		if projectID, envNotice := resolveAndCacheProjectID(v); projectID != 0 && v.StageID != 0 {
@@ -556,9 +560,13 @@ func handlePushProcess(ctx context.Context, args map[string]interface{}) (string
 			title := fmt.Sprintf("pre-push %s %s", name, time.Now().UTC().Format("2006-01-02 15:04"))
 			if snapObjID, snapVer, snapErr := v.CreateSnapshot(existingObjID, projectID, v.StageID, title); snapErr != nil {
 				logger.Warn("[snapshot] auto-snapshot failed: %v", snapErr)
-				return fmt.Sprintf(
-					"Push blocked: the pre-push snapshot of process #%d failed (%v). Without a snapshot the previous server version cannot be restored after this push. Retry once the Corezoid API is reachable — the deploy call that follows would fail against the same endpoint anyway.",
-					existingObjID, snapErr), true
+				if !processNeverDeployed(v, existingObjID) {
+					return fmt.Sprintf(
+						"Push blocked: the pre-push snapshot of process #%d failed (%v). Without a snapshot the previous server version cannot be restored after this push. Retry once the Corezoid API is reachable — the deploy call that follows would fail against the same endpoint anyway.",
+						existingObjID, snapErr), true
+				}
+				logger.Info("[snapshot] auto-snapshot skipped: process %d has never been deployed", existingObjID)
+				snapshotNote = fmt.Sprintf("Auto-snapshot skipped: process #%d has no deployed version yet, so there is no previous state to restore.", existingObjID)
 			} else {
 				logger.Info("[snapshot] created version %d (obj_id=%d) for process %d", snapVer, snapObjID, existingObjID)
 				snapshotNote = fmt.Sprintf("Snapshot created before push (version %d, obj_id=%d).", snapVer, snapObjID)
@@ -958,8 +966,22 @@ func createConv(ctx context.Context, args map[string]interface{}, convType strin
 		return fmt.Sprintf("Error marshaling process: %v", err), true
 	}
 
+	// Mirror pull-process's placement when the caller pinned the Corezoid folder
+	// but not the local one. Without this the two tools disagree about where a
+	// process lives on disk: create writes into the CWD while a later
+	// pull-process writes the same object into the folder tree that mirrors its
+	// parent_id — leaving two copies and split baseline sidecars.
+	if optStrArg(args, "folder_path") == "" {
+		if mirrored := mirroredDirForFolder(v, folderID); mirrored != "" {
+			folderPath = mirrored
+		}
+	}
+
 	fileName := convFileName(processID, processName)
 	filePath := filepath.Join(folderPath, fileName)
+	if err := os.MkdirAll(folderPath, 0o755); err != nil {
+		return fmt.Sprintf("Error creating folder %s: %v", folderPath, err), true
+	}
 	if err := os.WriteFile(filePath, data, 0644); err != nil {
 		return fmt.Sprintf("Error writing file: %v", err), true
 	}
@@ -970,6 +992,26 @@ func createConv(ctx context.Context, args map[string]interface{}, convType strin
 	}
 	return fmt.Sprintf("%s '%s' created in Corezoid folder #%d (%s) and saved to %s",
 		label, processName, folderID, resolvedFrom, filePath), false
+}
+
+// mirroredDirForFolder returns the local directory that mirrors folderID inside
+// the Corezoid tree — the same placement pull-process uses — or "" when it cannot
+// be determined (no stage marker, unresolvable folder, API error). Callers keep
+// their previous behaviour on "", so this can only improve placement.
+func mirroredDirForFolder(v *Executor, folderID int) string {
+	if v == nil || folderID == 0 || v.StageID == 0 {
+		return ""
+	}
+	stageRoot := findStageRootFromCWD(v.StageID)
+	if stageRoot == "" {
+		return ""
+	}
+	rel, err := v.resolveFolderPathFromAPI(folderID)
+	if err != nil {
+		logger.Warn("create: could not resolve folder path for %d: %v", folderID, err)
+		return ""
+	}
+	return filepath.Join(stageRoot, rel)
 }
 
 // resolveCreateTarget picks the Corezoid folder a create lands in: an explicit
@@ -1010,6 +1052,15 @@ func handleCreateFolder(ctx context.Context, args map[string]interface{}) (strin
 	newFolderID, err := v.CreateFolder(parentFolderID, folderName, "")
 	if err != nil {
 		return fmt.Sprintf("Error creating folder '%s': %v", folderName, err), true
+	}
+
+	// Same divergence as createConv: an explicit parent folder_id with no
+	// parent_path used to mirror the new folder into the CWD, so the on-disk
+	// tree stopped matching the Corezoid tree that pull-folder reproduces.
+	if optStrArg(args, "parent_path") == "" {
+		if mirrored := mirroredDirForFolder(v, parentFolderID); mirrored != "" {
+			parentPath = mirrored
+		}
 	}
 
 	safeName := sanitizeFileSegment(folderName)
@@ -1278,4 +1329,28 @@ func readParentIDFromFile(filePath string) (int, bool) {
 		}
 	}
 	return 0, false
+}
+
+// processNeverDeployed reports whether a process that exists on the server has
+// never been deployed: no committed version and no nodes. Such a process holds no
+// state a snapshot could capture, and CreateSnapshot rejects it outright — so the
+// pre-push snapshot gate must not treat that rejection as a reason to block.
+// A failed lookup returns false, keeping the conservative "block" behaviour.
+func processNeverDeployed(v *Executor, objID int) bool {
+	if v == nil || objID == 0 {
+		return false
+	}
+	data, err := v.GetProcessByID(objID)
+	if err != nil || data == nil {
+		return false
+	}
+	if commits, ok := data["commits"].(map[string]interface{}); ok {
+		if ver, ok := commits["version"].(float64); ok && ver > 0 {
+			return false
+		}
+	}
+	if list, ok := data["list"].([]interface{}); ok && len(list) > 0 {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
Two independent defects on the same create/push path. Kept together because they share one file and one user-visible scenario ("I created a process and things ended up in the wrong place / refused to push"), but they review separately — see the two sections.

## 1. The pre-push snapshot gate blocked every brand-new process

`CreateSnapshot` rejects a process that has never been deployed — there is no committed version to snapshot. The gate read that rejection as *"cannot protect the previous version, refuse the push"*.

But a never-deployed process has no previous version to lose. Net effect: `create-process → push-process` was impossible for every new process, which is the primary creation flow.

The gate now exempts exactly that case via `processNeverDeployed` — no committed version **and** no nodes. A draft carrying nodes still holds state a snapshot would capture, so it does not take the exemption. A failed lookup returns `false`, keeping the conservative block: an unreachable API must not be mistaken for a fresh process.

The original reasoning for blocking is unchanged and still correct for deployed processes — without git for `.conv.json` files, the previous server version is unrecoverable once `ProcessJSON` overwrites it.

## 2. create and pull disagreed about where an object lives on disk

Given a Corezoid `folder_id` but no local path, `create-process` / `create-folder` wrote into the CWD, while a later `pull-process` wrote the same object into the folder tree mirroring its `parent_id`. Result: two copies of one process, and split baseline sidecars — so diffs and conflict detection compare against the wrong file.

`mirroredDirForFolder` resolves the same placement `pull-process` uses. It returns `""` on anything it cannot determine — no stage, unresolvable folder, API error — and callers keep their previous CWD behaviour on `""`, so this can only improve placement, never redirect a working setup somewhere unexpected. `createConv` also `MkdirAll`s its target now, since a mirrored directory need not exist yet.

## Tests

This path had **no coverage at all**. `create_push_placement_test.go` adds nine cases pinning both functions, negative branches included: committed version, nodes-without-commit, lookup failure, nil/zero guards, successful mirror, no-stage fallback, API-error fallback.

Verified by mutation rather than by assertion count — dropping the guards, ignoring the resolve error, or making `processNeverDeployed` unconditional each fails the suite. (The first draft of the two guard tests passed under mutation; they were rewritten to set up a fully wired workspace so the guard is the only thing under test.)

`go vet ./...` and `go test -race ./...` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)