### PR TITLE
fix(mcp-server): declare server-emitted chunkify on api_code

### DIFF
--- a/plugins/corezoid/mcp-server/chunkify_schema_test.go
+++ b/plugins/corezoid/mcp-server/chunkify_schema_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+// A Code node pulled from a deployed process carries `chunkify`, which Corezoid
+// sets on deploy and nobody authors by hand. api_code declared
+// `additionalProperties: false`, so the plugin's own pull -> edit -> lint -> push
+// loop failed on its own output for every process containing a Code node:
+// "additional properties 'chunkify' not allowed". Declaring the field fixes the
+// round-trip without opening the schema to anything else.
+func TestSchema_AcceptsServerAddedChunkify(t *testing.T) {
+	sch, err := loadCompiledSchema()
+	if err != nil {
+		t.Fatalf("loadCompiledSchema: %v", err)
+	}
+	raw := []byte(`{
+	  "obj_type": 1, "obj_id": 1, "parent_id": 2, "title": "T", "description": "",
+	  "status": "active", "params": [], "ref_mask": true, "conv_type": "process",
+	  "scheme": {"nodes": [
+	    {"id": "aaaaaaaaaaaaaaaaaaaaaaa1", "obj_type": 1, "title": "Start",
+	     "description": "", "x": 0, "y": 0, "extra": "{}", "options": null,
+	     "condition": {"logics": [{"type": "go", "to_node_id": "aaaaaaaaaaaaaaaaaaaaaaa2"}], "semaphors": []}},
+	    {"id": "aaaaaaaaaaaaaaaaaaaaaaa2", "obj_type": 0, "title": "Code",
+	     "description": "", "x": 0, "y": 0, "extra": "{}", "options": null,
+	     "condition": {"logics": [
+	        {"type": "api_code", "lang": "js", "src": "data.x = 1;",
+	         "err_node_id": "aaaaaaaaaaaaaaaaaaaaaaa3", "chunkify": false},
+	        {"type": "go", "to_node_id": "aaaaaaaaaaaaaaaaaaaaaaa3"}], "semaphors": []}},
+	    {"id": "aaaaaaaaaaaaaaaaaaaaaaa3", "obj_type": 2, "title": "End",
+	     "description": "", "x": 0, "y": 0, "extra": "{}", "options": null,
+	     "condition": {"logics": [], "semaphors": []}}
+	  ], "web_settings": [[], []]}
+	}`)
+	var doc any
+	if err := json.NewDecoder(bytes.NewReader(raw)).Decode(&doc); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if err := sch.Validate(doc); err != nil {
+		t.Fatalf("a pulled process with chunkify must validate, got: %v", err)
+	}
+}
+
+// The schema stays closed: chunkify validates because it is declared, not because
+// unknown properties became tolerated. A misspelled property is in no `required`
+// list, so schema validation is the only thing that catches it.
+func TestSchema_StillRejectsUndeclaredLogicProp(t *testing.T) {
+	sch, err := loadCompiledSchema()
+	if err != nil {
+		t.Fatalf("loadCompiledSchema: %v", err)
+	}
+	raw := []byte(`{
+	  "obj_type": 1, "obj_id": 1, "parent_id": 2, "title": "T", "description": "",
+	  "status": "active", "params": [], "ref_mask": true, "conv_type": "process",
+	  "scheme": {"nodes": [
+	    {"id": "aaaaaaaaaaaaaaaaaaaaaaa1", "obj_type": 1, "title": "Start",
+	     "description": "", "x": 0, "y": 0, "extra": "{}", "options": null,
+	     "condition": {"logics": [{"type": "go", "to_node_id": "aaaaaaaaaaaaaaaaaaaaaaa2"}], "semaphors": []}},
+	    {"id": "aaaaaaaaaaaaaaaaaaaaaaa2", "obj_type": 0, "title": "Code",
+	     "description": "", "x": 0, "y": 0, "extra": "{}", "options": null,
+	     "condition": {"logics": [
+	        {"type": "api_code", "lang": "js", "src": "data.x = 1;",
+	         "err_node_id": "aaaaaaaaaaaaaaaaaaaaaaa3", "chunkfy": false},
+	        {"type": "go", "to_node_id": "aaaaaaaaaaaaaaaaaaaaaaa3"}], "semaphors": []}},
+	    {"id": "aaaaaaaaaaaaaaaaaaaaaaa3", "obj_type": 2, "title": "End",
+	     "description": "", "x": 0, "y": 0, "extra": "{}", "options": null,
+	     "condition": {"logics": [], "semaphors": []}}
+	  ], "web_settings": [[], []]}
+	}`)
+	var doc any
+	if err := json.NewDecoder(bytes.NewReader(raw)).Decode(&doc); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if err := sch.Validate(doc); err == nil {
+		t.Fatal("a typo of chunkify must still fail schema validation")
+	}
+}

--- a/plugins/corezoid/mcp-server/json-schema/logics/api_code.json
+++ b/plugins/corezoid/mcp-server/json-schema/logics/api_code.json
@@ -38,6 +38,10 @@
       "type": "object",
       "description": "Data types for the extra parameters",
       "default": {}
+    },
+    "chunkify": {
+      "type": ["boolean", "string", "number"],
+      "description": "Server-emitted execution flag. Not authored by hand — Corezoid adds it to deployed Code nodes, so pull-process round-trips carry it back. Declared here so the plugin's own pull -> edit -> lint -> push loop does not fail on its own output."
     }
   },
   "examples": [


### PR DESCRIPTION
## Problem

Corezoid sets `chunkify` on a deployed Code node — nobody authors it by hand. `json-schema/logics/api_code.json` declared `additionalProperties: false`, so a process that came back from `pull-process` failed validation on the plugin's own output:

```
additional properties 'chunkify' not allowed
```

That broke the documented `pull → edit → lint → push` loop for **any** process containing a Code node.

## Change

Four lines: `api_code` declares `chunkify`. Nothing else.

The schema stays closed. `chunkify` validates because it is declared, not because unknown properties became tolerated — a misspelled property still fails validation, which is the only thing that catches it, since a wrong name appears in no `required` list.

## Scope

This deliberately does **not** generalise to undeclared fields on other logic types. #162 did that — relaxed `additionalProperties` across the logics family, added a lint finding, and a `push-process` gate with its own waiver flag — and the design trade-off there kept drawing review. Declaring each server field as it is discovered is the smaller move; if another one turns up, it is another four lines here.

#162 can be closed in favour of this.

## Tests

`chunkify_schema_test.go`: a pulled process carrying `chunkify` validates; a typo of it (`chunkfy`) still does not.

Not run locally — this machine has Go 1.26.3 and `go.mod` requires 1.26.6, so CI is the first green run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)